### PR TITLE
disable rails_admin dashboard

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -30,8 +30,11 @@ RailsAdmin.config do |config|
   # config.show_gravatar = true
 
   config.actions do
-    dashboard                     # mandatory
-    index                         # mandatory
+    # mandatory
+    dashboard do
+      statistics false
+    end
+    index # mandatory
     new
     export
     bulk_delete
@@ -50,10 +53,21 @@ RailsAdmin.config do |config|
     module WillPaginate
       module ActiveRecord
         module RelationMethods
-          def per(value = nil) per_page(value) end
-          def total_count() count end
-          def first_page?() self == first end
-          def last_page?() self == last end
+          def per(value = nil)
+            per_page(value)
+          end
+
+          def total_count()
+            count
+          end
+
+          def first_page?()
+            self == first
+          end
+
+          def last_page?()
+            self == last
+          end
         end
       end
       module CollectionMethods


### PR DESCRIPTION
The Dashboard is suspected to have performance problems.
Disable it.

@MrSerth are you able to see what kind of queries cause the slowdown on production? I also remember reading something about n+1 queries during the authorization checks and I can imagine that there are quite a few users in CO