### PR TITLE
Disable download

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ gem 'bootstrap-will_paginate'
 gem 'carrierwave'
 gem 'concurrent-ruby'
 gem 'docker-api', require: 'docker'
-gem 'factory_bot_rails', '>= 5.0.1'
+gem 'factory_bot_rails'
 gem 'forgery'
 gem 'highline'
 gem 'jbuilder'
-gem 'jquery-rails', '>= 4.3.3'
+gem 'jquery-rails'
 gem 'ims-lti', '< 2.0.0'
 gem 'kramdown'
 gem 'newrelic_rpm'
@@ -17,14 +17,14 @@ gem 'pg'
 gem 'pry-byebug'
 gem 'puma'
 gem 'pundit'
-gem 'rails', '5.2.2.1'
-gem 'rails-i18n', '>= 5.1.3'
+gem 'rails', '5.2.3'
+gem 'rails-i18n'
 gem 'i18n-js'
-gem 'ransack', '>= 2.1.1'
+gem 'ransack'
 gem 'rubytree'
-gem 'sass-rails', '>= 5.0.7'
-gem 'slim-rails', '>= 3.2.0'
-gem 'pagedown-bootstrap-rails', '>= 2.1.4'
+gem 'sass-rails'
+gem 'slim-rails'
+gem 'pagedown-bootstrap-rails'
 gem 'sorcery'
 gem 'turbolinks'
 gem 'uglifier'
@@ -32,12 +32,12 @@ gem 'tubesock', git: 'https://github.com/gosukiwi/tubesock', branch: 'patch-1' #
 gem 'faye-websocket'
 gem 'eventmachine', '1.0.9.1' # explicitly added, this is used by faye-websocket, newer versions might crash or
 gem 'nokogiri'
-gem 'webpacker', '>= 4.0.2'
+gem 'webpacker'
 gem 'rest-client'
 gem 'rubyzip'
 gem 'mnemosyne-ruby'
 gem 'whenever', require: false
-gem 'rails-timeago', '>= 2.17.1'
+gem 'rails-timeago'
 
 group :development, :staging do
   gem 'bootsnap', require: false
@@ -52,7 +52,7 @@ group :development, :staging do
   gem 'rack-mini-profiler'
   gem 'rubocop', require: false
   gem 'rubocop-rspec'
-  gem 'web-console', '>= 3.7.0'
+  gem 'web-console'
 end
 
 group :development, :test, :staging do
@@ -60,7 +60,7 @@ group :development, :test, :staging do
 end
 
 group :test do
-  gem 'rails-controller-testing', '>= 1.0.4'
+  gem 'rails-controller-testing'
   gem 'autotest-rails'
   gem 'capybara'
   gem 'selenium-webdriver'
@@ -68,6 +68,6 @@ group :test do
   gem 'database_cleaner'
   gem 'nyan-cat-formatter'
   gem 'rspec-autotest'
-  gem 'rspec-rails', '>= 3.8.2'
+  gem 'rspec-rails'
   gem 'simplecov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,43 +11,43 @@ GEM
   remote: https://rubygems.org/
   specs:
     ZenTest (4.11.2)
-    actioncable (5.2.2.1)
-      actionpack (= 5.2.2.1)
+    actioncable (5.2.3)
+      actionpack (= 5.2.3)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailer (5.2.2.1)
-      actionpack (= 5.2.2.1)
-      actionview (= 5.2.2.1)
-      activejob (= 5.2.2.1)
+    actionmailer (5.2.3)
+      actionpack (= 5.2.3)
+      actionview (= 5.2.3)
+      activejob (= 5.2.3)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (5.2.2.1)
-      actionview (= 5.2.2.1)
-      activesupport (= 5.2.2.1)
+    actionpack (5.2.3)
+      actionview (= 5.2.3)
+      activesupport (= 5.2.3)
       rack (~> 2.0)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.2.2.1)
