### PR TITLE
Refactor external_user_statistics to own controller action

### DIFF
--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -492,13 +492,13 @@ working_time_accumulated: working_time_accumulated})
     # Render statistics page for one specific external user
 
     if policy(@exercise).detailed_statistics?
-      @submissions = Submission.where(user: @external_user,
+      submissions = Submission.where(user: @external_user,
         exercise_id: @exercise.id).in_study_group_of(current_user).order('created_at')
       @show_autosaves = params[:show_autosaves] == 'true'
-      @submissions = @submissions.where.not(cause: 'autosave') unless @show_autosaves
+      submissions = submissions.where.not(cause: 'autosave') unless @show_autosaves
       interventions = UserExerciseIntervention.where('user_id = ?  AND exercise_id = ?', @external_user.id,
         @exercise.id)
-      @all_events = (@submissions + interventions).sort_by(&:created_at)
+      @all_events = (submissions + interventions).sort_by(&:created_at)
       @deltas = @all_events.map.with_index do |item, index|
         delta = item.created_at - @all_events[index - 1].created_at if index.positive?
         delta.nil? || (delta > StatisticsHelper::WORKING_TIME_DELTA_IN_SECONDS) ? 0 : delta
@@ -510,12 +510,12 @@ working_time_accumulated: working_time_accumulated})
     else
       final_submissions = Submission.where(user: @external_user,
         exercise_id: @exercise.id).in_study_group_of(current_user).final
-      @submissions = []
+      submissions = []
       %i[before_deadline within_grace_period after_late_deadline].each do |filter|
         relevant_submission = final_submissions.send(filter).latest
-        @submissions.push relevant_submission if relevant_submission.present?
+        submissions.push relevant_submission if relevant_submission.present?
       end
-      @all_events = @submissions
+      @all_events = submissions
     end
 
     render 'exercises/external_users/statistics'

--- a/app/policies/exercise_policy.rb
+++ b/app/policies/exercise_policy.rb
@@ -5,7 +5,7 @@ class ExercisePolicy < AdminOrAuthorPolicy
     admin?
   end
 
-  %i[show? feedback? statistics? rfcs_for_exercise?].each do |action|
+  %i[show? feedback? statistics? external_user_statistics? rfcs_for_exercise?].each do |action|
     define_method(action) { admin? || teacher_in_study_group? || (teacher? && @record.public?) || author? }
   end
 

--- a/app/views/exercises/external_users/statistics.html.slim
+++ b/app/views/exercises/external_users/statistics.html.slim
@@ -3,20 +3,21 @@ h1
   ' (external user
   = link_to_if(policy(@external_user).show?, @external_user.displayname, @external_user)
   ' )
-- current_submission = @submissions.first
+- submissions = @all_events.filter{|event| event.is_a? Submission}
+- current_submission = submissions.first
 - if current_submission
   - initial_files = current_submission.files.to_a
 
   - all_files = []
   - file_types = Set.new()
-  - @submissions.each do |submission|
+  - submissions.each do |submission|
     - submission.files.each do |file|
       - file_types.add(ActiveSupport::JSON.encode(file.file_type))
     - all_files.push(submission.files)
   - all_files.reject!(&:blank?)
   - file_types.reject!(&:blank?)
 
-  .d-none#data data-submissions=ActiveSupport::JSON.encode(@submissions) data-files=ActiveSupport::JSON.encode(all_files) data-file-types=ActiveSupport::JSON.encode(file_types)
+  .d-none#data data-submissions=ActiveSupport::JSON.encode(submissions) data-files=ActiveSupport::JSON.encode(all_files) data-file-types=ActiveSupport::JSON.encode(file_types)
 
   #stats-editor.row
     - index = 0
@@ -33,7 +34,7 @@ h1
       input type='range' orient='horizontal' list='datapoints' min=0 max=all_files.length-1 value=0 style="width: 100%"
       datalist#datapoints
         - index=0
-        - @submissions.each do |submission|
+        - submissions.each do |submission|
           - next if submission.files.blank?
           option data-submission=submission
             =index

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -477,6 +477,7 @@ de:
       feedback: Feedback
       requests_for_comments: Kommentaranfragen
       study_group_dashboard: Live Dashboard
+      external_user_statistics: Statistik für externe Nutzer
     show:
       is_unpublished: Aufgabe ist deaktiviert
     statistics:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -477,6 +477,7 @@ en:
       feedback: Feedback
       requests_for_comments: Requests for Comments
       study_group_dashboard: Live Dashboard
+      external_user_statistics: External User Statistics
     show:
       is_unpublished: Exercise is unpublished
     statistics:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,7 +117,9 @@ Rails.application.routes.draw do
   resources :user_exercise_feedbacks, except: %i[show index]
 
   resources :external_users, only: %i[index show], concerns: :statistics do
-    resources :exercises, concerns: :statistics
+    resources :exercises do
+      get :statistics, to: 'exercises#external_user_statistics', on: :member
+    end
     member do
       get :tag_statistics
     end

--- a/spec/controllers/exercises_controller_spec.rb
+++ b/spec/controllers/exercises_controller_spec.rb
@@ -236,8 +236,8 @@ describe ExercisesController do
     expect_template(:statistics)
   end
 
-  describe 'GET #statistics for external users' do
-    let(:perform_request) { get :statistics, params: params }
+  describe 'GET #external_user_statistics' do
+    let(:perform_request) { get :external_user_statistics, params: params }
     let(:params) { {id: exercise.id, external_user_id: external_user.id} }
     let(:external_user) { create(:external_user) }
 
@@ -250,7 +250,7 @@ describe ExercisesController do
     context 'when viewing the default submission statistics page without a parameter' do
       it 'does not list autosaved submissions' do
         perform_request
-        expect(assigns(:submissions)).to match_array [
+        expect(assigns(:all_events).filter {|event| event.is_a? Submission }).to match_array [
           an_object_having_attributes(cause: 'run', user_id: external_user.id),
           an_object_having_attributes(cause: 'assess', user_id: external_user.id),
           an_object_having_attributes(cause: 'run', user_id: external_user.id),
@@ -263,7 +263,7 @@ describe ExercisesController do
 
       it 'lists all submissions, including autosaved submissions' do
         perform_request
-        submissions = assigns(:submissions)
+        submissions = assigns(:all_events).filter {|event| event.is_a? Submission }
         expect(submissions).to match_array Submission.all
         expect(submissions).to include an_object_having_attributes(cause: 'autosave', user_id: external_user.id)
       end


### PR DESCRIPTION
This PR:
- is based on [this review comment](https://github.com/openHPI/codeocean/pull/1303#pullrequestreview-1044832274)
- keeps the same behaviour implemented for #1300
- refactors the `ExerciseController#statistics` method to be separated into two parts (one of the general exercise statistics and one for a specific user who solved the given exercise)
- does not yet tackle the large number of instance variables passed to the view (most code is just moved)