### PR TITLE
Edge compat

### DIFF
--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -552,6 +552,10 @@ configureEditors: function () {
   },
 
   showWebsocketError: function() {
+    if (window.navigator.userAgent.indexOf('Edge') > -1) {
+      // Mute errors in Microsoft Edge
+      return;
+    }
     $.flash.danger({
       text: $('#flash').data('message-failure')
     });

--- a/app/assets/javascripts/editor/execution.js.erb
+++ b/app/assets/javascripts/editor/execution.js.erb
@@ -4,7 +4,7 @@ CodeOceanEditorWebsocket = {
   createSocketUrl: function(url) {
       var sockURL = new URL(window.location);
       sockURL.pathname = url;
-      sockURL.protocol = '<%= DockerClient.config['ws_client_protocol'] %>';
+      sockURL.protocol = '<%= DockerClient.config['ws_client_protocol'].match(/(\w+):*\/*/)&.to_a&.at(1) %>:'
 
       // strip anchor if it is in the url
       sockURL.hash = ''

--- a/app/assets/javascripts/editor/execution.js.erb
+++ b/app/assets/javascripts/editor/execution.js.erb
@@ -4,7 +4,7 @@ CodeOceanEditorWebsocket = {
   createSocketUrl: function(url) {
       var sockURL = new URL(window.location);
       sockURL.pathname = url;
-      sockURL.protocol = '<%= DockerClient.config['ws_client_protocol'].match(/(\w+):*\/*/)&.to_a&.at(1) %>:';
+      sockURL.protocol = '<%= DockerClient.config['ws_client_protocol']&.match(/(\w+):*\/*/)&.to_a&.at(1) %>:';
 
       // strip anchor if it is in the url
       sockURL.hash = '';

--- a/app/assets/javascripts/editor/execution.js.erb
+++ b/app/assets/javascripts/editor/execution.js.erb
@@ -4,6 +4,7 @@ CodeOceanEditorWebsocket = {
   createSocketUrl: function(url) {
       var sockURL = new URL(window.location);
       sockURL.pathname = url;
+      // sanitize socket protocol string, strip trailing slash and other malicious chars if they are there
       sockURL.protocol = '<%= DockerClient.config['ws_client_protocol']&.match(/(\w+):*\/*/)&.to_a&.at(1) %>:';
 
       // strip anchor if it is in the url

--- a/app/assets/javascripts/editor/execution.js.erb
+++ b/app/assets/javascripts/editor/execution.js.erb
@@ -4,10 +4,10 @@ CodeOceanEditorWebsocket = {
   createSocketUrl: function(url) {
       var sockURL = new URL(window.location);
       sockURL.pathname = url;
-      sockURL.protocol = '<%= DockerClient.config['ws_client_protocol'].match(/(\w+):*\/*/)&.to_a&.at(1) %>:'
+      sockURL.protocol = '<%= DockerClient.config['ws_client_protocol'].match(/(\w+):*\/*/)&.to_a&.at(1) %>:';
 
       // strip anchor if it is in the url
-      sockURL.hash = ''
+      sockURL.hash = '';
 
       return sockURL.toString();
   },

--- a/app/assets/javascripts/editor/websocket.js.erb
+++ b/app/assets/javascripts/editor/websocket.js.erb
@@ -108,5 +108,5 @@ CommandSocket.prototype.flush = function() {
  */
 CommandSocket.prototype.killWebSocket = function() {
   this.websocket.flush();
-  this.websocket.close();
+  this.websocket.close(1000);
 };

--- a/config/docker.yml.erb.example
+++ b/config/docker.yml.erb.example
@@ -9,7 +9,7 @@ development:
   <<: *default
   host: tcp://127.0.0.1:2376
   ws_host: ws://127.0.0.1:2376 #url to connect rails server to docker host
-  ws_client_protocol: ws:// #set the websocket protocol to be used by the client to connect to the rails server (ws on development, wss on production)
+  ws_client_protocol: 'ws:' #set the websocket protocol to be used by the client to connect to the rails server (ws on development, wss on production)
   workspace_root: <%= Rails.root.join('tmp', 'files', Rails.env) %>
   pool:
     active: true
@@ -32,7 +32,7 @@ production:
       timeout: 60
   workspace_root: <%= Rails.root.join('tmp', 'files', Rails.env) %>
   ws_host: ws://localhost:4243 #url to connect rails server to docker host
-  ws_client_protocol: wss:// #set the websocket protocol to be used by the client to connect to the rails server (ws on development, wss on production)
+  ws_client_protocol: 'wss:' #set the websocket protocol to be used by the client to connect to the rails server (ws on development, wss on production)
 
 staging:
   <<: *default

--- a/config/docker.yml.erb.travis
+++ b/config/docker.yml.erb.travis
@@ -9,7 +9,7 @@ development:
   <<: *default
   host: tcp://127.0.0.1:2376
   ws_host: ws://127.0.0.1:2376 #url to connect rails server to docker host
-  ws_client_protocol: ws:// #set the websocket protocol to be used by the client to connect to the rails server (ws on development, wss on production)
+  ws_client_protocol: 'ws:' #set the websocket protocol to be used by the client to connect to the rails server (ws on development, wss on production)
   workspace_root: <%= Rails.root.join('tmp', 'files', Rails.env) %>
   pool:
     active: true
@@ -32,7 +32,7 @@ production:
       timeout: 60
   workspace_root: <%= Rails.root.join('tmp', 'files', Rails.env) %>
   ws_host: ws://localhost:4243 #url to connect rails server to docker host
-  ws_client_protocol: wss:// #set the websocket protocol to be used by the client to connect to the rails server (ws on development, wss on production)
+  ws_client_protocol: 'wss:' #set the websocket protocol to be used by the client to connect to the rails server (ws on development, wss on production)
 
 staging:
   <<: *default


### PR DESCRIPTION
IE11/Edge does not allow the trailing slash in the `protocol` property of a `URL` object, resulting in a silent fallback to `http` when opening up the websocket connection (in [execution.js.erb:7](https://github.com/openHPI/codeocean/blob/master/app/assets/javascripts/editor/execution.js.erb#L7)).

**Deployed configs should be adjusted as well** (even though the additional check in `editor/execution.js` technically makes this unnecessary).