### PR TITLE
Don't call (failing) policy selection if the exercise has no execution_environment

### DIFF
--- a/app/views/exercises/index.html.slim
+++ b/app/views/exercises/index.html.slim
@@ -28,7 +28,7 @@ h1 = Exercise.model_name.human(count: 2)
         tr data-id=exercise.id
           td = exercise.title
           td = link_to_if(policy(exercise.author).show?, exercise.author, exercise.author)
-          td = link_to_if(policy(exercise.execution_environment).show?, exercise.execution_environment, exercise.execution_environment)
+          td = link_to_if(exercise.execution_environment && policy(exercise.execution_environment).show?, exercise.execution_environment, exercise.execution_environment)
           td = exercise.files.teacher_defined_tests.count
           td = exercise.maximum_score
           td.public data-value=exercise.public? = symbol_for(exercise.public?)


### PR DESCRIPTION
Fixes #49