### PR TITLE
creates an autosave submission on opening of the editor. 

### DIFF
--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -680,5 +680,7 @@ configureEditors: function () {
     this.showFirstFile();
 
     $(window).on("beforeunload", this.unloadAutoSave.bind(this));
+    // create autosave when the editor is opened the first time
+    this.autosave().bind(this);
   }
 };


### PR DESCRIPTION
otherwise we lose track of the time between opening the exercise and the first submission