### PR TITLE
Sync execution environments

### DIFF
--- a/app/controllers/execution_environments_controller.rb
+++ b/app/controllers/execution_environments_controller.rb
@@ -135,8 +135,8 @@ class ExecutionEnvironmentsController < ApplicationController
   def set_docker_images
     @docker_images ||= ExecutionEnvironment.pluck(:docker_image)
     @docker_images += Runner.strategy_class.available_images
-  rescue Runner::Error::InternalServerError => e
-    flash[:warning] = e.message
+  rescue Runner::Error => e
+    flash[:warning] = html_escape e.message
   ensure
     @docker_images = @docker_images.sort.uniq
   end

--- a/app/controllers/execution_environments_controller.rb
+++ b/app/controllers/execution_environments_controller.rb
@@ -15,9 +15,7 @@ class ExecutionEnvironmentsController < ApplicationController
   def create
     @execution_environment = ExecutionEnvironment.new(execution_environment_params)
     authorize!
-    create_and_respond(object: @execution_environment) do
-      sync_to_runner_management
-    end
+    create_and_respond(object: @execution_environment)
   end
 
   def destroy
@@ -165,9 +163,7 @@ class ExecutionEnvironmentsController < ApplicationController
   end
 
   def update
-    update_and_respond(object: @execution_environment, params: execution_environment_params) do
-      sync_to_runner_management
-    end
+    update_and_respond(object: @execution_environment, params: execution_environment_params)
   end
 
   def sync_all_to_runner_management
@@ -186,11 +182,4 @@ class ExecutionEnvironmentsController < ApplicationController
       redirect_to ExecutionEnvironment, alert: t('execution_environments.index.synchronize_all.failure')
     end
   end
-
-  def sync_to_runner_management
-    unless Runner.management_active? && Runner.strategy_class.sync_environment(@execution_environment)
-      t('execution_environments.form.errors.not_synced_to_runner_management')
-    end
-  end
-  private :sync_to_runner_management
 end

--- a/app/controllers/execution_environments_controller.rb
+++ b/app/controllers/execution_environments_controller.rb
@@ -177,6 +177,8 @@ class ExecutionEnvironmentsController < ApplicationController
 
     success = ExecutionEnvironment.all.map do |execution_environment|
       Runner.strategy_class.sync_environment(execution_environment)
+    rescue Runner::Error
+      false
     end
     if success.all?
       redirect_to ExecutionEnvironment, notice: t('execution_environments.index.synchronize_all.success')

--- a/app/models/execution_environment.rb
+++ b/app/models/execution_environment.rb
@@ -78,7 +78,8 @@ class ExecutionEnvironment < ApplicationRecord
   end
 
   def validate_docker_image?
-    docker_image.present? && !Rails.env.test?
+    # We only validate the code execution with the provided image if there is at least one container to test with.
+    pool_size.positive? && docker_image.present? && !Rails.env.test?
   end
 
   def working_docker_image?

--- a/lib/runner/strategy.rb
+++ b/lib/runner/strategy.rb
@@ -13,6 +13,10 @@ class Runner::Strategy
     raise NotImplementedError
   end
 
+  def self.remove_environment(_environment)
+    raise NotImplementedError
+  end
+
   def self.request_from_management(_environment)
     raise NotImplementedError
   end

--- a/lib/runner/strategy.rb
+++ b/lib/runner/strategy.rb
@@ -9,6 +9,10 @@ class Runner::Strategy
     raise NotImplementedError
   end
 
+  def self.environments
+    raise NotImplementedError
+  end
+
   def self.sync_environment(_environment)
     raise NotImplementedError
   end

--- a/lib/runner/strategy/docker_container_pool.rb
+++ b/lib/runner/strategy/docker_container_pool.rb
@@ -15,16 +15,35 @@ class Runner::Strategy::DockerContainerPool < Runner::Strategy
   end
 
   def self.sync_environment(environment)
