### PR TITLE
Migration fixes

### DIFF
--- a/db/migrate/20180130172021_add_reached_full_score_to_request_for_comment.rb
+++ b/db/migrate/20180130172021_add_reached_full_score_to_request_for_comment.rb
@@ -1,8 +1,8 @@
 class AddReachedFullScoreToRequestForComment < ActiveRecord::Migration
   def up
     add_column :request_for_comments, :full_score_reached, :boolean, default: false
-    RequestForComment.all.each { |rfc|
-      if (rfc.submission.present? && rfc.submission.exercise.has_user_solved(rfc.user))
+    RequestForComment.find_each { |rfc|
+      if rfc.submission.present? and rfc.submission.exercise.has_user_solved(rfc.user)
         rfc.full_score_reached = true
         rfc.save
       end

--- a/db/migrate/20180222145909_fix_timestamps_on_feedback.rb
+++ b/db/migrate/20180222145909_fix_timestamps_on_feedback.rb
@@ -1,6 +1,10 @@
 class FixTimestampsOnFeedback < ActiveRecord::Migration
-  def change
+  def up
     change_column_default(:user_exercise_feedbacks, :created_at, nil)
     change_column_default(:user_exercise_feedbacks, :updated_at, nil)
+  end
+
+  def down
+    
   end
 end


### PR DESCRIPTION
* migrate RFC-attributes in batches of 1000 to [save memory](https://rubyinrails.com/2017/11/16/use-find-each-instead-of-all-each-in-rails/)
* make migrations (at least pseudo-) reversible