### PR TITLE
Poseidon: Use absolute path to remove workspace directory

### DIFF
--- a/lib/runner/strategy/poseidon.rb
+++ b/lib/runner/strategy/poseidon.rb
@@ -119,8 +119,9 @@ class Runner::Strategy::Poseidon < Runner::Strategy
     end
 
     # First, clean the workspace and second, copy all files to their location.
-    # This ensures that no artefacts from a previous submission remain in the workspace.
-    body = {copy: copy, delete: ['./']}
+    # This ensures that no artifacts from a previous submission remain in the workspace.
+    # TODO: Switch back to clean diretory content only. See https://github.com/openHPI/poseidon/issues/42
+    body = {copy: copy, delete: ['/workspace']}
     response = self.class.http_connection.patch url, body.to_json
     return if response.status == 204
 

--- a/spec/lib/runner/strategy/poseidon_spec.rb
+++ b/spec/lib/runner/strategy/poseidon_spec.rb
@@ -328,7 +328,7 @@ describe Runner::Strategy::Poseidon do
       WebMock
         .stub_request(:patch, "#{described_class.config[:url]}/runners/#{runner_id}/files")
         .with(
-          body: {copy: [{path: file.filepath, content: encoded_file_content}], delete: ['./']},
+          body: {copy: [{path: file.filepath, content: encoded_file_content}], delete: ['/workspace']},
           headers: {'Content-Type' => 'application/json'}
         )
         .to_return(body: response_body, status: response_status)


### PR DESCRIPTION
This MR implements a workaround for https://github.com/openHPI/poseidon/issues/42