-    # There is no dedicated sync mechanism yet. However, we need to emit a warning when the pool was previously
-    # empty for this execution environment. In this case the validation command probably was not executed.
-    return true unless environment.pool_size_previously_changed?
-
-    case environment.pool_size_previously_was
-      when nil, 0
-        false
-      else
-        true
+    # Force a database commit and start a new transaction.
+    if environment.class.connection.transaction_open?
+      environment.class.connection.commit_db_transaction
+      environment.class.connection.begin_db_transaction
     end
+
+    url = "#{config[:url]}/docker_container_pool/refill_environment/#{environment.id}"
+    Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Refilling execution environment at #{url}" }
+    response = Faraday.post(url)
+    return true if response.success?
+
+    raise Runner::Error::UnexpectedResponse.new("Could not refill execution environment in DockerContainerPool, got response: #{response.as_json}")
+  rescue Faraday::Error => e
+    raise Runner::Error::FaradayError.new("Request to DockerContainerPool failed: #{e.inspect}")
+  ensure
+    Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Finished refilling environment" }
+  end
+
+  def self.remove_environment(environment)
+    url = "#{config[:url]}/docker_container_pool/purge_environment/#{environment.id}"
+    Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Purging execution environment at #{url}" }
+    response = Faraday.delete(url)
+    return true if response.success?
+
+    raise Runner::Error::UnexpectedResponse.new("Could not delete execution environment in DockerContainerPool, got response: #{response.as_json}")
+  rescue Faraday::Error => e
+    raise Runner::Error::FaradayError.new("Request to DockerContainerPool failed: #{e.inspect}")
+  ensure
+    Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Finished purging environment" }
   end
 
   def self.request_from_management(environment)

--- a/lib/runner/strategy/docker_container_pool.rb
+++ b/lib/runner/strategy/docker_container_pool.rb
@@ -14,6 +14,10 @@ class Runner::Strategy::DockerContainerPool < Runner::Strategy
     FileUtils.mkdir_p(File.expand_path(config[:workspace_root]))
   end
 
+  def self.environments
+    pool_size.keys.map {|key| {id: key} }
+  end
+
   def self.sync_environment(environment)
     # Force a database commit and start a new transaction.
     if environment.class.connection.transaction_open?

--- a/lib/runner/strategy/docker_container_pool.rb
+++ b/lib/runner/strategy/docker_container_pool.rb
@@ -68,7 +68,10 @@ class Runner::Strategy::DockerContainerPool < Runner::Strategy
   def destroy_at_management
     url = "#{self.class.config[:url]}/docker_container_pool/destroy_container/#{container.id}"
     Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Destroying runner at #{url}" }
-    Faraday.delete(url)
+    response = Faraday.delete(url)
+    return true if response.success?
+
+    raise Runner::Error::UnexpectedResponse.new("Could not delete execution environment in DockerContainerPool, got response: #{response.as_json}")
   rescue Faraday::Error => e
     raise Runner::Error::FaradayError.new("Request to DockerContainerPool failed: #{e.inspect}")
   ensure

--- a/lib/runner/strategy/null.rb
+++ b/lib/runner/strategy/null.rb
@@ -5,7 +5,13 @@
 class Runner::Strategy::Null < Runner::Strategy
   def self.initialize_environment; end
 
-  def self.sync_environment(_environment); end
+  def self.sync_environment(_environment)
+    raise Runner::Error.new
+  end
+
+  def self.remove_environment(_environment)
+    raise Runner::Error.new
+  end
 
   def self.request_from_management(_environment)
     SecureRandom.uuid

--- a/lib/runner/strategy/null.rb
+++ b/lib/runner/strategy/null.rb
@@ -5,6 +5,10 @@
 class Runner::Strategy::Null < Runner::Strategy
   def self.initialize_environment; end
 
+  def self.environments
+    raise Runner::Error.new
+  end
+
   def self.sync_environment(_environment)
     raise Runner::Error.new
   end

