### PR TITLE
Fix codeharbor-export policies

### DIFF
--- a/app/policies/exercise_policy.rb
+++ b/app/policies/exercise_policy.rb
@@ -19,8 +19,12 @@ class ExercisePolicy < AdminOrAuthorPolicy
     admin?
   end
 
-  [:clone?, :destroy?, :edit?, :update?, :export_external_check?, :export_external_confirm?].each do |action|
+  [:clone?, :destroy?, :edit?, :update?].each do |action|
     define_method(action) { admin? || teacher_in_study_group? || author? }
+  end
+
+  [:export_external_check?, :export_external_confirm?].each do |action|
+    define_method(action) { (admin? || teacher_in_study_group? || author?) && @user.codeharbor_link }
   end
 
   [:implement?, :working_times?, :intervention?, :search?, :submit?, :reload?].each do |action|

--- a/spec/policies/exercise_policy_spec.rb
+++ b/spec/policies/exercise_policy_spec.rb
@@ -93,7 +93,7 @@ let(:exercise) { FactoryBot.build(:dummy, public: true) }
           context 'when user has codeharbor_link' do
             before { user.codeharbor_link = FactoryBot.build(:codeharbor_link) }
 
-            it 'does not grants access' do
+            it 'does not grant access' do
               expect(subject).not_to permit(user, exercise)
             end
           end


### PR DESCRIPTION
fixes #765 

Added a check to determine if a user actually has the codeharbor_link configured before offering the export.
