### PR TITLE
#1300 option to limit exercise statistics

### DIFF
--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -472,6 +472,8 @@ working_time_accumulated: working_time_accumulated})
       if policy(@exercise).detailed_statistics?
         @submissions = Submission.where(user: @external_user,
           exercise_id: @exercise.id).in_study_group_of(current_user).order('created_at')
+        @show_autosaves = params[:show_autosaves] == 'true'
+        @submissions = @submissions.where.not(cause: 'autosave') unless @show_autosaves
         interventions = UserExerciseIntervention.where('user_id = ?  AND exercise_id = ?', @external_user.id,
           @exercise.id)
         @all_events = (@submissions + interventions).sort_by(&:created_at)

--- a/app/views/exercises/external_users/statistics.html.slim
+++ b/app/views/exercises/external_users/statistics.html.slim
@@ -38,6 +38,17 @@ h1
           option data-submission=submission
             =index
           - index += 1
+  .bg-light.w-100.p-2.mb-4.align-items-center.d-flex.justify-content-between
+    - if @show_autosaves
+      span.pl-1.pb-1
+        i.fa.fa-info-circle.align-middle
+        small.mr-5.ml-1 = t('.toggle_status_on')
+      = link_to t('.toggle_autosave_off'), statistics_external_user_exercise_path(show_autosaves: false), class: "btn btn-outline-dark float-right btn-sm"
+    - else
+      span.pl-1.pb-1
+        i.fa.fa-info-circle.align-middle
+        small.mr-5.ml-1 = t('.toggle_status_off')
+      = link_to t('.toggle_autosave_on'), statistics_external_user_exercise_path(show_autosaves: true), class: "btn btn-outline-dark float-right btn-sm"
   #timeline
     .table-responsive
       table.table

--- a/app/views/exercises/external_users/statistics.html.slim
+++ b/app/views/exercises/external_users/statistics.html.slim
@@ -38,17 +38,18 @@ h1
           option data-submission=submission
             =index
           - index += 1
-  .bg-light.w-100.p-2.mb-4.align-items-center.d-flex.justify-content-between
-    - if @show_autosaves
-      span.pl-1.pb-1
-        i.fa.fa-info-circle.align-middle
-        small.mr-5.ml-1 = t('.toggle_status_on')
-      = link_to t('.toggle_autosave_off'), statistics_external_user_exercise_path(show_autosaves: false), class: "btn btn-outline-dark float-right btn-sm"
-    - else
-      span.pl-1.pb-1
-        i.fa.fa-info-circle.align-middle
-        small.mr-5.ml-1 = t('.toggle_status_off')
-      = link_to t('.toggle_autosave_on'), statistics_external_user_exercise_path(show_autosaves: true), class: "btn btn-outline-dark float-right btn-sm"
+  - if policy(@exercise).detailed_statistics?
+    .bg-light.w-100.p-2.mb-4.align-items-center.d-flex.justify-content-between
+      - if @show_autosaves
+        span.pl-1.pb-1
+          i.fa.fa-info-circle.align-middle
+          small.mr-5.ml-1 = t('.toggle_status_on')
+        = link_to t('.toggle_autosave_off'), statistics_external_user_exercise_path(show_autosaves: false), class: "btn btn-outline-dark float-right btn-sm"
+      - else
+        span.pl-1.pb-1
+          i.fa.fa-info-circle.align-middle
+          small.mr-5.ml-1 = t('.toggle_status_off')
+        = link_to t('.toggle_autosave_on'), statistics_external_user_exercise_path(show_autosaves: true), class: "btn btn-outline-dark float-right btn-sm"
   #timeline
     .table-responsive
       table.table

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -521,6 +521,10 @@ de:
         after_late_deadline: Verspätete Abgabe
         addendum: '* Differenzen von mehr als %{delta} Minuten werden ignoriert.'
         filter: "Hinweis: Nur die letzte Abgabe vor einer Abgabefrist ist sichtbar."
+        toggle_autosave_on: Zwischenspeicherungen anzeigen
+        toggle_autosave_off: Zwischenspeicherungen ausblenden
+        toggle_status_on: Zwischenspeicherungen sind eingeblendet
+        toggle_status_off: Zwischenspeicherungen sind ausgeblendet
   proxy_exercises:
       index:
         clone: Duplizieren

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -521,6 +521,10 @@ en:
         after_late_deadline: Too Late
         addendum: "* Deltas longer than %{delta} minutes are ignored."
         filter: "Remember: Only the last submission per deadline is shown."
+        toggle_autosave_on: Show Autosaves
+        toggle_autosave_off: Hide Autosaves
+        toggle_status_on: Autosaves are currently visible
+        toggle_status_off: Autosaves are currently hidden
   proxy_exercises:
       index:
         clone: Duplicate

--- a/spec/features/external_user_statistics_spec.rb
+++ b/spec/features/external_user_statistics_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'ExternalUserStatistics', js: true do
+  let(:learner) { create(:external_user) }
+  let(:exercise) { create(:dummy, user: user) }
+  let(:study_group) { create(:study_group) }
+  let(:password) { 'password123456' }
+
+  before do
+    2.times { create(:submission, cause: 'autosave', user: learner, exercise: exercise, study_group: study_group) }
+    2.times { create(:submission, cause: 'run', user: learner, exercise: exercise, study_group: study_group) }
+    create(:submission, cause: 'assess', user: learner, exercise: exercise, study_group: study_group)
+    create(:submission, cause: 'submit', user: learner, exercise: exercise, study_group: study_group)
+
+    study_group.external_users << learner
+    study_group.internal_users << user
+    study_group.save
+
+    visit(sign_in_path)
+    fill_in('email', with: user.email)
+    fill_in('password', with: password)
+    click_button(I18n.t('sessions.new.link'))
+    allow_any_instance_of(LtiHelper).to receive(:lti_outcome_service?).and_return(true)
+    visit(statistics_external_user_exercise_path(id: exercise.id, external_user_id: learner.id))
+  end
+
+  context 'when a admin accesses the page' do
+    let(:user) { create(:admin, password: password) }
+
+    it 'does display the option to enable autosaves' do
+      expect(page).to have_content(I18n.t('exercises.external_users.statistics.toggle_status_on')).or have_content(I18n.t('exercises.external_users.statistics.toggle_status_off'))
+    end
+  end
+
+  context 'when a teacher accesses the page' do
+    let(:user) { create(:teacher, password: password) }
+
+    it 'does not display the option to enable autosaves' do
+      expect(page).not_to have_content(I18n.t('exercises.external_users.statistics.toggle_status_on'))
+      expect(page).not_to have_content(I18n.t('exercises.external_users.statistics.toggle_status_off'))
+    end
+  end
+end


### PR DESCRIPTION
Add option to limit exercise statistics to user-interactions #1300

When in the statistics view of a certain exercise you can now toggle all autosave submissions on and off. There is also a label indicating the status of the current state to make it more user friendly.

