### PR TITLE
Update LOCAL_SETUP.md

### DIFF
--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -59,7 +59,7 @@ All problems that have occurred resulted from a more restrictive rights manageme
 ### Start server
 vagrant ssh  
 cd /vagrant  
-rails s -p 3000  
+rails s -p 3000 -b 0.0.0.0
 
 ### Login to CodeOcean
 192.168.59.104:3000  


### PR DESCRIPTION
rails server will not be bridged to host unless listening on 0.0.0.0. There were no errors when deployed on vagrant/virtualbox on mac, nevertheless the password "admin" would still not work :-(