### PR TITLE
Prevent creation of the Docker containers if just running a db rake task

### DIFF
--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -1,6 +1,8 @@
 DockerClient.initialize_environment unless Rails.env.test? && `which docker`.blank?
 
-if ApplicationRecord.connection.tables.present? && DockerContainerPool.config[:active]
+if !Rake.application.top_level_tasks.to_s.include?('db:') &&
+    ApplicationRecord.connection.tables.present? &&
+    DockerContainerPool.config[:active]
   DockerContainerPool.start_refill_task
   at_exit { DockerContainerPool.clean_up }
 end


### PR DESCRIPTION
Otherwise, the rake task might fail if the database connection could not be established (e.g. when creating a new database).