### PR TITLE
Fix feedback timestamps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'highline'
 gem 'jbuilder'
 gem 'jquery-rails'
 gem 'jquery-turbolinks'
-gem 'ims-lti', '1.1.10'
+gem 'ims-lti', '1.1.10' # version 1.1.13 will crash, because @provider.valid_request?(request) on lti.rb line 89 will return false.
 gem 'kramdown'
 gem 'newrelic_rpm'
 gem 'pg', '< 1.0', platform: :ruby
@@ -37,6 +37,7 @@ gem 'uglifier'
 gem 'will_paginate'
 gem 'tubesock'
 gem 'faye-websocket'
+gem 'eventmachine', '1.0.9.1' # explicitly added, this is used by faye-websocket, version 1.25 still has an error in eventmachine.rb:202: [BUG] Segmentation fault, which is not yet fixed and causes the whole ruby process to crash
 gem 'nokogiri'
 gem 'd3-rails'
 gem 'rest-client'

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'uglifier'
 gem 'will_paginate'
 gem 'tubesock'
 gem 'faye-websocket'
-gem 'eventmachine', '1.0.9.1' # explicitly added, this is used by faye-websocket, version 1.25 still has an error in eventmachine.rb:202: [BUG] Segmentation fault, which is not yet fixed and causes the whole ruby process to crash
+gem 'eventmachine', '1.0.9.1' # explicitly added, this is used by faye-websocket, version 1.2.5 still has an error in eventmachine.rb:202: [BUG] Segmentation fault, which is not yet fixed and causes the whole ruby process to crash
 gem 'nokogiri'
 gem 'd3-rails'
 gem 'rest-client'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'highline'
 gem 'jbuilder'
 gem 'jquery-rails'
 gem 'jquery-turbolinks'
-gem 'ims-lti', '~> 1.1.0'
+gem 'ims-lti', '1.1.10'
 gem 'kramdown'
 gem 'newrelic_rpm'
 gem 'pg', '< 1.0', platform: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,8 +124,8 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.0)
     erubis (2.7.0)
-    eventmachine (1.2.5)
-    eventmachine (1.2.5-java)
+    eventmachine (1.0.9.1)
+    eventmachine (1.0.9.1-java)
     excon (0.60.0)
     execjs (2.7.0)
     factory_bot (4.8.2)
@@ -410,6 +410,7 @@ DEPENDENCIES
   d3-rails
   database_cleaner
   docker-api
+  eventmachine (= 1.0.9.1)
   factory_bot_rails
   faye-websocket
   forgery

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,9 +148,9 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    ims-lti (1.1.13)
+    ims-lti (1.1.10)
       builder
-      oauth (>= 0.4.5, < 0.6)
+      oauth (~> 0.4.5)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -191,7 +191,7 @@ GEM
     nokogiri (1.8.2-java)
     nyan-cat-formatter (0.12.0)
       rspec (>= 2.99, >= 2.14.2, < 4)
-    oauth (0.5.4)
+    oauth (0.4.7)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
@@ -201,7 +201,7 @@ GEM
     pagedown-rails (1.1.4)
       railties (> 3.1)
     parallel (1.12.1)
-    parser (2.5.0.0)
+    parser (2.5.0.2)
       ast (~> 2.4.0)
     pg (0.21.0)
     polyamorous (1.3.3)
@@ -414,7 +414,7 @@ DEPENDENCIES
   faye-websocket
   forgery
   highline
-  ims-lti (~> 1.1.0)
+  ims-lti (= 1.1.10)
   jbuilder
   jquery-rails
   jquery-turbolinks

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -15,7 +15,7 @@ namespace :deploy do
   after :compile_assets, :copy_vendor_assets do
     on roles(fetch(:assets_roles)) do
       within release_path do
-        execute :cp, 'vendor/assets/images/*', 'public/assets/'
+        execute :cp, '-r', 'vendor/assets/images/', 'public/assets/'
         execute :cp, '-r', 'vendor/assets/javascripts/ace', 'public/assets/'
       end
     end

--- a/db/migrate/20180222145909_fix_timestamps_on_feedback.rb
+++ b/db/migrate/20180222145909_fix_timestamps_on_feedback.rb
@@ -1,0 +1,6 @@
+class FixTimestampsOnFeedback < ActiveRecord::Migration
+  def change
+    change_column_default(:user_exercise_feedbacks, :created_at, nil)
+    change_column_default(:user_exercise_feedbacks, :updated_at, nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180202132034) do
+ActiveRecord::Schema.define(version: 20180222145909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -352,15 +352,15 @@ ActiveRecord::Schema.define(version: 20180202132034) do
   end
 
   create_table "user_exercise_feedbacks", force: :cascade do |t|
-    t.integer  "exercise_id",                                             null: false
-    t.integer  "user_id",                                                 null: false
-    t.string   "user_type",                                               null: false
+    t.integer  "exercise_id",             null: false
+    t.integer  "user_id",                 null: false
+    t.string   "user_type",               null: false
     t.integer  "difficulty"
     t.integer  "working_time_seconds"
     t.string   "feedback_text"
     t.integer  "user_estimated_worktime"
-    t.datetime "created_at",              default: '2018-01-30 17:39:22', null: false
-    t.datetime "updated_at",              default: '2018-01-30 17:39:22', null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
   end
 
   create_table "user_exercise_interventions", force: :cascade do |t|


### PR DESCRIPTION
fixed several severe bugs, that were still in the version update-gemfile.
One resulted in a segmentation fault on debian, the other one prevented lti sign-ins.
deployment was also broken and was fixed with an recursive flag.

And we fixed the feedback timestamps (removed default that overwrote correct timestamps)