-      activesupport (= 5.2.2.1)
+    actionview (5.2.3)
+      activesupport (= 5.2.3)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activejob (5.2.2.1)
-      activesupport (= 5.2.2.1)
+    activejob (5.2.3)
+      activesupport (= 5.2.3)
       globalid (>= 0.3.6)
-    activemodel (5.2.2.1)
-      activesupport (= 5.2.2.1)
-    activerecord (5.2.2.1)
-      activemodel (= 5.2.2.1)
-      activesupport (= 5.2.2.1)
+    activemodel (5.2.3)
+      activesupport (= 5.2.3)
+    activerecord (5.2.3)
+      activemodel (= 5.2.3)
+      activesupport (= 5.2.3)
       arel (>= 9.0)
-    activestorage (5.2.2.1)
-      actionpack (= 5.2.2.1)
-      activerecord (= 5.2.2.1)
+    activestorage (5.2.3)
+      actionpack (= 5.2.3)
+      activerecord (= 5.2.3)
       marcel (~> 0.3.1)
-    activesupport (5.2.2.1)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -69,14 +69,14 @@ GEM
     bindex (0.5.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
-    bootsnap (1.4.1)
+    bootsnap (1.4.2)
       msgpack (~> 1.0)
     bootstrap-will_paginate (1.0.0)
       will_paginate
     builder (3.2.3)
     bunny (2.14.1)
       amq-protocol (~> 2.3, >= 2.3.0)
-    byebug (11.0.0)
+    byebug (11.0.1)
     capistrano (3.11.0)
       airbrussh (>= 1.0.0)
       i18n
@@ -96,7 +96,7 @@ GEM
       capistrano (~> 3.7)
       capistrano-bundler
       puma (~> 3.4)
-    capybara (3.14.0)
+    capybara (3.16.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -185,17 +185,17 @@ GEM
     mnemosyne-ruby (1.5.1)
       activesupport (>= 4)
       bunny
-    msgpack (1.2.7)
+    msgpack (1.2.9)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
-    net-ssh (5.1.0)
+    net-scp (2.0.0)
+      net-ssh (>= 2.6.5, < 6.0.0)
+    net-ssh (5.2.0)
     netrc (0.11.0)
-    newrelic_rpm (6.1.0.352)
+    newrelic_rpm (6.2.0.354)
     nio4r (2.3.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.2)
       mini_portile2 (~> 2.4.0)
     nyan-cat-formatter (0.12.0)
       rspec (>= 2.99, >= 2.14.2, < 4)
@@ -208,11 +208,10 @@ GEM
       rack (>= 1.2, < 3)
     pagedown-bootstrap-rails (2.1.4)
       railties (> 3.1)
-    parallel (1.14.0)
-    parser (2.6.0.0)
+    parallel (1.16.2)
+    parser (2.6.2.0)
       ast (~> 2.4.0)
     pg (1.1.4)
-    powerpack (0.1.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -221,7 +220,7 @@ GEM
       pry (~> 0.10)
     psych (3.1.0)
     public_suffix (3.0.3)
-    puma (3.12.0)
+    puma (3.12.1)
     pundit (2.0.1)
       activesupport (>= 3.0.0)
     rack (2.0.6)
@@ -231,18 +230,18 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (5.2.2.1)
-      actioncable (= 5.2.2.1)
-      actionmailer (= 5.2.2.1)
-      actionpack (= 5.2.2.1)
-      actionview (= 5.2.2.1)
-      activejob (= 5.2.2.1)
-      activemodel (= 5.2.2.1)
-      activerecord (= 5.2.2.1)
-      activestorage (= 5.2.2.1)
-      activesupport (= 5.2.2.1)
+    rails (5.2.3)
+      actioncable (= 5.2.3)
+      actionmailer (= 5.2.3)
+      actionpack (= 5.2.3)
+      actionview (= 5.2.3)
+      activejob (= 5.2.3)
+      activemodel (= 5.2.3)
+      activerecord (= 5.2.3)
+      activestorage (= 5.2.3)
+      activesupport (= 5.2.3)
       bundler (>= 1.3.0)
-      railties (= 5.2.2.1)
+      railties (= 5.2.3)
       sprockets-rails (>= 2.0.0)
     rails-controller-testing (1.0.4)
       actionpack (>= 5.0.1.x)
@@ -259,9 +258,9 @@ GEM
     rails-timeago (2.17.1)
       actionpack (>= 3.1)
       activesupport (>= 3.1)
-    railties (5.2.2.1)
-      actionpack (= 5.2.2.1)
-      activesupport (= 5.2.2.1)
+    railties (5.2.3)
+      actionpack (= 5.2.3)
+      activesupport (= 5.2.3)
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
@@ -303,20 +302,19 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.65.0)
+    rubocop (0.66.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
       psych (>= 3.1.0)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
+      unicode-display_width (>= 1.4.0, < 1.6)
     rubocop-rspec (1.32.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
-    rubytree (1.0.0)
+    rubytree (1.0.1)
       json (~> 2.1)
       structured_warnings (~> 0.3)
     rubyzip (1.2.2)
@@ -377,7 +375,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    unicode-display_width (1.4.1)
+    unicode-display_width (1.5.0)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -393,7 +391,7 @@ GEM
     websocket-extensions (0.1.3)
     whenever (0.10.0)
       chronic (>= 0.6.3)
-    will_paginate (3.1.6)
+    will_paginate (3.1.7)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -418,7 +416,7 @@ DEPENDENCIES
   database_cleaner
   docker-api
   eventmachine (= 1.0.9.1)
-  factory_bot_rails (>= 5.0.1)
+  factory_bot_rails
   faye-websocket
   forgery
   headless
@@ -426,42 +424,42 @@ DEPENDENCIES
   i18n-js
   ims-lti (< 2.0.0)
   jbuilder
-  jquery-rails (>= 4.3.3)
+  jquery-rails
   kramdown
   listen
   mnemosyne-ruby
   newrelic_rpm
   nokogiri
   nyan-cat-formatter
-  pagedown-bootstrap-rails (>= 2.1.4)
+  pagedown-bootstrap-rails
   pg
   pry-byebug
   puma
   pundit
   rack-mini-profiler
-  rails (= 5.2.2.1)
-  rails-controller-testing (>= 1.0.4)
-  rails-i18n (>= 5.1.3)
-  rails-timeago (>= 2.17.1)
-  ransack (>= 2.1.1)
+  rails (= 5.2.3)
+  rails-controller-testing
+  rails-i18n
+  rails-timeago
+  ransack
   rest-client
   rspec-autotest
-  rspec-rails (>= 3.8.2)
+  rspec-rails
   rubocop
   rubocop-rspec
   rubytree
   rubyzip
-  sass-rails (>= 5.0.7)
+  sass-rails
   selenium-webdriver
   simplecov
-  slim-rails (>= 3.2.0)
+  slim-rails
   sorcery
   spring
   tubesock!
   turbolinks
   uglifier
-  web-console (>= 3.7.0)
-  webpacker (>= 4.0.2)
+  web-console
+  webpacker
   whenever
 
 BUNDLED WITH

--- a/app/controllers/concerns/lti.rb
+++ b/app/controllers/concerns/lti.rb
@@ -182,7 +182,8 @@ module Lti
      :hide_sidebar,
      :read_only,
      :hide_test_results,
-     :disable_hints].each do |option|
+     :disable_hints,
+     :disable_download].each do |option|
       value = params["custom_embed_options_#{option}".to_sym] == 'true'
       # Optimize storage and save only those that are true, the session cookie is limited to 4KB
       @embed_options[option] = value if value.present?

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -62,6 +62,10 @@ class SubmissionsController < ApplicationController
   end
 
   def download
+    if @embed_options[:disable_download]
+      raise Pundit::NotAuthorizedError
+    end
+
     # files = @submission.files.map{ }
     # zipline( files, 'submission.zip')
     # send_data(@file.content, filename: @file.name_with_extension)
@@ -98,6 +102,10 @@ class SubmissionsController < ApplicationController
   end
 
   def download_file
+    if @embed_options[:disable_download]
+      raise Pundit::NotAuthorizedError
+    end
+
     if @file.native_file?
       send_file(@file.native_file.path)
     else

--- a/app/views/exercises/_editor_file_tree.html.slim
+++ b/app/views/exercises/_editor_file_tree.html.slim
@@ -4,7 +4,8 @@ div id='sidebar-collapsed' class=(@exercise.hide_file_tree ? '' : 'd-none')
   - if @exercise.allow_file_creation and not @exercise.hide_file_tree?
     = render('editor_button', classes: 'btn-block btn-primary btn enforce-top-margin', data: {:'data-cause' => 'file', :'data-toggle' => 'tooltip', :'data-placement' => 'right'}, icon: 'fa fa-plus', id: 'create-file-collapsed', label:'', title: t('exercises.editor.create_file'))
 
-  = render('editor_button', classes: 'btn-block btn-primary btn enforce-top-margin', data: {:'data-toggle' => 'tooltip', :'data-placement' => 'right'}, icon: 'fa fa-download', id: 'download-collapsed', label:'', title: t('exercises.editor.download'))
+  - unless @embed_options[:disable_download]
+    = render('editor_button', classes: 'btn-block btn-primary btn enforce-top-margin', data: {:'data-toggle' => 'tooltip', :'data-placement' => 'right'}, icon: 'fa fa-download', id: 'download-collapsed', label:'', title: t('exercises.editor.download'))
   = render('editor_button', classes: 'btn-block btn-primary btn enforce-top-margin', data: {:'data-message-confirm' => t('exercises.editor.confirm_start_over'), :'data-url' => reload_exercise_path(@exercise), :'data-toggle' => 'tooltip', :'data-placement' => 'right'}, icon: 'fa fa-history', id: 'start-over-collapsed', label:'', title: t('exercises.editor.start_over'))
   //- if !@course_token.blank?
     = render('editor_button', classes: 'btn-block btn-primary btn enforce-top-margin', data: {:'data-toggle' => 'tooltip', :'data-placement' => 'right'}, icon: 'fa fa-search', id: 'sidebar-search-collapsed', label: '', title: t('search.search_in_forum'))
@@ -23,7 +24,8 @@ div id='sidebar-uncollapsed' class=(@exercise.hide_file_tree ? 'd-none' : '')
     = render('editor_button', classes: 'btn-block btn-primary btn', data: {:'data-cause' => 'file'}, icon: 'fa fa-plus', id: 'create-file', label: t('exercises.editor.create_file'))
     = render('editor_button', classes: 'btn-block btn-warning btn', data: {:'data-cause' => 'file', :'data-message-confirm' => t('shared.confirm_destroy')}, icon: 'fa fa-times', id: 'destroy-file', label: t('exercises.editor.destroy_file'))
 
-  = render('editor_button', classes: 'btn-block btn-primary btn enforce-top-margin', icon: 'fa fa-download', id: 'download', label: t('exercises.editor.download'))
+  - unless @embed_options[:disable_download]
+    = render('editor_button', classes: 'btn-block btn-primary btn enforce-top-margin', icon: 'fa fa-download', id: 'download', label: t('exercises.editor.download'))
   = render('editor_button', classes: 'btn-block btn-primary btn', data: {:'data-message-confirm' => t('exercises.editor.confirm_start_over'), :'data-url' => reload_exercise_path(@exercise)}, icon: 'fa fa-history', id: 'start-over', label: t('exercises.editor.start_over'))
 
   //- if !@course_token.blank?

--- a/provision.sh
+++ b/provision.sh
@@ -6,7 +6,7 @@
 
 postgres_version=10
 ruby_version=2.6.1
-rails_version=5.2.2
+rails_version=5.2.3
 geckodriver_version=0.24.0
 
 ########## INSTALL SCRIPT ###########


### PR DESCRIPTION
As required for Monday, this PR adds support for another LTI option to disallow downloading exercises and submissions.

Further, this PR also updates the bundle to the newest versions where available.