--- a/spec/controllers/execution_environments_controller_spec.rb
+++ b/spec/controllers/execution_environments_controller_spec.rb
@@ -46,13 +46,20 @@ describe ExecutionEnvironmentsController do
   end
 
   describe 'DELETE #destroy' do
-    before { delete :destroy, params: {id: execution_environment.id} }
+    before do
+      allow(Runner.strategy_class).to receive(:remove_environment).and_return(true)
+      delete :destroy, params: {id: execution_environment.id}
+    end
 
     expect_assigns(execution_environment: :execution_environment)
 
     it 'destroys the execution environment' do
       execution_environment = FactoryBot.create(:ruby)
       expect { delete :destroy, params: {id: execution_environment.id} }.to change(ExecutionEnvironment, :count).by(-1)
+    end
+
+    it 'removes the execution environment from the runner management' do
+      expect(Runner.strategy_class).to have_received(:remove_environment)
     end
 
     expect_redirect(:execution_environments)

--- a/spec/controllers/execution_environments_controller_spec.rb
+++ b/spec/controllers/execution_environments_controller_spec.rb
@@ -13,7 +13,7 @@ describe ExecutionEnvironmentsController do
 
   describe 'POST #create' do
     context 'with a valid execution environment' do
-      let(:perform_request) { proc { post :create, params: {execution_environment: FactoryBot.build(:ruby).attributes} } }
+      let(:perform_request) { proc { post :create, params: {execution_environment: FactoryBot.build(:ruby, pool_size: 1).attributes} } }
 
       before do
         allow(Rails.env).to receive(:test?).and_return(false, true)
@@ -186,7 +186,7 @@ describe ExecutionEnvironmentsController do
         runner = instance_double 'runner'
         allow(Runner).to receive(:for).and_return(runner)
         allow(runner).to receive(:execute_command).and_return({})
-        put :update, params: {execution_environment: FactoryBot.attributes_for(:ruby), id: execution_environment.id}
+        put :update, params: {execution_environment: FactoryBot.attributes_for(:ruby, pool_size: 1), id: execution_environment.id}
       end
 
       expect_assigns(docker_images: Array)

--- a/spec/lib/runner/strategy/poseidon_spec.rb
+++ b/spec/lib/runner/strategy/poseidon_spec.rb
@@ -9,6 +9,16 @@ describe Runner::Strategy::Poseidon do
   let(:error_message) { 'test error message' }
   let(:response_body) { nil }
 
+  let(:codeocean_config) { instance_double(CodeOcean::Config) }
+  let(:runner_management_config) { {runner_management: {enabled: true, strategy: :poseidon, url: 'https://runners.example.org', unused_runner_expiration_time: 180}} }
+
+  before do
+    # Ensure to reset the memorized helper
+    Runner.instance_variable_set :@strategy_class, nil
+    allow(CodeOcean::Config).to receive(:new).with(:code_ocean).and_return(codeocean_config)
+    allow(codeocean_config).to receive(:read).and_return(runner_management_config)
+  end
+
   # All requests handle a BadRequest (400) response the same way.
   shared_examples 'BadRequest (400) error handling' do
     context 'when Poseidon returns BadRequest (400)' do

--- a/spec/lib/runner/strategy/poseidon_spec.rb
+++ b/spec/lib/runner/strategy/poseidon_spec.rb
@@ -141,11 +141,11 @@ describe Runner::Strategy::Poseidon do
     end
 
     shared_examples 'returns false when the api request failed' do |status|
-      it "returns false on status #{status}" do
+      it "raises an exception on status #{status}" do
         faraday_connection = instance_double 'Faraday::Connection'
         allow(described_class).to receive(:http_connection).and_return(faraday_connection)
         allow(faraday_connection).to receive(:put).and_return(Faraday::Response.new(status: status))
