### PR TITLE
Safe Comment Params

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -55,7 +55,7 @@ class CommentsController < ApplicationController
 
   # PATCH/PUT /comments/1.json
   def update
-    if @comment.update(comment_params_without_request_id)
+    if @comment.update(comment_params_for_update)
       render :show, status: :ok, location: @comment
     else
       render json: @comment.errors, status: :unprocessable_entity
@@ -75,6 +75,10 @@ class CommentsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_comment
     @comment = Comment.find(params[:id])
+  end
+
+  def comment_params_for_update
+    params.require(:comment).permit(:text)
   end
 
   def comment_params_without_request_id

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CommentsController do
+  let(:user) { create(:learner) }
+  let(:rfc_with_comment) { create(:rfc_with_comment, user: user) }
+  let(:comment) { rfc_with_comment.comments.first }
+  let(:updated_comment) { comment.reload }
+  let(:perform_request) { proc { put :update, format: :json, params: {id: comment.id, comment: comment_params} } }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    perform_request.call
+  end
+
+  describe 'PUT #update' do
+    context 'with valid params' do
+      let(:comment_params) { {text: 'test100'} }
+
+      it 'saves the permitted changes' do
+        expect(updated_comment.text).to eq('test100')
+      end
+
+      expect_http_status(:ok)
+    end
+
+    context 'with additional params' do
+      let(:comment_params) { {text: 'test100', row: 5, file_id: 50} }
+
+      it 'applies the permitted changes' do
+        expect(updated_comment.row).not_to eq(5)
+        expect(updated_comment.file_id).not_to eq(50)
+        expect(updated_comment.row).to eq(1)
+        expect(updated_comment.file_id).to eq(comment.file_id)
+        expect(updated_comment.text).to eq('test100')
+      end
+
+      expect_http_status(:ok)
+    end
+  end
+end

--- a/spec/factories/request_for_comment.rb
+++ b/spec/factories/request_for_comment.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     factory :rfc_with_comment, class: 'RequestForComment' do
       after(:create) do |rfc|
         rfc.file = rfc.submission.files.first
-        Comment.create(file: rfc.file, user: rfc.user, text: "comment for rfc #{rfc.question}")
+        Comment.create(file: rfc.file, user: rfc.user, row: 1, text: "comment for rfc #{rfc.question}")
       end
     end
   end


### PR DESCRIPTION
Regarding issue: Changing the file of a comment should not be possible #876

Added strong params to comments_controller to prevent users from editing attributes which are not intended to be edited, also created specs to test this behaviour.

Closes #876 