### PR TITLE
Rfc authentication

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -20,10 +20,11 @@ class UserMailer < ApplicationMailer
 
   def got_new_comment(comment, request_for_comment, commenting_user)
     # TODO: check whether we can take the last known locale of the receiver?
+    token = AuthenticationToken.generate!(request_for_comment.user)
     @receiver_displayname = request_for_comment.user.displayname
     @commenting_user_displayname = commenting_user.displayname
     @comment_text = comment.text
-    @rfc_link = request_for_comment_url(request_for_comment)
+    @rfc_link = request_for_comment_url(request_for_comment, token: token.shared_secret)
     mail(
       subject: t('mailers.user_mailer.got_new_comment.subject',
         commenting_user_displayname: @commenting_user_displayname), to: request_for_comment.user.email
@@ -31,10 +32,11 @@ class UserMailer < ApplicationMailer
   end
 
   def got_new_comment_for_subscription(comment, subscription, from_user)
+    token = AuthenticationToken.generate!(subscription.user)
     @receiver_displayname = subscription.user.displayname
     @author_displayname = from_user.displayname
     @comment_text = comment.text
-    @rfc_link = request_for_comment_url(subscription.request_for_comment)
+    @rfc_link = request_for_comment_url(subscription.request_for_comment, token: token.shared_secret)
     @unsubscribe_link = unsubscribe_subscription_url(subscription)
     mail(
       subject: t('mailers.user_mailer.got_new_comment_for_subscription.subject',
@@ -43,10 +45,11 @@ class UserMailer < ApplicationMailer
   end
 
   def send_thank_you_note(request_for_comments, receiver)
+    token = AuthenticationToken.generate!(request_for_comments.user)
     @receiver_displayname = receiver.displayname
     @author = request_for_comments.user.displayname
     @thank_you_note = request_for_comments.thank_you_note
-    @rfc_link = request_for_comment_url(request_for_comments)
+    @rfc_link = request_for_comment_url(request_for_comments, token: token.shared_secret)
     mail(subject: t('mailers.user_mailer.send_thank_you_note.subject', author: @author), to: receiver.email)
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -44,12 +44,12 @@ class UserMailer < ApplicationMailer
     )
   end
 
-  def send_thank_you_note(request_for_comments, receiver)
-    token = AuthenticationToken.generate!(request_for_comments.user)
+  def send_thank_you_note(request_for_comment, receiver)
+    token = AuthenticationToken.generate!(request_for_comment.user)
     @receiver_displayname = receiver.displayname
-    @author = request_for_comments.user.displayname
-    @thank_you_note = request_for_comments.thank_you_note
-    @rfc_link = request_for_comment_url(request_for_comments, token: token.shared_secret)
+    @author = request_for_comment.user.displayname
+    @thank_you_note = request_for_comment.thank_you_note
+    @rfc_link = request_for_comment_url(request_for_comment, token: token.shared_secret)
     mail(subject: t('mailers.user_mailer.send_thank_you_note.subject', author: @author), to: receiver.email)
   end
 

--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+class AuthenticationToken < ApplicationRecord
+  include Creation
+  def self.generate!(user)
+    create!(
+      shared_secret: SecureRandom.hex(32),
+      user: user,
+      expire_at: 7.days.from_now
+    )
+  end
+end

--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -4,6 +4,7 @@ require 'securerandom'
 
 class AuthenticationToken < ApplicationRecord
   include Creation
+
   def self.generate!(user)
     create!(
       shared_secret: SecureRandom.hex(32),

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   ROLES = %w[admin teacher learner].freeze
 
   belongs_to :consumer
+  has_many :authentication_token, dependent: :destroy
   has_many :study_group_memberships, as: :user
   has_many :study_groups, through: :study_group_memberships, as: :user
   has_many :exercises, as: :user

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -601,8 +601,6 @@ de:
           <br>
           Sie finden ihre Kommentaranfrage hier: %{link_to_comment} <br>
           <br>
-          Falls Sie beim Klick auf diesen Link eine Fehlermeldung erhalten, dass Sie nicht berechtigt wären diese Aktion auszuführen, öffnen Sie bitte eine beliebige Programmieraufgabe aus einem Kurs heraus und klicken den Link danach noch einmal.<br>
-          <br>
           Eine Übersicht Ihrer Kommentaranfragen gibt es hier: %{link_my_comments} <br>
           Alle Kommentaranfragen aller Benutzer finden Sie hier: %{link_all_comments} <br>
           <br>
@@ -617,8 +615,6 @@ de:
           %{commenting_user_displayname} wrote: %{comment_text} <br>
           <br>
           You can find your request for comments here: %{link_to_comment} <br>
-          <br>
-          If you receive an error that you are not authorized to perform this action when clicking the link, please log-in through any course exercise beforehand and click the link again. <br>
           <br>
           An overview of all your comments can be accessed here: %{link_my_comments} <br>
           All comments of all participants are available here: %{link_all_comments} <br>
@@ -641,8 +637,6 @@ de:
           <br>
           Sie finden die Kommentaranfrage hier: %{link_to_comment} <br>
           <br>
-          Falls Sie beim Klick auf diesen Link eine Fehlermeldung erhalten, dass Sie nicht berechtigt wären diese Aktion auszuführen, öffnen Sie bitte eine beliebige Programmieraufgabe aus einem Kurs heraus und klicken den Link danach noch einmal.<br>
-          <br>
           Danke, dass Sie anderen Nutzern von CodeOcean helfen!
           <br>
           Diese Mail wurde automatisch von CodeOcean verschickt.<br>
@@ -656,8 +650,6 @@ de:
           %{author} wrote: %{thank_you_note} <br>
           <br>
           You can find the request for comments here: %{link_to_comment} <br>
-          <br>
-          If you receive an error that you are not authorized to perform this action when clicking the link, please log-in through any course exercise beforehand and click the link again. <br>
           <br>
           Thank you for helping other users on CodeOcean!
           <br>
@@ -676,8 +668,6 @@ de:
           <br>
           Sie finden die Kommentaranfrage hier: %{link_to_comment} <br>
           <br>
-          Falls Sie beim Klick auf diesen Link eine Fehlermeldung erhalten, dass Sie nicht berechtigt wären diese Aktion auszuführen, öffnen Sie bitte eine beliebige Programmieraufgabe aus einem Kurs heraus und klicken den Link danach noch einmal.<br>
-          <br>
           Wenn Sie keine weiteren Benachrichtigungen zu dieser Anfrage erhalten möchten, klicken Sie bitte hier: %{unsubscribe_link}
           <br>
           Diese Mail wurde automatisch von CodeOcean verschickt.<br>
@@ -691,8 +681,6 @@ de:
           %{author_displayname} wrote: %{comment_text} <br>
           <br>
           You can find the request for comments here: %{link_to_comment} <br>
-          <br>
-          If you receive an error that you are not authorized to perform this action when clicking the link, please log-in through any course exercise beforehand and click the link again. <br>
           <br>
           If you don't want to be notified about further comments, please click here: %{unsubscribe_link}
           <br>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -601,8 +601,6 @@ en:
           <br>
           Sie finden ihre Kommentaranfrage hier: %{link_to_comment} <br>
           <br>
-          Falls Sie beim Klick auf diesen Link eine Fehlermeldung erhalten, dass Sie nicht berechtigt wären diese Aktion auszuführen, öffnen Sie bitte eine beliebige Programmieraufgabe aus einem Kurs heraus und klicken den Link danach noch einmal.<br>
-          <br>
           Eine Übersicht Ihrer Kommentaranfragen gibt es hier: %{link_my_comments} <br>
           Alle Kommentaranfragen aller Benutzer finden Sie hier: %{link_all_comments} <br>
           <br>
@@ -617,8 +615,6 @@ en:
           %{commenting_user_displayname} wrote: %{comment_text} <br>
           <br>
           You can find your request for comments here: %{link_to_comment} <br>
-          <br>
-          If you receive an error that you are not authorized to perform this action when clicking the link, please log-in through any course exercise beforehand and click the link again. <br>
           <br>
           An overview of all your comments can be accessed here: %{link_my_comments} <br>
           All comments of all participants are available here: %{link_all_comments} <br>
@@ -641,8 +637,6 @@ en:
           <br>
           Sie finden die Kommentaranfrage hier: %{link_to_comment} <br>
           <br>
-          Falls Sie beim Klick auf diesen Link eine Fehlermeldung erhalten, dass Sie nicht berechtigt wären diese Aktion auszuführen, öffnen Sie bitte eine beliebige Programmieraufgabe aus einem Kurs heraus und klicken den Link danach noch einmal.<br>
-          <br>
           Danke, dass Sie anderen Nutzern von CodeOcean helfen!
           <br>
           Diese Mail wurde automatisch von CodeOcean verschickt.<br>
@@ -656,8 +650,6 @@ en:
           %{author} wrote: %{thank_you_note} <br>
           <br>
           You can find the request for comments here: %{link_to_comment} <br>
-          <br>
-          If you receive an error that you are not authorized to perform this action when clicking the link, please log-in through any course exercise beforehand and click the link again. <br>
           <br>
           Thank you for helping other users on CodeOcean!
           <br>
@@ -676,8 +668,6 @@ en:
           <br>
           Sie finden die Kommentaranfrage hier: %{link_to_comment} <br>
           <br>
-          Falls Sie beim Klick auf diesen Link eine Fehlermeldung erhalten, dass Sie nicht berechtigt wären diese Aktion auszuführen, öffnen Sie bitte eine beliebige Programmieraufgabe aus einem Kurs heraus und klicken den Link danach noch einmal.<br>
-          <br>
           Wenn Sie keine weiteren Benachrichtigungen zu dieser Anfrage erhalten möchten, klicken Sie bitte hier: %{unsubscribe_link}
           <br>
           Diese Mail wurde automatisch von CodeOcean verschickt.<br>
@@ -691,8 +681,6 @@ en:
           %{author_displayname} wrote: %{comment_text} <br>
           <br>
           You can find the request for comments here: %{link_to_comment} <br>
-          <br>
-          If you receive an error that you are not authorized to perform this action when clicking the link, please log-in through any course exercise beforehand and click the link again. <br>
           <br>
           If you don't want to be notified about further comments, please click here: %{unsubscribe_link}
           <br>

--- a/db/migrate/20220721131946_create_authentication_tokens.rb
+++ b/db/migrate/20220721131946_create_authentication_tokens.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateAuthenticationTokens < ActiveRecord::Migration[6.1]
+  def change
+    create_table :authentication_tokens, id: :uuid do |t|
+      t.string :shared_secret, null: false, index: {unique: true}
+      t.references :user, polymorphic: true, null: false
+      t.date :expire_at, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220721131946_create_authentication_tokens.rb
+++ b/db/migrate/20220721131946_create_authentication_tokens.rb
@@ -5,7 +5,7 @@ class CreateAuthenticationTokens < ActiveRecord::Migration[6.1]
     create_table :authentication_tokens, id: :uuid do |t|
       t.string :shared_secret, null: false, index: {unique: true}
       t.references :user, polymorphic: true, null: false
-      t.date :expire_at, null: false
+      t.datetime :expire_at, null: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_15_215112) do
+ActiveRecord::Schema.define(version: 2022_07_21_131946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -28,6 +28,17 @@ ActiveRecord::Schema.define(version: 2022_04_15_215112) do
     t.index ["exercise_collection_id"], name: "index_anomaly_notifications_on_exercise_collection_id"
     t.index ["exercise_id"], name: "index_anomaly_notifications_on_exercise_id"
     t.index ["user_type", "user_id"], name: "index_anomaly_notifications_on_user"
+  end
+
+  create_table "authentication_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "shared_secret", null: false
+    t.string "user_type", null: false
+    t.bigint "user_id", null: false
+    t.date "expire_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["shared_secret"], name: "index_authentication_tokens_on_shared_secret", unique: true
+    t.index ["user_type", "user_id"], name: "index_authentication_tokens_on_user"
   end
 
   create_table "codeharbor_links", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2022_07_21_131946) do
     t.string "shared_secret", null: false
     t.string "user_type", null: false
     t.bigint "user_id", null: false
-    t.date "expire_at", null: false
+    t.datetime "expire_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["shared_secret"], name: "index_authentication_tokens_on_shared_secret", unique: true

--- a/spec/factories/authentication_token.rb
+++ b/spec/factories/authentication_token.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :authentication_token, class: 'AuthenticationToken' do
+    created_by_external_user
+    shared_secret { SecureRandom.hex(32) }
+    expire_at { 7.days.from_now }
+
+    trait :invalid do
+      expire_at { 8.days.ago }
+    end
+  end
+end

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -35,12 +35,13 @@ describe 'Authentication' do
 
     context 'with no authentication token' do
       let(:request_for_comment) { create(:rfc_with_comment, user: user) }
+      let(:rfc_path) { request_for_comment_url(request_for_comment) }
 
       it 'denies access to the request for comment' do
-        mail.deliver_now
-        visit(rfc_link)
+        visit(rfc_path)
+        expect(page).not_to have_current_path(rfc_path)
         expect(page).not_to have_content(request_for_comment.exercise.title)
-        expect(response).to redirect_to(root_path)
+        expect(page).to have_current_path(root_path)
         expect(page).to have_content(I18n.t('application.not_authorized'))
       end
     end
@@ -60,8 +61,7 @@ describe 'Authentication' do
         it 'allows access to the request for comment' do
           mail.deliver_now
           visit(rfc_link)
-          expect(current_url).to be(rfc_link)
-          expect(response).to have_http_status :ok
+          expect(page).to have_current_path(rfc_link)
           expect(page).to have_content(request_for_comment.exercise.title)
         end
       end
@@ -72,8 +72,9 @@ describe 'Authentication' do
         it 'denies access to the request for comment' do
           mail.deliver_now
           visit(rfc_link)
+          expect(page).not_to have_current_path(rfc_link)
           expect(page).not_to have_content(request_for_comment.exercise.title)
-          expect(response).to redirect_to(root_path)
+          expect(page).to have_current_path(root_path)
           expect(page).to have_content(I18n.t('application.not_authorized'))
         end
       end

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -32,6 +32,52 @@ describe 'Authentication' do
         expect(page).to have_content(I18n.t('sessions.create.failure'))
       end
     end
+
+    context 'with no authentication token' do
+      let(:request_for_comment) { create(:rfc_with_comment, user: user) }
+
+      it 'denies access to the request for comment' do
+        mail.deliver_now
+        visit(rfc_link)
+        expect(page).not_to have_content(request_for_comment.exercise.title)
+        expect(response).to redirect_to(root_path)
+        expect(page).to have_content(I18n.t('application.not_authorized'))
+      end
+    end
+
+    context 'with an authentication token' do
+      let(:user) { create(:learner) }
+      let(:request_for_comment) { create(:rfc_with_comment, user: user) }
+      let(:commenting_user) { InternalUser.create(attributes_for(:teacher)) }
+      let(:mail) { UserMailer.got_new_comment(request_for_comment.comments.first, request_for_comment, commenting_user) }
+      let(:rfc_link) { request_for_comment_url(request_for_comment, token: token.shared_secret) }
+
+      before { allow(AuthenticationToken).to receive(:generate!).with(user).and_return(token).once }
+
+      context 'when the token is valid' do
+        let(:token) { create(:authentication_token, user: user) }
+
+        it 'allows access to the request for comment' do
+          mail.deliver_now
+          visit(rfc_link)
+          expect(current_url).to be(rfc_link)
+          expect(response).to have_http_status :ok
+          expect(page).to have_content(request_for_comment.exercise.title)
+        end
+      end
+
+      context 'with an expired authentication token' do
+        let(:token) { create(:authentication_token, :invalid, user: user) }
+
+        it 'denies access to the request for comment' do
+          mail.deliver_now
+          visit(rfc_link)
+          expect(page).not_to have_content(request_for_comment.exercise.title)
+          expect(response).to redirect_to(root_path)
+          expect(page).to have_content(I18n.t('application.not_authorized'))
+        end
+      end
+    end
   end
 
   context 'when signed in' do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -14,7 +14,7 @@ describe UserMailer do
     end
 
     it 'sets the correct sender' do
-      expect(mail.from).to include(CodeOcean::Application.config.action_mailer[:default_options][:from])
+      expect(mail.from).to include('codeocean@hpi.de')
     end
 
     it 'sets the correct subject' do
@@ -45,7 +45,7 @@ describe UserMailer do
     end
 
     it 'sets the correct sender' do
-      expect(mail.from).to include(CodeOcean::Application.config.action_mailer[:default_options][:from])
+      expect(mail.from).to include('codeocean@hpi.de')
     end
 
     it 'sets the correct subject' do
@@ -69,7 +69,7 @@ describe UserMailer do
     let(:mail) { described_class.got_new_comment(request_for_comment.comments.first, request_for_comment, commenting_user).deliver_now }
 
     it 'sets the correct sender' do
-      expect(mail.from).to include(CodeOcean::Application.config.action_mailer[:default_options][:from])
+      expect(mail.from).to include('codeocean@hpi.de')
     end
 
     it 'sets the correct subject' do
@@ -81,22 +81,17 @@ describe UserMailer do
     end
 
     it 'includes the correct URL' do
-      expect(mail.body).to include(request_for_comment_url(request_for_comment))
+      expect(mail.body).to include(request_for_comment_url(request_for_comment, token: token.shared_secret))
     end
 
-    it 'includes the correct authentication token' do
-      expect(mail.body).to include(token.shared_secret)
-    end
-
-    it 'sets a new authentication token' do
+    it 'creates a new authentication token' do
       expect { mail }.to change(AuthenticationToken, :count).by(1)
     end
 
-    it 'sets a non expired authentication token' do
+    it 'sets a non-expired authentication token' do
       mail
-      expect(token.expire_at.future?).to be(true)
-      token.expire_at -= 8.days
-      expect(token.expire_at.future?).to be(false)
+      # A five minute tolerance is allowed to account for the time difference between `now` and the creation timestamp of the token.
+      expect(token.expire_at - Time.zone.now).to be_within(5.minutes).of(7.days)
     end
   end
 
@@ -109,7 +104,7 @@ describe UserMailer do
     let(:mail) { described_class.got_new_comment_for_subscription(request_for_comment.comments.first, subscription, from_user).deliver_now }
 
     it 'sets the correct sender' do
-      expect(mail.from).to include(CodeOcean::Application.config.action_mailer[:default_options][:from])
+      expect(mail.from).to include('codeocean@hpi.de')
     end
 
     it 'sets the correct subject' do
@@ -121,22 +116,17 @@ describe UserMailer do
     end
 
     it 'includes the correct URL' do
-      expect(mail.body).to include(request_for_comment_url(subscription.request_for_comment))
+      expect(mail.body).to include(request_for_comment_url(subscription.request_for_comment, token: token.shared_secret))
     end
 
-    it 'includes the correct authentication token' do
-      expect(mail.body).to include(token.shared_secret)
-    end
-
-    it 'sets a new authentication token' do
+    it 'creates a new authentication token' do
       expect { mail }.to change(AuthenticationToken, :count).by(1)
     end
 
-    it 'sets a non expired authentication token' do
+    it 'sets a non-expired authentication token' do
       mail
-      expect(token.expire_at.future?).to be(true)
-      token.expire_at -= 8.days
-      expect(token.expire_at.future?).to be(false)
+      # A five minute tolerance is allowed to account for the time difference between `now` and the creation timestamp of the token.
+      expect(token.expire_at - Time.zone.now).to be_within(5.minutes).of(7.days)
     end
   end
 
@@ -148,7 +138,7 @@ describe UserMailer do
     let(:mail) { described_class.send_thank_you_note(request_for_comments, receiver).deliver_now }
 
     it 'sets the correct sender' do
-      expect(mail.from).to include(CodeOcean::Application.config.action_mailer[:default_options][:from])
+      expect(mail.from).to include('codeocean@hpi.de')
     end
 
     it 'sets the correct subject' do
@@ -160,22 +150,17 @@ describe UserMailer do
     end
 
     it 'includes the correct URL' do
-      expect(mail.body).to include(request_for_comment_url(request_for_comments))
+      expect(mail.body).to include(request_for_comment_url(request_for_comments, token: token.shared_secret))
     end
 
-    it 'includes the correct authentication token' do
-      expect(mail.body).to include(token.shared_secret)
-    end
-
-    it 'sets a new authentication token' do
+    it 'creates a new authentication token' do
       expect { mail }.to change(AuthenticationToken, :count).by(1)
     end
 
-    it 'sets a non expired authentication token' do
+    it 'sets a non-expired authentication token' do
       mail
-      expect(token.expire_at.future?).to be(true)
-      token.expire_at -= 8.days
-      expect(token.expire_at.future?).to be(false)
+      # A five minute tolerance is allowed to account for the time difference between `now` and the creation timestamp of the token.
+      expect(token.expire_at - Time.zone.now).to be_within(5.minutes).of(7.days)
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -60,4 +60,122 @@ describe UserMailer do
       expect(mail.body).to include(reset_password_internal_user_url(user, token: user.reset_password_token))
     end
   end
+
+  describe '#got_new_comment' do
+    let(:user) { create(:learner) }
+    let(:token) { AuthenticationToken.find_by(user: user) }
+    let(:request_for_comment) { create(:rfc_with_comment, user: user) }
+    let(:commenting_user) { InternalUser.create(attributes_for(:teacher)) }
+    let(:mail) { described_class.got_new_comment(request_for_comment.comments.first, request_for_comment, commenting_user).deliver_now }
+
+    it 'sets the correct sender' do
+      expect(mail.from).to include(CodeOcean::Application.config.action_mailer[:default_options][:from])
+    end
+
+    it 'sets the correct subject' do
+      expect(mail.subject).to eq(I18n.t('mailers.user_mailer.got_new_comment.subject', commenting_user_displayname: commenting_user.displayname))
+    end
+
+    it 'sets the correct receiver' do
+      expect(mail.to).to include(request_for_comment.user.email)
+    end
+
+    it 'includes the correct URL' do
+      expect(mail.body).to include(request_for_comment_url(request_for_comment))
+    end
+
+    it 'includes the correct authentication token' do
+      expect(mail.body).to include(token.shared_secret)
+    end
+
+    it 'sets a new authentication token' do
+      expect { mail }.to change(AuthenticationToken, :count).by(1)
+    end
+
+    it 'sets a non expired authentication token' do
+      mail
+      expect(token.expire_at.future?).to be(true)
+      token.expire_at -= 8.days
+      expect(token.expire_at.future?).to be(false)
+    end
+  end
+
+  describe '#got_new_comment_for_subscription' do
+    let(:user) { create(:learner) }
+    let(:token) { AuthenticationToken.find_by(user: user) }
+    let(:request_for_comment) { create(:rfc_with_comment, user: user) }
+    let(:subscription) { Subscription.create(request_for_comment: request_for_comment, user: user) }
+    let(:from_user) { InternalUser.create(attributes_for(:teacher)) }
+    let(:mail) { described_class.got_new_comment_for_subscription(request_for_comment.comments.first, subscription, from_user).deliver_now }
+
+    it 'sets the correct sender' do
+      expect(mail.from).to include(CodeOcean::Application.config.action_mailer[:default_options][:from])
+    end
+
+    it 'sets the correct subject' do
+      expect(mail.subject).to eq(I18n.t('mailers.user_mailer.got_new_comment_for_subscription.subject', author_displayname: from_user.displayname))
+    end
+
+    it 'sets the correct receiver' do
+      expect(mail.to).to include(subscription.user.email)
+    end
+
+    it 'includes the correct URL' do
+      expect(mail.body).to include(request_for_comment_url(subscription.request_for_comment))
+    end
+
+    it 'includes the correct authentication token' do
+      expect(mail.body).to include(token.shared_secret)
+    end
+
+    it 'sets a new authentication token' do
+      expect { mail }.to change(AuthenticationToken, :count).by(1)
+    end
+
+    it 'sets a non expired authentication token' do
+      mail
+      expect(token.expire_at.future?).to be(true)
+      token.expire_at -= 8.days
+      expect(token.expire_at.future?).to be(false)
+    end
+  end
+
+  describe '#send_thank_you_note' do
+    let(:user) { create(:learner) }
+    let(:token) { AuthenticationToken.find_by(user: user) }
+    let(:request_for_comments) { create(:rfc_with_comment, user: user) }
+    let(:receiver) { InternalUser.create(attributes_for(:teacher)) }
+    let(:mail) { described_class.send_thank_you_note(request_for_comments, receiver).deliver_now }
+
+    it 'sets the correct sender' do
+      expect(mail.from).to include(CodeOcean::Application.config.action_mailer[:default_options][:from])
+    end
+
+    it 'sets the correct subject' do
+      expect(mail.subject).to eq(I18n.t('mailers.user_mailer.send_thank_you_note.subject', author: request_for_comments.user.displayname))
+    end
+
+    it 'sets the correct receiver' do
+      expect(mail.to).to include(receiver.email)
+    end
+
+    it 'includes the correct URL' do
+      expect(mail.body).to include(request_for_comment_url(request_for_comments))
+    end
+
+    it 'includes the correct authentication token' do
+      expect(mail.body).to include(token.shared_secret)
+    end
+
+    it 'sets a new authentication token' do
+      expect { mail }.to change(AuthenticationToken, :count).by(1)
+    end
+
+    it 'sets a non expired authentication token' do
+      mail
+      expect(token.expire_at.future?).to be(true)
+      token.expire_at -= 8.days
+      expect(token.expire_at.future?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Regarding issue: Add authentication token to RfC mails #1301

Via token authentication it is now possible to view a Request for Comment even when not logged in.

Closes #1301 