### PR TITLE
Fix click event for compatibility

### DIFF
--- a/app/views/request_for_comments/show.html.erb
+++ b/app/views/request_for_comments/show.html.erb
@@ -115,7 +115,7 @@ do not put a carriage return in the line below. it will be present in the presen
   }
 
   function handleSidebarClick(e) {
-    var target  = e.domEvent.toElement;
+    var target  = e.domEvent.target;
     var editor =  e.editor;
 
     if (target.className.indexOf("ace_gutter-cell") == -1) return;


### PR DESCRIPTION
Fixes Firefox support for the comment popup (cf. https://open.hpi.de/courses/javawork2016/question/b992d910-e40c-4643-bd21-f9a1fe9c7cb3 third comment).