### PR TITLE
Check Runner management status in execution environment updates

### DIFF
--- a/app/models/execution_environment.rb
+++ b/app/models/execution_environment.rb
@@ -80,7 +80,7 @@ class ExecutionEnvironment < ApplicationRecord
 
   def validate_docker_image?
     # We only validate the code execution with the provided image if there is at least one container to test with.
-    pool_size.positive? && docker_image.present? && !Rails.env.test?
+    pool_size.positive? && docker_image.present? && !Rails.env.test? && Runner.management_active?
   end
 
   def working_docker_image?
@@ -105,7 +105,7 @@ class ExecutionEnvironment < ApplicationRecord
   end
 
   def delete_runner_environment
-    Runner.strategy_class.remove_environment(self)
+    Runner.strategy_class.remove_environment(self) if Runner.management_active?
   rescue Runner::Error => e
     unless errors.include?(:docker_image)
       errors.add(:docker_image, "error: #{e}")
@@ -115,7 +115,7 @@ class ExecutionEnvironment < ApplicationRecord
 
   def sync_runner_environment
     previous_saved_environment = self.class.find(id)
-    Runner.strategy_class.sync_environment(previous_saved_environment)
+    Runner.strategy_class.sync_environment(previous_saved_environment) if Runner.management_active?
   rescue Runner::Error => e
     unless errors.include?(:docker_image)
       errors.add(:docker_image, "error: #{e}")


### PR DESCRIPTION
@KlausGPaul Please have a look at whether this information fixes the issue you're facing in the seed step: 

It is probably related to the sample config in `code_ocean.yml`. The config listed there probably does not work well with the Vagrant setup yet. You might want to try the following there:

```yml
  runner_management:
    enabled: true
    strategy: docker_container_pool
    url: http://127.0.0.1:7100
    unused_runner_expiration_time: 180
```

As of now, we have two potential backends for running submissions: Poseidon and DockerContainerPool. So far, the Vagrant setup uses the DockerContainerPool environment while the default config includes the settings for Poseidon.

Furthermore, the issue fixed with this PR will allow updating and editing an execution environment without a valid Runner management.