### PR TITLE
restrict name to be set to lis_person_name_full (should be display na…

### DIFF
--- a/app/controllers/concerns/lti.rb
+++ b/app/controllers/concerns/lti.rb
@@ -42,12 +42,12 @@ module Lti
   private :external_user_email
 
   def external_user_name(provider)
+    # save person_name_full if supplied. this is the display_name, if it is set.
+    # else only save the firstname, we don't want lastnames (family names)
     if provider.lis_person_name_full
       provider.lis_person_name_full
-    elsif provider.lis_person_name_given && provider.lis_person_name_family
-      "#{provider.lis_person_name_given} #{provider.lis_person_name_family}"
     else
-      provider.lis_person_name_given || provider.lis_person_name_family
+      provider.lis_person_name_given
     end
   end
   private :external_user_name

--- a/app/models/external_user.rb
+++ b/app/models/external_user.rb
@@ -6,7 +6,7 @@ class ExternalUser < ActiveRecord::Base
 
   def displayname
     result = name
-    if(result == nil || discount == "")
+    if(result == nil || result == "")
       result = "User " + id.to_s
     end
     result

--- a/app/models/external_user.rb
+++ b/app/models/external_user.rb
@@ -5,11 +5,9 @@ class ExternalUser < ActiveRecord::Base
   validates :external_id, presence: true
 
   def displayname
-    result =  "User " + id.to_s
-    if(!consumer.nil? && consumer.name == 'openHPI')
-      result = Rails.cache.fetch("#{cache_key}/displayname", expires_in: 12.hours) do
-         Xikolo::UserClient.get(external_id.to_s)[:display_name]
-      end
+    result = name
+    if(result == nil || discount == "")
+      result = "User " + id.to_s
     end
     result
   end


### PR DESCRIPTION
…me) or to lis_person_name_given (should be first name).

don't use xikolo api any longer for consumer openHPI, use the values in CodeOcean.

attention: already saved values in the database beforehand will be exposed and might contain other data than that we retrieve right now.