### PR TITLE
Retrieve files from runner

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,7 +27,7 @@ Metrics/CyclomaticComplexity:
   Max: 20
 
 Metrics/PerceivedComplexity:
-  Max: 22
+  Max: 23
 
 # We don't want to change previous migrations...
 #

--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -669,6 +669,7 @@ var CodeOceanEditor = {
         $('#flowrHint').fadeOut();
         this.clearHints();
         this.showOutputBar();
+        this.clearFileDownloads();
     },
 
     isActiveFileBinary: function () {
@@ -735,6 +736,24 @@ var CodeOceanEditor = {
         var container = $('#error-hints');
         container.find('ul.body').append(template(message.description, message.hint));
         container.fadeIn();
+    },
+
+    prepareFileDownloads: function(message) {
+        const fileTree = $('#download-file-tree');
+        fileTree.jstree(message.data);
+        fileTree.on('select_node.jstree', function (node, selected, _event) {
+            selected.instance.deselect_all();
+            const downloadPath = selected.node.original.download_path;
+            if (downloadPath) {
+                window.location = downloadPath;
+            }
+        }.bind(this));
+        $('#download-files').removeClass('d-none');
+    },
+
+    clearFileDownloads: function() {
+        $('#download-files').addClass('d-none');
+        $('#download-file-tree').replaceWith($('<div id="download-file-tree">'));
     },
 
     showContainerDepletedMessage: function () {

--- a/app/assets/javascripts/editor/execution.js
+++ b/app/assets/javascripts/editor/execution.js
@@ -48,6 +48,7 @@ CodeOceanEditorWebsocket = {
     this.websocket.on('exit', this.handleExitCommand.bind(this));
     this.websocket.on('status', this.showStatus.bind(this));
     this.websocket.on('hint', this.showHint.bind(this));
+    this.websocket.on('files', this.prepareFileDownloads.bind(this));
   },
 
   handleExitCommand: function() {

--- a/app/assets/stylesheets/exercises.css.scss
+++ b/app/assets/stylesheets/exercises.css.scss
@@ -40,11 +40,11 @@ input[type='file'] {
   }
 }
 
-[data-bs-toggle="collapse"] .fa-solid:before {
+[data-bs-toggle="collapse"] .fa-solid:first-child:before {
   content: "\f139";
 }
 
-[data-bs-toggle="collapse"].collapsed .fa-solid:before {
+[data-bs-toggle="collapse"].collapsed .fa-solid:first-child:before {
   content: "\f13a";
 }
 

--- a/app/controllers/concerns/file_conversion.rb
+++ b/app/controllers/concerns/file_conversion.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module FileConversion
+  private
+
+  def convert_files_json_to_files(files_json)
+    all_file_types = FileType.all
+    directories = []
+    files = files_json['files'].filter_map do |file|
+      # entryType: `-` describes a regular file, `d` a directory. See `info ls` for others
+      directories.push(file['name']) if file['entryType'] == 'd'
+      next unless file['entryType'] == '-'
+
+      extension = File.extname(file['name'])
+      name = File.basename(file['name'], extension)
+      path = File.dirname(file['name']).sub(%r{^(?>\./|\.)}, '').presence
+      file_type = all_file_types.detect {|ft| ft.file_extension == extension } || FileType.new(file_extension: extension)
+      CodeOcean::File.new(
+        name: name,
+        path: path,
+        size: file['size'],
+        owner: file['owner'],
+        group: file['group'],
+        permissions: file['permissions'],
+        updated_at: file['modificationTime'],
+        file_type: file_type
+      )
+    end
+    [augment_files_for_download(files), directories]
+  end
+
+  def augment_files_for_download(files)
+    raise NotImplementedError
+  end
+end

--- a/app/controllers/live_streams_controller.rb
+++ b/app/controllers/live_streams_controller.rb
@@ -21,12 +21,21 @@ class LiveStreamsController < ApplicationController
     send_runner_file(runner, desired_file, fallback_location)
   end
 
+  def download_arbitrary_file
+    @execution_environment = authorize ExecutionEnvironment.find(params[:id])
+    desired_file = params[:filename].to_s
+    runner = Runner.for(current_user, @execution_environment)
+    fallback_location = shell_execution_environment_path(@execution_environment)
+    privileged = params[:sudo] || @execution_environment.privileged_execution?
+    send_runner_file(runner, desired_file, fallback_location, privileged: privileged)
+  end
+
   private
 
-  def send_runner_file(runner, desired_file, redirect_fallback = root_path)
+  def send_runner_file(runner, desired_file, redirect_fallback = root_path, privileged: false)
     filename = File.basename(desired_file)
     send_stream(filename: filename, disposition: 'attachment') do |stream|
-      runner.download_file desired_file do |chunk, overall_size, content_type|
+      runner.download_file desired_file, privileged_execution: privileged do |chunk, overall_size, content_type|
         unless response.committed?
           # Disable Rack::ETag, which would otherwise cause the response to be cached
           # See https://github.com/rack/rack/issues/1619#issuecomment-848460528

--- a/app/controllers/live_streams_controller.rb
+++ b/app/controllers/live_streams_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class LiveStreamsController < ApplicationController
+  # Including ActionController::Live changes all actions in this controller!
+  # Therefore, it is extracted into a separate controller
+  include ActionController::Live
+
+  def download_submission_file
+    begin
+      @submission = authorize AuthenticatedUrlHelper.retrieve!(Submission, request, force_render_host: false)
+    rescue Pundit::NotAuthorizedError
+      # TODO: Option to disable?
+      # Using the submission ID parameter would allow looking up the corresponding exercise ID
+      # Therefore, we just redirect to the root_path, but actually expect to redirect back (that should work!)
+      redirect_back(fallback_location: root_path, alert: t('exercises.download_file_tree.gone'))
+    end
+
+    desired_file = params[:filename].to_s
+    runner = Runner.for(current_user, @submission.exercise.execution_environment)
+    fallback_location = implement_exercise_path(@submission.exercise)
+    send_runner_file(runner, desired_file, fallback_location)
+  end
+
+  private
+
+  def send_runner_file(runner, desired_file, redirect_fallback = root_path)
+    filename = File.basename(desired_file)
+    send_stream(filename: filename, disposition: 'attachment') do |stream|
+      runner.download_file desired_file do |chunk, overall_size, content_type|
+        unless response.committed?
+          # Disable Rack::ETag, which would otherwise cause the response to be cached
+          # See https://github.com/rack/rack/issues/1619#issuecomment-848460528
+          response.set_header('Last-Modified', Time.now.httpdate)
+          response.set_header('Content-Length', overall_size) if overall_size
+          response.set_header('Content-Type', content_type) if content_type
+          # Commit the response headers immediately, as streaming would otherwise remove the Content-Length header
+          # This will prevent chunked transfer encoding from being used, which is okay as we know the overall size
+          # See https://github.com/rails/rails/issues/18714
+          response.commit!
+        end
+
+        if stream.connected?
+          stream.write chunk
+        else
+          # The client disconnected, so we stop streaming
+          break
+        end
+      end
+    rescue Runner::Error
+      redirect_back(fallback_location: redirect_fallback, alert: t('exercises.download_file_tree.gone'))
+    end
+  end
+
+  # TODO: Taken from Rails 7, remove when upgrading
+  # rubocop:disable all
+  def send_stream(filename:, disposition: "attachment", type: nil)
+    response.headers["Content-Type"] =
+      (type.is_a?(Symbol) ? Mime[type].to_s : type) ||
+        Mime::Type.lookup_by_extension(File.extname(filename).downcase.delete(".")) ||
+        "application/octet-stream"
+
+    response.headers["Content-Disposition"] =
+      ActionDispatch::Http::ContentDisposition.format(disposition: disposition, filename: filename)
+
+    yield response.stream
+  ensure
+    response.stream.close
+  end
+  # rubocop:enable all
+end

--- a/app/helpers/authenticated_url_helper.rb
+++ b/app/helpers/authenticated_url_helper.rb
@@ -17,14 +17,14 @@ module AuthenticatedUrlHelper
       add_query_parameters(url, {TOKEN_PARAM => token})
     end
 
-    def retrieve!(klass, request, cookies = {})
+    def retrieve!(klass, request, cookies = {}, force_render_host: true)
       # Don't use the default session mechanism and default cookie
-      request.session_options[:skip] = true
+      request.session_options[:skip] = true if force_render_host
       # Show errors as JSON format, if any
       request.format = :json
 
       # Disallow access from normal domain and show an error instead
-      if ApplicationController::RENDER_HOST.present? && request.host != ApplicationController::RENDER_HOST
+      if force_render_host && ApplicationController::RENDER_HOST.present? && request.host != ApplicationController::RENDER_HOST
         raise Pundit::NotAuthorizedError
       end
 

--- a/app/models/code_ocean/file.rb
+++ b/app/models/code_ocean/file.rb
@@ -18,6 +18,8 @@ module CodeOcean
     before_validation :set_ancestor_values, if: :incomplete_descendent?
 
     attr_writer :size
+    # These attributes are mainly used when retrieving files from a runner
+    attr_accessor :download_path
 
     belongs_to :context, polymorphic: true
     belongs_to :file, class_name: 'CodeOcean::File', optional: true # This is only required for submissions and is validated below
@@ -100,6 +102,14 @@ module CodeOcean
       end
     end
 
+    def filepath_without_extension
+      if path.present?
+        ::File.join(path, name)
+      else
+        name
+      end
+    end
+
     def hash_content
       self.hashed_content = Digest::MD5.new.hexdigest(read || '')
     end
@@ -112,6 +122,10 @@ module CodeOcean
 
     def name_with_extension
       name.to_s + (file_type&.file_extension || '')
+    end
+
+    def name_with_extension_and_size
+      "#{name_with_extension} (#{ActionController::Base.helpers.number_to_human_size(size)})"
     end
 
     def set_ancestor_values

--- a/app/models/file_type.rb
+++ b/app/models/file_type.rb
@@ -7,8 +7,14 @@ class FileType < ApplicationRecord
   include DefaultValues
 
   AUDIO_FILE_EXTENSIONS = %w[.aac .flac .m4a .mp3 .ogg .wav .wma].freeze
+  COMPRESSED_FILE_EXTENSIONS = %w[.7z .bz2 .gz .rar .tar .zip].freeze
+  CSV_FILE_EXTENSIONS = %w[.csv].freeze
+  EXCEL_FILE_EXTENSIONS = %w[.xls .xlsx].freeze
   IMAGE_FILE_EXTENSIONS = %w[.bmp .gif .jpeg .jpg .png].freeze
+  PDF_FILE_EXTENSIONS = %w[.pdf].freeze
+  POWERPOINT_FILE_EXTENSIONS = %w[.ppt .pptx].freeze
   VIDEO_FILE_EXTENSIONS = %w[.avi .flv .mkv .mp4 .m4v .ogv .webm].freeze
+  WORD_FILE_EXTENSIONS = %w[.doc .docx].freeze
 
   after_initialize :set_default_values
 
@@ -23,7 +29,7 @@ class FileType < ApplicationRecord
   validates :name, presence: true
   validates :renderable, boolean_presence: true
 
-  %i[audio image video].each do |type|
+  %i[audio compressed csv excel image pdf powerpoint video word].each do |type|
     define_method("#{type}?") do
       self.class.const_get("#{type.upcase}_FILE_EXTENSIONS").include?(file_extension)
     end

--- a/app/models/testrun_message.rb
+++ b/app/models/testrun_message.rb
@@ -17,6 +17,7 @@ class TestrunMessage < ApplicationRecord
     exception: 10,
     result: 11,
     canvasevent: 12,
+    files: 13,
   }, _default: :write, _prefix: true
 
   enum stream: {

--- a/app/policies/execution_environment_policy.rb
+++ b/app/policies/execution_environment_policy.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ExecutionEnvironmentPolicy < AdminOnlyPolicy
-  %i[execute_command? shell? statistics? show? sync_to_runner_management?].each do |action|
+  # download_arbitrary_file? is used in the live_streams_controller.rb
+  %i[execute_command? shell? list_files? statistics? show? sync_to_runner_management? download_arbitrary_file?].each do |action|
     define_method(action) { admin? || author? }
   end
 

--- a/app/policies/submission_policy.rb
+++ b/app/policies/submission_policy.rb
@@ -6,7 +6,8 @@ class SubmissionPolicy < ApplicationPolicy
   end
 
   # insights? is used in the flowr_controller.rb as we use it to authorize the user for a submission
-  %i[download? download_file? run? score? show? statistics? stop? test?
+  # download_submission_file? is used in the live_streams_controller.rb
+  %i[download? download_file? download_submission_file? run? score? show? statistics? stop? test?
      insights?].each do |action|
     define_method(action) { admin? || author? }
   end

--- a/app/views/community_solutions/_form.html.slim
+++ b/app/views/community_solutions/_form.html.slim
@@ -35,7 +35,7 @@
           .card-header.d-flex.justify-content-between.align-items-center.px-0.py-2
             .px-2 = I18n.t('exercises.editor_file_tree.file_root')
           .card-body.pt-0.pe-0.ps-1.pb-1
-            #files data-entries=FileTree.new(@files).to_js_tree
+            #files data-entries=FileTree.new(@files).to_js_tree_in_json
       div class=(@community_solution.exercise.hide_file_tree ? 'col-sm-12' : 'col-sm-9')
         div.editor-col.col.p-0 id='frames'
           - @files.each do |file|
@@ -52,7 +52,7 @@
             .card-header.d-flex.justify-content-between.align-items-center.px-0.py-2
               .px-2 = I18n.t('exercises.editor_file_tree.file_root')
             .card-body.pt-0.pe-0.ps-1.pb-1
-              #own-files data-entries=FileTree.new(@own_files).to_js_tree
+              #own-files data-entries=FileTree.new(@own_files).to_js_tree_in_json
         div class=(@community_solution.exercise.hide_file_tree ? 'col-sm-12' : 'col-sm-9')
           div.editor-col.col.p-0 id='own-frames'
             - @own_files.each do |file|

--- a/app/views/execution_environments/shell.html.slim
+++ b/app/views/execution_environments/shell.html.slim
@@ -1,11 +1,29 @@
 h1 = @execution_environment
 
-#shell data-message-timeout=t('exercises.editor.timeout', permitted_execution_time: @execution_environment.permitted_execution_time) data-message-out-of-memory=t('exercises.editor.out_of_memory',  memory_limit: @execution_environment.memory_limit) data-url=execute_command_execution_environment_path(@execution_environment)
+#shell data-message-timeout=t('exercises.editor.timeout', permitted_execution_time: @execution_environment.permitted_execution_time) data-message-out-of-memory=t('exercises.editor.out_of_memory',  memory_limit: @execution_environment.memory_limit) data-id=@execution_environment.id
   label.form-label for='command' = t('execution_environments.shell.command')
   .input-group.mb-3
     .input-group-text.form-switch.ps-5.text-muted
       input#sudo.form-check-input.mt-0 type='checkbox'
       label.ms-2 for='sudo' = 'sudo'
     input#command.form-control type='text'
+
+  .card.mb-3
+    .card-header#download-files role="tab"
+      a.file-heading.collapsed.d-flex.justify-content-between.align-items-center data-bs-toggle="collapse" href="#collapse_files" aria-expanded="false"
+        div.clearfix role="button"
+          i.fa-solid aria-hidden="true"
+          span = t('execution_environments.shell.file_tree.headline')
+        div
+          = render('exercises/editor_button', classes: 'btn-default btn-sm', data: {:'data-bs-toggle' => 'tooltip', :'data-url' => list_files_in_execution_environment_path(@execution_environment)}, icon: 'fa-solid fa-arrows-rotate', id: 'reload-files', label: t('execution_environments.shell.file_tree.reload'), title: t('execution_environments.shell.file_tree.reload_tooltip'))
+    .card-collapse.collapse id="collapse_files" role="tabpanel"
+      .card-body.pt-0.pe-0.ps-1.pb-1
+        #download-file-tree.justify-content-center.d-flex.my-3
+          span.mx-1 = t('execution_environments.shell.file_tree.empty')
+          button#reload-now-link.btn.btn-link.p-0.m-0.border-0 = t('execution_environments.shell.file_tree.list_now')
+      .card-footer.justify-content-center.align-items-center.d-flex.text-muted
+        i.fa-solid.fa-info
+        span.ms-2 = t('execution_environments.shell.file_tree.root_notice')
+
   pre#output data-message-no-output=t('exercises.implement.no_output', timestamp: l(Time.now, format: :short))
     p = t('exercises.implement.no_output_yet')

--- a/app/views/exercises/_download_file_tree.html.slim
+++ b/app/views/exercises/_download_file_tree.html.slim
@@ -1,0 +1,8 @@
+div.enforce-bottom-margin.overflow-scroll.d-none#download-files
+  .card.border-secondary
+    .card-header.d-flex.justify-content-between.align-items-center.px-0.py-1
+      .px-2 = t('exercises.download_file_tree.file_root')
+
+    .card-body.pt-0.pe-0.ps-1.pb-1
+
+      #download-file-tree

--- a/app/views/exercises/_editor_file_tree.html.slim
+++ b/app/views/exercises/_editor_file_tree.html.slim
@@ -25,7 +25,7 @@ div.d-grid.enforce-bottom-margin id='sidebar-uncollapsed' class=(@exercise.hide_
 
           .card-body.pt-0.pe-0.ps-1.pb-1
 
-            #files data-entries=FileTree.new(files).to_js_tree
+            #files data-entries=FileTree.new(files).to_js_tree_in_json
 
         hr
 

--- a/app/views/exercises/_editor_output.html.slim
+++ b/app/views/exercises/_editor_output.html.slim
@@ -3,7 +3,10 @@ div.d-grid id='output_sidebar_collapsed'
 div.d-grid id='output_sidebar_uncollapsed' class='d-none col-sm-12 enforce-bottom-margin' data-message-no-output=t('exercises.implement.no_output_yet')
   = render('editor_button', classes: 'btn-outline-dark btn overflow-hidden mb-2', icon: 'fa-solid fa-square-minus', id: 'toggle-sidebar-output', label: t('exercises.editor.collapse_output_sidebar'))
 
+
   #content-right-sidebar.overflow-scroll
+    = render('download_file_tree')
+
     div.enforce-bottom-margin.overflow-auto.d-none id='score_div'
       #results
         h2 = t('exercises.implement.results')

--- a/app/views/exercises/external_users/statistics.html.slim
+++ b/app/views/exercises/external_users/statistics.html.slim
@@ -22,7 +22,7 @@ h1
   #stats-editor.row
     - index = 0
     - all_files.each do |files|
-      .files class=(@exercise.hide_file_tree ? 'd-none col-sm-3' : 'col-sm-3') data-index=index data-entries=FileTree.new(files).to_js_tree
+      .files class=(@exercise.hide_file_tree ? 'd-none col-sm-3' : 'col-sm-3') data-index=index data-entries=FileTree.new(files).to_js_tree_in_json
       - index += 1
     div class=(@exercise.hide_file_tree ? 'col-sm-12' : 'col-sm-9')
       #current-file.editor

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -326,6 +326,14 @@ de:
     shell:
       command: Befehl
       headline: Shell
+      file_tree:
+        reload: Aktualisieren
+        reload_tooltip: Aktualisieren Sie die Liste der verfügbaren Dateien im Runners. Diese Aktion wird einige Sekunden in Anspruch nehmen.
+        list_now: Jetzt laden.
+        headline: Dateisystem
+        empty: Das Dateisystem wurde bisher noch nicht aufgelistet.
+        root_notice: Dateien werden standardmäßig mit einem nicht-priviligerten Nutzer abgerufen. Um Dateien als "root" abzurufen, müssen Sie den "sudo" Schalter neben der Befehlszeile aktivieren und anschließend das Dateisystem vor dem Herunterladen einer Datei aktualisieren.
+        permission_denied: Der Zugriff auf die angeforderte Datei wurde verweigert. Bitte überprüfen Sie, dass die Datei existiert, der aktuelle Benutzer Leseberechtigungen besitzt und versuchen Sie ggf. die Datei mit "root"-Rechten anzufordern. Dazu müssen Sie den "sudo"-Schalter neben der Befehlszeile aktivieren und anschließend das Dateisystem vor dem Herunterladen einer Datei aktualisieren.
     statistics:
       exercise: Übung
       users: Anzahl (externer) Nutzer

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -385,6 +385,9 @@ de:
         disclaimer: Bei Fragen zu Deadlines wenden Sie sich bitte an das Teaching Team. Die hier angezeigte Abgabefrist dient nur zur Information und Angaben auf der jeweiligen Kursseite in der E-Learning-Plattform sollen immer Vorrang haben.
     editor_file_tree:
       file_root: Dateien
+    download_file_tree:
+      file_root: Erstellte Dateien
+      gone: Die angeforderte Datei konnte nicht abgerufen werden. Erstellte Dateien werden nur kurzzeitig vorgehalten und dann gelöscht. Bitte führen Sie den Code erneut aus und versuchen Sie dann wieder den Download der Datei.
     import_codeharbor:
       import_errors:
         invalid: Fehlerhafte Aufgabe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -326,6 +326,14 @@ en:
     shell:
       command: Command
       headline: Shell
+      file_tree:
+        reload: Reload
+        reload_tooltip: Reload the file system of the runner. This action might take a few seconds.
+        list_now: List now.
+        headline: File System
+        empty: The file system has not been queried yet.
+        root_notice: Files are retrieved with a non-privileged user by default. To retrieve files as "root", you must enable the "sudo" switch shown next to the command input and then reload the file system before accessing any file.
+        permission_denied: Access to the requested file has been denied. Please verify that the file exists, the current user has read permissions, and try requesting the file with "root" privileges if necessary.  To retrieve files as "root", you must enable the "sudo" switch shown next to the command input and then reload the file system before accessing any file.
     statistics:
       exercise: Exercise
       users: (External) Users Count

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -385,6 +385,9 @@ en:
         disclaimer: If unsure about a deadline, please contact a course instructor. The deadline shown here is only informational and information from the e-learning platform should always take precedence.
     editor_file_tree:
       file_root: Files
+    download_file_tree:
+      file_root: Generated Files
+      gone: The requested file could not be retrieved. Generated files are only held for a short time and are then deleted. Please run the code again and then try downloading the file a second time.
     import_codeharbor:
       import_errors:
         invalid: Invalid exercise

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,7 @@ Rails.application.routes.draw do
     member do
       get 'download', as: :download, action: :download
       get 'download/:filename', as: :download_file, constraints: {filename: FILENAME_REGEXP}, action: :download_file
+      get 'download_stream/:filename', as: :download_stream_file, constraints: {filename: FILENAME_REGEXP}, action: :download_submission_file, controller: 'live_streams'
       get 'render/:filename', as: :render, constraints: {filename: FILENAME_REGEXP}, action: :render_file
       get 'run/:filename', as: :run, constraints: {filename: FILENAME_REGEXP}, action: :run
       get :score

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,8 @@ Rails.application.routes.draw do
     member do
       get :shell
       post 'shell', as: :execute_command, action: :execute_command
+      get :list_files, as: :list_files_in
+      get 'download/:filename', as: :download_file_from, constraints: {filename: FILENAME_REGEXP}, action: :download_arbitrary_file, controller: 'live_streams'
       get :statistics
       post :sync_to_runner_management
     end

--- a/lib/file_tree.rb
+++ b/lib/file_tree.rb
@@ -2,6 +2,8 @@
 
 class FileTree
   def file_icon(file)
+    return 'fa-solid fa-lock' if file.missing_read_permissions?
+
     if file.file_type.audio?
       'fa-regular fa-file-audio'
     elsif file.file_type.compressed?
@@ -35,9 +37,13 @@ class FileTree
   end
   private :folder_icon
 
-  def initialize(files = [])
+  # @param [CodeOcean::File] files The files to be displayed in the tree.
+  # @param [String] directories Additional directories to be displayed in the tree
+  # @param [Boolean] force_closed Specify whether the tree should be closed by default
+  def initialize(files = [], directories = [], force_closed: false)
     # Our tree needs a root node, but we won't display it.
     @root = Tree::TreeNode.new('ROOT')
+    @force_closed = force_closed
 
     files.uniq(&:filepath).each do |file|
       parent = @root
@@ -47,31 +53,51 @@ class FileTree
       end
       parent.add(Tree::TreeNode.new(file.name_with_extension, file))
     end
+
+    directories.uniq.each do |directory|
+      parent = @root
+      (directory || '').split('/').each do |segment|
+        node = parent.children.detect {|child| child.name == segment } || parent.add(Tree::TreeNode.new(segment))
+        parent = node
+      end
+    end
   end
 
   def map_to_js_tree(node)
     {
-      children: node.children.map {|child| map_to_js_tree(child) },
+      children: children(node),
       icon: node_icon(node),
       id: node.content.try(:ancestor_id),
       state: {
-        disabled: !node.leaf?,
-        opened: !node.leaf?,
+        disabled: !(node.leaf? && node.content.is_a?(CodeOcean::File)),
+        opened: !(node.leaf? || @force_closed),
       },
       text: name(node),
       download_path: node.content.try(:download_path),
+      path: node.content.try(:download_path) ? nil : path(node),
     }
   end
   private :map_to_js_tree
 
   def node_icon(node)
-    if node.leaf? && !node.root?
+    if node.leaf? && !node.root? && node.content.is_a?(CodeOcean::File)
       file_icon(node.content)
     else
       folder_icon
     end
   end
   private :node_icon
+
+  def children(node)
+    if node.children.present? || node.content.is_a?(CodeOcean::File)
+      node.children.sort_by {|n| n.name.downcase }.map {|child| map_to_js_tree(child) }
+    else
+      # Folders added manually should always be expandable and therefore might have children.
+      # This allows users to open the folder and get a refreshed view, even if it might be empty.
+      true
+    end
+  end
+  private :children
 
   def name(node)
     # We just need any information that is only present in files retrieved from the runner's file system.
@@ -84,10 +110,15 @@ class FileTree
   end
   private :name
 
+  def path(node)
+    "#{node.parentage&.reverse&.drop(1)&.map(&:name)&.join('/')}/#{node.name}"
+  end
+  private :path
+
   def to_js_tree
     {
       core: {
-        data: @root.children.map {|child| map_to_js_tree(child) },
+        data: @root.children.sort_by {|node| node.name.downcase }.map {|child| map_to_js_tree(child) },
       },
     }
   end

--- a/lib/file_tree.rb
+++ b/lib/file_tree.rb
@@ -58,7 +58,8 @@ class FileTree
         disabled: !node.leaf?,
         opened: !node.leaf?,
       },
-      text: node.name,
+      text: name(node),
+      download_path: node.content.try(:download_path),
     }
   end
   private :map_to_js_tree
@@ -71,6 +72,17 @@ class FileTree
     end
   end
   private :node_icon
+
+  def name(node)
+    # We just need any information that is only present in files retrieved from the runner's file system.
+    # In our case, that is the presence of the `privileged_execution` attribute.
+    if node.content.is_a?(CodeOcean::File) && !node.content.privileged_execution.nil?
+      node.content.name_with_extension_and_size
+    else
+      node.name
+    end
+  end
+  private :name
 
   def to_js_tree
     {

--- a/lib/file_tree.rb
+++ b/lib/file_tree.rb
@@ -4,16 +4,26 @@ class FileTree
   def file_icon(file)
     if file.file_type.audio?
       'fa-regular fa-file-audio'
+    elsif file.file_type.compressed?
+      'fa-regular fa-file-zipper'
+    elsif file.file_type.excel?
+      'fa-regular fa-file-excel'
     elsif file.file_type.image?
       'fa-regular fa-file-image'
+    elsif file.file_type.pdf?
+      'fa-regular fa-file-pdf'
+    elsif file.file_type.powerpoint?
+      'fa-regular fa-file-powerpoint'
     elsif file.file_type.video?
       'fa-regular fa-file-video'
+    elsif file.file_type.word?
+      'fa-regular fa-file-word'
     elsif file.read_only?
       'fa-solid fa-lock'
     elsif file.file_type.executable?
       'fa-regular fa-file-code'
-    elsif file.file_type.renderable?
-      'fa-regular fa-file-text'
+    elsif file.file_type.renderable? || file.file_type.csv?
+      'fa-regular fa-file-lines'
     else
       'fa-regular fa-file'
     end

--- a/lib/file_tree.rb
+++ b/lib/file_tree.rb
@@ -77,6 +77,10 @@ class FileTree
       core: {
         data: @root.children.map {|child| map_to_js_tree(child) },
       },
-    }.to_json
+    }
+  end
+
+  def to_js_tree_in_json
+    to_js_tree.to_json
   end
 end

--- a/lib/runner/connection.rb
+++ b/lib/runner/connection.rb
@@ -146,7 +146,7 @@ class Runner::Connection
         @strategy.destroy_at_management
         @error = Runner::Error::ExecutionTimeout.new('Execution exceeded its time limit')
       when :terminated_by_codeocean, :terminated_by_management
-        @exit_callback.call @exit_code
+        @exit_callback.call @exit_code, @strategy.retrieve_files
       when :terminated_by_client, :error
         @strategy.destroy_at_management
       else # :established

--- a/lib/runner/strategy.rb
+++ b/lib/runner/strategy.rb
@@ -33,7 +33,7 @@ class Runner::Strategy
     raise NotImplementedError
   end
 
-  def retrieve_files(_path:, _recursive:, privileged_execution:)
+  def retrieve_files(path:, recursive:, privileged_execution:)
     raise NotImplementedError
   end
 

--- a/lib/runner/strategy.rb
+++ b/lib/runner/strategy.rb
@@ -33,6 +33,14 @@ class Runner::Strategy
     raise NotImplementedError
   end
 
+  def retrieve_files(_path:, _recursive:, privileged_execution:)
+    raise NotImplementedError
+  end
+
+  def download_file(_file, privileged_execution:, &_block)
+    raise NotImplementedError
+  end
+
   def attach_to_execution(_command, _event_loop, _starting_time, privileged_execution:)
     raise NotImplementedError
   end

--- a/lib/runner/strategy/docker_container_pool.rb
+++ b/lib/runner/strategy/docker_container_pool.rb
@@ -104,7 +104,7 @@ class Runner::Strategy::DockerContainerPool < Runner::Strategy
     Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Finished copying files" }
   end
 
-  def retrieve_files(_path:, _recursive:, privileged_execution:)
+  def retrieve_files(path:, recursive:, privileged_execution:)
     # The DockerContainerPool does not support retrieving files from the runner.
   end
 

--- a/lib/runner/strategy/docker_container_pool.rb
+++ b/lib/runner/strategy/docker_container_pool.rb
@@ -104,6 +104,10 @@ class Runner::Strategy::DockerContainerPool < Runner::Strategy
     Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Finished copying files" }
   end
 
+  def retrieve_files(_path:, _recursive:, privileged_execution:)
+    # The DockerContainerPool does not support retrieving files from the runner.
+  end
+
   def attach_to_execution(command, event_loop, starting_time, privileged_execution: false) # rubocop:disable Lint/UnusedMethodArgument for the keyword argument
     reset_inactivity_timer
 

--- a/lib/runner/strategy/null.rb
+++ b/lib/runner/strategy/null.rb
@@ -25,6 +25,12 @@ class Runner::Strategy::Null < Runner::Strategy
 
   def copy_files(_files); end
 
+  def retrieve_files(_path:, _recursive:, privileged_execution: false); end
+
+  def download_file(_file, privileged_execution: false, &_block) # rubocop:disable Lint/UnusedMethodArgument for the keyword argument
+    raise Runner::Error.new
+  end
+
   def attach_to_execution(command, event_loop, starting_time, privileged_execution: false) # rubocop:disable Lint/UnusedMethodArgument for the keyword argument
     socket = Connection.new(nil, self, event_loop)
     # We don't want to return an error if the execution environment is changed

--- a/lib/runner/strategy/null.rb
+++ b/lib/runner/strategy/null.rb
@@ -25,7 +25,7 @@ class Runner::Strategy::Null < Runner::Strategy
 
   def copy_files(_files); end
 
-  def retrieve_files(_path:, _recursive:, privileged_execution: false); end
+  def retrieve_files(path:, recursive:, privileged_execution: false); end
 
   def download_file(_file, privileged_execution: false, &_block) # rubocop:disable Lint/UnusedMethodArgument for the keyword argument
     raise Runner::Error.new

--- a/lib/runner/strategy/poseidon.rb
+++ b/lib/runner/strategy/poseidon.rb
@@ -132,6 +132,64 @@ class Runner::Strategy::Poseidon < Runner::Strategy
     Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Finished copying files" }
   end
 
+  def retrieve_files(path: './', recursive: true, privileged_execution: false)
+    url = "#{runner_url}/files"
+    params = {
+      path: path,
+      recursive: recursive,
+      privilegedExecution: privileged_execution || @execution_environment.privileged_execution,
+    }
+    Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Retrieving files at #{runner_url} with #{params}" }
+    response = self.class.http_connection.get url, params
+    case response.status
+      when 200
+        JSON.parse(response.body)
+      when 424
+        raise Runner::Error::WorkspaceError.new("The path #{path} is not available or could not be read.")
+      else
+        self.class.handle_error response
+    end
+  rescue Faraday::Error => e
+    raise Runner::Error::FaradayError.new("Request to Poseidon failed: #{e.inspect}")
+  ensure
+    Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Finished listing files" }
+  end
+
+  def download_file(file, privileged_execution: false, &block)
+    url = "#{runner_url}/files/raw"
+    params = {
+      path: file,
+      privilegedExecution: privileged_execution || @execution_environment.privileged_execution,
+    }
+    Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Download file #{params} from #{runner_url}" }
+    response = self.class.new_http_connection.get url, params do |request|
+      content_length = nil
+      content_type = nil
+      next if block.blank?
+
+      request.options.on_data = proc do |chunk, _overall_received_bytes, env|
+        next unless env.success?
+
+        content_length ||= env.response_headers['Content-Length'].presence&.to_i
+        content_type ||= env.response_headers['Content-Type'].presence || 'application/octet-stream'
+        yield chunk, content_length, content_type
+      end
+      request.options
+    end
+    case response.status
+      when 200
+        response.body
+      when 424
+        raise Runner::Error::WorkspaceError.new("The file #{file} is not available or could not be read.")
+      else
+        self.class.handle_error response
+    end
+  rescue Faraday::Error => e
+    raise Runner::Error::FaradayError.new("Request to Poseidon failed: #{e.inspect}")
+  ensure
+    Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Finished downloading file" }
+  end
+
   def attach_to_execution(command, event_loop, starting_time, privileged_execution: false)
     websocket_url = execute_command(command, privileged_execution: privileged_execution)
     socket = Connection.new(websocket_url, self, event_loop)
@@ -229,6 +287,12 @@ class Runner::Strategy::Poseidon < Runner::Strategy
   def self.http_connection
     @http_connection ||= Faraday.new(ssl: {ca_file: config[:ca_file]}, headers: headers) do |faraday|
       faraday.adapter :net_http_persistent
+    end
+  end
+
+  def self.new_http_connection
+    Faraday.new(ssl: {ca_file: config[:ca_file]}, headers: headers) do |faraday|
+      faraday.adapter :net_http
     end
   end
 

--- a/spec/lib/file_tree_spec.rb
+++ b/spec/lib/file_tree_spec.rb
@@ -180,8 +180,8 @@ describe FileTree do
     end
   end
 
-  describe '#to_js_tree' do
-    let(:js_tree) { file_tree.to_js_tree }
+  describe '#to_js_tree_in_json' do
+    let(:js_tree) { file_tree.to_js_tree_in_json }
 
     it 'returns a String' do
       expect(js_tree).to be_a(String)
@@ -196,7 +196,7 @@ describe FileTree do
     context 'with files' do
       let(:files) { build_list(:file, 10, context: nil, path: 'foo/bar/baz') }
       let(:file_tree) { described_class.new(files) }
-      let(:js_tree) { file_tree.to_js_tree }
+      let(:js_tree) { file_tree.to_js_tree_in_json }
 
       it 'produces the required JSON format with a file' do
         # We ignore the root node and only use the children here

--- a/spec/lib/file_tree_spec.rb
+++ b/spec/lib/file_tree_spec.rb
@@ -60,7 +60,7 @@ describe FileTree do
         let(:file) { build(:file, file_type: build(:dot_svg)) }
 
         it 'is a text file icon' do
-          expect(file_icon).to include('fa-file-text')
+          expect(file_icon).to include('fa-file-lines')
           expect(file_icon).to include('fa-regular')
         end
       end

--- a/spec/lib/file_tree_spec.rb
+++ b/spec/lib/file_tree_spec.rb
@@ -161,7 +161,7 @@ describe FileTree do
     end
 
     context 'with leaf nodes' do
-      let(:node) { root.add(Tree::TreeNode.new('')) }
+      let(:node) { root.add(Tree::TreeNode.new('', CodeOcean::File.new)) }
 
       it 'is a file icon' do
         expect(file_tree).to receive(:file_icon)

--- a/spec/views/execution_environments/shell.html.slim_spec.rb
+++ b/spec/views/execution_environments/shell.html.slim_spec.rb
@@ -12,6 +12,6 @@ describe 'execution_environments/shell.html.slim' do
 
   it 'contains the required data attributes' do
     expect(rendered).to have_css('#shell[data-message-timeout]')
-    expect(rendered).to have_css("#shell[data-url='#{execute_command_execution_environment_path(execution_environment)}']")
+    expect(rendered).to have_css("#shell[data-id='#{execution_environment.id}']")
   end
 end


### PR DESCRIPTION
This PR is based on #1349 and adds the following:

- A list of generated files after a "run" finished for learners (compiled files and submission files are automatically filtered)
- Signed download URLs to retrieve the files from a runner (in order to prevent tampering and arbitrary file access)
- A file system browser for admins
- The possibility to get any file as admin (if the sudo-switch is used)

See detailed commit messages for more information.

Learner:
<img width="1434" alt="Bildschirmfoto 2022-10-04 um 16 13 47" src="https://user-images.githubusercontent.com/7300329/193843329-75ed9b37-ea5d-47c5-ae05-32125143a871.png">

Admin:
<img width="1322" alt="Bildschirmfoto 2022-10-04 um 16 15 52" src="https://user-images.githubusercontent.com/7300329/193843358-66be4831-9a3e-45d5-b841-490028d0ae67.png">

