### PR TITLE
Improve Prometheus integration

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 return unless CodeOcean::Config.new(:code_ocean).read[:prometheus_exporter][:enabled]
-return if Rake.application.top_level_tasks.to_s.include?('db:')
+return if %w[db: assets:].any? { |task| Rake.application.top_level_tasks.to_s.include?(task) }
 
 # Add metric callbacks to all models
 ApplicationRecord.include Prometheus::Record

--- a/lib/prometheus/controller.rb
+++ b/lib/prometheus/controller.rb
@@ -41,7 +41,7 @@ module Prometheus
                            state: RequestForComment::SOLVED)
 
         # count of rfcs with comments
-        @rfc_commented_count.observe(RequestForComment.with_comments.count)
+        @rfc_commented_count.observe(RequestForComment.joins(:comments).distinct.count(:id))
       end
 
       def update_notification(object)


### PR DESCRIPTION
## What does this change?

* Exclude Prometheus integration for rake tasks
* Query database for the count of RfCs with comments

## Decisions / Choices I made

* Postpone parallelization of Prometheus initialization