### PR TITLE
Remove Temporary Fix for Early HTTP Response from Poseidon

### DIFF
--- a/lib/runner/strategy/poseidon.rb
+++ b/lib/runner/strategy/poseidon.rb
@@ -127,9 +127,6 @@ class Runner::Strategy::Poseidon < Runner::Strategy
 
     Runner.destroy(@allocation_id) if response.status == 400
     self.class.handle_error response
-  rescue Faraday::ConnectionFailed
-    # TODO: Remove fix after the following issue is resolved: https://github.com/openHPI/poseidon/issues/54
-    raise Runner::Error::RunnerNotFound.new
   rescue Faraday::Error => e
     raise Runner::Error::FaradayError.new("Request to Poseidon failed: #{e.inspect}")
   ensure


### PR DESCRIPTION
After [Poseidon#76](https://github.com/openHPI/poseidon/issues/76) has been merged, we can remove the temporary workaround for [Poseidon#54](https://github.com/openHPI/poseidon/issues/54).