### PR TITLE
More Sentry monitoring and bug fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,7 @@ Metrics/CyclomaticComplexity:
   Max: 20
 
 Metrics/PerceivedComplexity:
-  Max: 23
+  Max: 25
 
 # We don't want to change previous migrations...
 #

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -110,7 +110,7 @@ class SubmissionsController < ApplicationController
       client_socket = tubesock
 
       client_socket.onopen do |_event|
-        return kill_client_socket(client_socket) if @embed_options[:disable_run]
+        kill_client_socket(client_socket) and return true if @embed_options[:disable_run]
       end
 
       client_socket.onclose do |_event|
@@ -159,6 +159,9 @@ class SubmissionsController < ApplicationController
         Sentry.capture_exception(e)
       end
     end
+
+    # If running is not allowed (and the socket is closed), we can stop here.
+    return true if @embed_options[:disable_run]
 
     @testrun[:output] = +''
     durations = @submission.run(@file) do |socket, starting_time|

--- a/app/models/linter_check_run.rb
+++ b/app/models/linter_check_run.rb
@@ -42,7 +42,7 @@ class LinterCheckRun < ApplicationRecord
     end
 
     # Now, we store all check runs and skip validations (they are already done)
-    LinterCheckRun.insert_all!(validated_check_runs) # rubocop:disable Rails/SkipsModelValidations
+    LinterCheckRun.insert_all!(validated_check_runs) if validated_check_runs.present? # rubocop:disable Rails/SkipsModelValidations
   end
   private_class_method :validate_and_store!
 end

--- a/app/models/testrun_message.rb
+++ b/app/models/testrun_message.rb
@@ -94,7 +94,7 @@ class TestrunMessage < ApplicationRecord
     end
 
     # Now, we store all messages and skip validations (they are already done)
-    TestrunMessage.insert_all!(validated_messages) # rubocop:disable Rails/SkipsModelValidations
+    TestrunMessage.insert_all!(validated_messages) if validated_messages.present? # rubocop:disable Rails/SkipsModelValidations
   end
   private_class_method :validate_and_store!
 

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -233,6 +233,7 @@ describe SubmissionsController do
 
     before do
       allow_any_instance_of(described_class).to receive(:hijack)
+      allow_any_instance_of(described_class).to receive(:kill_client_socket)
       perform_request.call
     end
 
@@ -247,6 +248,7 @@ describe SubmissionsController do
     before do
       file.update(hidden: false)
       allow_any_instance_of(described_class).to receive(:hijack)
+      allow_any_instance_of(described_class).to receive(:kill_client_socket)
       get :test, params: {filename: "#{file.filepath}.json", id: submission.id}
     end
 


### PR DESCRIPTION
Follow-up for #1536 and #1543 

So far, we missed the Sentry instrumentation for score and test runs. See an [old example](https://codeocean.sentry.io/performance/codeocean:e3ff4e7cca03447ba8b502866ae70a15/?environment=production&project=5667283&query=&statsPeriod=7d&transaction=SubmissionsController%23score#span-644dc77b41ac1b2e) and a [new example](https://codeocean.sentry.io/performance/codeocean:4e01343ac3dc482598a49303031f9a42/?project=5667283&query=server_name%3ASebastians-MBP&referrer=performance-transaction-summary&showTransactions=recent&statsPeriod=7d&transaction=SubmissionsController%23score&unselectedSeries=p100%28%29).

If I checked the other spans right, this should be the last one where we miss a lot of instrumentation. I also fixed one bug that occurred recently.
