### PR TITLE
Migrate jQuery function use for ajax in case of success or failure

### DIFF
--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -436,7 +436,7 @@ configureEditors: function () {
       url: $('#editor').data('errors-url')
     });
     jqxhr.always(this.hideSpinner);
-    jqxhr.success(this.renderHint);
+    jqxhr.done(this.renderHint);
   },
 
   toggleButtonStates: function () {

--- a/app/assets/javascripts/editor/participantsupport.js
+++ b/app/assets/javascripts/editor/participantsupport.js
@@ -83,7 +83,7 @@ CodeOceanEditorRequestForComments = {
         $.flash.success({text: $('#askForCommentsButton').data('message-success')});
         // trigger a run
         this.runSubmission.call(this, submission);
-      }.bind(this)).error(this.ajaxError.bind(this));
+      }.bind(this)).fail(this.ajaxError.bind(this));
     };
 
     this.createSubmission($('#requestComments'), null, createRequestForComments.bind(this));

--- a/app/assets/javascripts/editor/submissions.js
+++ b/app/assets/javascripts/editor/submissions.js
@@ -106,7 +106,7 @@ CodeOceanEditorSubmissions = {
     this.ajax({
       method: 'GET',
       url: $('#start-over').data('url')
-    }).success(function(response) {
+    }).done(function(response) {
       this.hideSpinner();
       _.each(this.editors, function(editor) {
         var file_id = $(editor.container).data('file-id');

--- a/app/assets/javascripts/error_templates.js
+++ b/app/assets/javascripts/error_templates.js
@@ -8,9 +8,9 @@ $(document).on('turbolinks:load', function() {
                     dataType: 'json',
                     error_template_attribute_id: $('#add-attribute').find('select').val()
                 }
-            }).success(function () {
+            }).done(function () {
                 location.reload();
-            }).error(function (error) {
+            }).fail(function (error) {
                 $.flash.danger({text: error.statusText});
             });
         });


### PR DESCRIPTION
Reenables users to reset their exercise implementation to the original version

The problem laid in old methods used from jQuery versions prior to 1.8 (which was released on August 9, 2012)

> Deprecation Notice from jQuery docs:
> 
> The jqXHR.success(), jqXHR.error(), and jqXHR.complete() callbacks will be deprecated in jQuery 1.8. To prepare your code for their eventual removal, use jqXHR.done(), jqXHR.fail(), and jqXHR.always() instead.