### PR TITLE
Order files by name by default

### DIFF
--- a/app/models/code_ocean/file.rb
+++ b/app/models/code_ocean/file.rb
@@ -47,6 +47,8 @@ module CodeOcean
       scope :"#{role}s", -> { where(role: role) }
     end
 
+    default_scope { order(name: :asc) }
+
     validates :feedback_message, if: :teacher_defined_test?, presence: true
     validates :feedback_message, absence: true, unless: :teacher_defined_test?
     validates :file_type_id, presence: true

--- a/app/views/exercises/show.html.slim
+++ b/app/views/exercises/show.html.slim
@@ -25,7 +25,7 @@ h1
 h2 = t('activerecord.attributes.exercise.files')
 
 ul.list-unstyled.panel-group#files
-  - @exercise.files.order('name').each do |file|
+  - @exercise.files.each do |file|
     li.panel.panel-default
       .panel-heading role="tab" id="heading"
         a.file-heading data-toggle="collapse" data-parent="#files" href=".collapse#{file.id}"


### PR DESCRIPTION
This makes the order of test files consistent and useful. I need this in the ruby course (starting tomorrow) to provide helpful feedback with each test file, which are meant to guide users to the complete solution, step by step.

Explicit ordering in the view (!) is now no longer necessary.

**Questions for reviewers:**
- Could this have (unwanted) side effects in other places where files (e.g. by users) are listed?