### PR TITLE
Fix linebreak for AWS

### DIFF
--- a/lib/runner/connection/buffer.rb
+++ b/lib/runner/connection/buffer.rb
@@ -71,8 +71,8 @@ class Runner::Connection::Buffer
     @buffering = false
     @global_buffer = +''
     # For our buffering, we identified line breaks with the `\n` and removed those temporarily.
-    # Thus, we now re-add the `\n` at the end of the string and remove the `\r` at the same time.
-    message = message.gsub(/\r$/, "\n")
+    # Thus, we now re-add the `\n` at the end of the string and (optionally) remove a trailing `\r` at the same time.
+    message = message.gsub(/\r?$/, "\n")
     @line_buffer.push message
   end
 


### PR DESCRIPTION
Allow `\r\n` and `\n` line breaks for `Connection::Buffer`

* Nomad sends CRLF-separated lines
* AWS sends LF-separated lines

Closes https://github.com/openHPI/poseidon/issues/121