### PR TITLE
Feature/anomaly feedback ui

### DIFF
--- a/app/assets/stylesheets/exercises.css.scss
+++ b/app/assets/stylesheets/exercises.css.scss
@@ -114,6 +114,7 @@ a.file-heading {
 
   .feedback-header {
     display: flex;
+    align-items: baseline;
 
     .username {
       flex-grow: 1;

--- a/app/models/user_exercise_feedback.rb
+++ b/app/models/user_exercise_feedback.rb
@@ -9,4 +9,9 @@ class UserExerciseFeedback < ActiveRecord::Base
   def to_s
     "User Exercise Feedback"
   end
+
+  def anomaly_notification
+    AnomalyNotification.where({exercise_id: exercise.id, user_id: user_id, user_type: user_type})
+        .where("created_at < ?", created_at).order("created_at DESC").to_a.first
+  end
 end

--- a/app/views/exercises/feedback.html.slim
+++ b/app/views/exercises/feedback.html.slim
@@ -14,6 +14,8 @@ h1 = link_to(@exercise, exercise_path(@exercise))
         .panel-heading role="tab" id="heading"
           div.clearfix.feedback-header
             span.username = link_to(feedback.user.name, statistics_external_user_exercise_path(id: @exercise.id, external_user_id: feedback.user.id))
+            - if feedback.anomaly_notification
+              i class="fa fa-envelope-o" data-placement="top" data-toggle="tooltip" data-container="body" title=feedback.anomaly_notification.reason
             span.date = feedback.created_at
         .panel-collapse role="tabpanel"
           .panel-body.feedback
@@ -22,3 +24,5 @@ h1 = link_to(@exercise, exercise_path(@exercise))
             .worktime = "#{t('user_exercise_feedback.working_time')} #{feedback.user_estimated_worktime}" if feedback.user_estimated_worktime
 
   = render('shared/pagination', collection: @feedbacks)
+
+  script type="text/javascript" $(function () { $('[data-toggle="tooltip"]').tooltip() });


### PR DESCRIPTION
Deciding if a user feedback was (only) generated after the user was notified through exercise anomaly detection is not entirely possible. The current approach is to get the notification with the latest creation date (before the feedback was created) that the user got for the exercise. There is one edge case that is left out intentionally: if a user gets a notification and then gives user feedback more than once for the same exercise, all feedback entries after the notification will show the notification as their reason.