-        expect(action.call).to be_falsey
+        expect { action.call }.to raise_exception Runner::Error::UnexpectedResponse
       end
     end
 
@@ -157,11 +157,11 @@ describe Runner::Strategy::Poseidon do
       include_examples 'returns false when the api request failed', status
     end
 
-    it 'returns false if Faraday raises an error' do
+    it 'raises an exception if Faraday raises an error' do
       faraday_connection = instance_double 'Faraday::Connection'
       allow(described_class).to receive(:http_connection).and_return(faraday_connection)
       allow(faraday_connection).to receive(:put).and_raise(Faraday::TimeoutError)
-      expect(action.call).to be_falsey
+      expect { action.call }.to raise_exception Runner::Error::FaradayError
     end
   end
 

--- a/spec/models/execution_environment_spec.rb
+++ b/spec/models/execution_environment_spec.rb
@@ -138,8 +138,14 @@ describe ExecutionEnvironment do
       expect(execution_environment.send(:validate_docker_image?)).to be false
     end
 
+    it 'is false when the pool size is empty' do
+      expect(execution_environment.pool_size).to be 0
+      expect(execution_environment.send(:validate_docker_image?)).to be false
+    end
+
     it 'is true otherwise' do
       execution_environment.docker_image = FactoryBot.attributes_for(:ruby)[:docker_image]
+      execution_environment.pool_size = 1
       allow(Rails.env).to receive(:test?).and_return(false)
       expect(execution_environment.send(:validate_docker_image?)).to be true
     end

--- a/spec/models/execution_environment_spec.rb
+++ b/spec/models/execution_environment_spec.rb
@@ -8,7 +8,7 @@ describe ExecutionEnvironment do
   it 'validates that the Docker image works' do
     allow(execution_environment).to receive(:validate_docker_image?).and_return(true)
     allow(execution_environment).to receive(:working_docker_image?).and_return(true)
-    execution_environment.update(docker_image: FactoryBot.attributes_for(:ruby)[:docker_image])
+    execution_environment.update(FactoryBot.build(:ruby).attributes)
     expect(execution_environment).to have_received(:working_docker_image?)
   end
 
@@ -146,10 +146,12 @@ describe ExecutionEnvironment do
   end
 
   describe '#working_docker_image?' do
+    let(:execution_environment) { FactoryBot.create(:ruby) }
     let(:working_docker_image?) { execution_environment.send(:working_docker_image?) }
     let(:runner) { instance_double 'runner' }
 
     before do
+      allow(execution_environment).to receive(:sync_runner_environment).and_return(true)
       allow(Runner).to receive(:for).with(execution_environment.author, execution_environment).and_return runner
     end
 
@@ -176,7 +178,7 @@ describe ExecutionEnvironment do
     context 'when the Docker client produces an error' do
       it 'adds an error' do
         allow(runner).to receive(:execute_command).and_raise(Runner::Error)
-        working_docker_image?
+        expect { working_docker_image? }.to raise_error(ActiveRecord::RecordInvalid)
         expect(execution_environment.errors[:docker_image]).to be_present
       end
     end

--- a/spec/models/runner_spec.rb
+++ b/spec/models/runner_spec.rb
@@ -233,7 +233,7 @@ describe Runner do
       end
 
       it 'raises an error when the environment could not be synced' do
-        allow(strategy_class).to receive(:sync_environment).with(runner.execution_environment).and_return(false)
+        allow(strategy_class).to receive(:sync_environment).with(runner.execution_environment).and_raise(Runner::Error::EnvironmentNotFound)
         expect { runner.send(:request_new_id) }.to raise_error(Runner::Error::EnvironmentNotFound, /#{environment_id}.*could not be synced/)
       end
     end


### PR DESCRIPTION
This MR:

* Allows editing execution environments even when they didn't exist yet in the runner management
* Implements the `environments` and `delete_environment` methods for all strategies
* Ensures that execution environments are in sync at the runner management after failed edits