### PR TITLE
Add Programming Groups

### DIFF
--- a/.rubocop/rails.yml
+++ b/.rubocop/rails.yml
@@ -20,3 +20,8 @@ Rails/UnknownEnv:
 
 Rails/I18nLazyLookup:
   Enabled: false
+
+Rails/DynamicFindBy:
+  Whitelist:
+    - find_by_sql # Default value for this cop
+    - find_by_id_with_type # custom method defined in the `User` model

--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -919,10 +919,6 @@ var CodeOceanEditor = {
             const delta = 100; // time in ms to wait for window event before time gets stopped
             let tid;
             $.ajax({
-                data: {
-                    exercise_id: editor.data('exercise-id'),
-                    user_id: editor.data('user-id')
-                },
                 dataType: 'json',
                 method: 'GET',
                 // get working times for this exercise

--- a/app/assets/javascripts/editor/submissions.js
+++ b/app/assets/javascripts/editor/submissions.js
@@ -211,10 +211,13 @@ CodeOceanEditorSubmissions = {
         Turbolinks.visit(response.redirect);
       } else if (response.status === 'container_depleted') {
           this.showContainerDepletedMessage();
-      } else if (response.message) {
-          $.flash.danger({
-              text: response.message
-          });
+      } else {
+        for (let [type, text] of Object.entries(response)) {
+          $.flash[type]({
+            text: text,
+            showPermanent: true // We might display a very long text message!
+          })
+        }
       }
       this.initializeEventHandlers();
     })

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,6 +23,15 @@ class ApplicationController < ActionController::Base
     @current_user ||= find_or_login_current_user&.store_current_study_group_id(session[:study_group_id])
   end
 
+  def current_contributor
+    @current_contributor ||= if session[:pg_id]
+                               current_user.programming_groups.find(session[:pg_id])
+                             else
+                               current_user
+                             end
+  end
+  helper_method :current_contributor
+
   def find_or_login_current_user
     login_from_authentication_token ||
       login_from_lti_session ||

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,7 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :render_not_authorized
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
   rescue_from ActionController::InvalidAuthenticityToken, with: :render_csrf_error
+  add_flash_types :danger, :warning, :info, :success
 
   def current_user
     @current_user ||= find_or_login_current_user&.store_current_study_group_id(session[:study_group_id])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,7 +67,6 @@ class ApplicationController < ActionController::Base
 
       # All external users are logged in "manually"
       session[:external_user_id] = token.user.id
-      session.delete(:lti_parameters_id)
       token.user
     end
   end

--- a/app/controllers/community_solutions_controller.rb
+++ b/app/controllers/community_solutions_controller.rb
@@ -100,6 +100,6 @@ class CommunitySolutionsController < ApplicationController
 
   def set_exercise_and_submission
     @exercise = @community_solution.exercise
-    @submission = current_user.submissions.final.where(exercise_id: @community_solution.exercise.id).order('created_at DESC').first
+    @submission = current_contributor.submissions.final.where(exercise: @community_solution.exercise).order(created_at: :desc).first
   end
 end

--- a/app/controllers/concerns/file_parameters.rb
+++ b/app/controllers/concerns/file_parameters.rb
@@ -17,7 +17,7 @@ module FileParameters
         # avoid that public files from other contexts can be created
         # `next` is similar to an early return and will proceed with the next iteration of the loop
         next true if file.context_type == 'Exercise' && file.context_id != exercise.id
-        next true if file.context_type == 'Submission' && (file.context.user_id != current_user.id || file.context.user_type != current_user.class.name)
+        next true if file.context_type == 'Submission' && (file.context.contributor_id != current_user.id || file.context.contributor_type != current_user.class.name)
         next true if file.context_type == 'CommunitySolution' && controller_name != 'community_solutions'
 
         # Optimization: We already queried the ancestor file, let's reuse the object.

--- a/app/controllers/concerns/file_parameters.rb
+++ b/app/controllers/concerns/file_parameters.rb
@@ -17,7 +17,7 @@ module FileParameters
         # avoid that public files from other contexts can be created
         # `next` is similar to an early return and will proceed with the next iteration of the loop
         next true if file.context_type == 'Exercise' && file.context_id != exercise.id
-        next true if file.context_type == 'Submission' && (file.context.contributor_id != current_user.id || file.context.contributor_type != current_user.class.name)
+        next true if file.context_type == 'Submission' && (file.context.contributor_id != current_contributor.id || file.context.contributor_type != current_contributor.class.name)
         next true if file.context_type == 'CommunitySolution' && controller_name != 'community_solutions'
 
         # Optimization: We already queried the ancestor file, let's reuse the object.

--- a/app/controllers/concerns/lti.rb
+++ b/app/controllers/concerns/lti.rb
@@ -141,12 +141,12 @@ module Lti
       raise Error.new("Score #{submission.normalized_score} must be between 0 and #{MAXIMUM_SCORE}!")
     end
 
-    if submission.user.consumer
-      lti_parameter = LtiParameter.where(consumers_id: submission.user.consumer.id,
-        external_users_id: submission.user_id,
+    if submission.contributor.consumer
+      lti_parameter = LtiParameter.where(consumers_id: submission.contributor.consumer.id,
+        external_users_id: submission.contributor_id,
         exercises_id: submission.exercise_id).last
 
-      provider = build_tool_provider(consumer: submission.user.consumer, parameters: lti_parameter.lti_parameters)
+      provider = build_tool_provider(consumer: submission.contributor.consumer, parameters: lti_parameter.lti_parameters)
     end
 
     if provider.nil?

--- a/app/controllers/concerns/lti.rb
+++ b/app/controllers/concerns/lti.rb
@@ -19,24 +19,6 @@ module Lti
 
   private :build_tool_provider
 
-  # exercise_id.nil? ==> the user has logged out. All session data is to be destroyed
-  # exercise_id.exists? ==> the user has submitted the results of an exercise to the consumer.
-  # Only the assignment of the programming group is deleted.
-  def clear_lti_session_data(exercise_id = nil)
-    if exercise_id.nil?
-      session.delete(:external_user_id)
-      session.delete(:study_group_id)
-      session.delete(:embed_options)
-    end
-    session.delete(:pg_id)
-
-    # We allow reusing the LTI credentials and don't remove them on purpose.
-    # This allows users to jump between remote and web evaluation with the same behavior.
-    # Also it prevents the user from deleting the lti_parameters for their programming team members.
-  end
-
-  private :clear_lti_session_data
-
   def consumer_return_url(provider, options = {})
     consumer_return_url = provider.try(:launch_presentation_return_url) || params[:launch_presentation_return_url]
     consumer_return_url += "?#{options.to_query}" if consumer_return_url && options.present?

--- a/app/controllers/concerns/lti.rb
+++ b/app/controllers/concerns/lti.rb
@@ -110,7 +110,6 @@ module Lti
                 else
                   proxy_exercise.get_matching_exercise(current_user)
                 end
-    session[:lti_exercise_id] = @exercise.id if @exercise
     refuse_lti_launch(message: t('sessions.oauth.invalid_exercise_token')) unless @exercise
   end
 
@@ -242,7 +241,6 @@ module Lti
     @lti_parameters = lti_parameters
 
     session[:external_user_id] = current_user.id
-    session[:lti_parameters_id] = lti_parameters.id
   end
 
   private :store_lti_session_data

--- a/app/controllers/concerns/redirect_behavior.rb
+++ b/app/controllers/concerns/redirect_behavior.rb
@@ -124,9 +124,7 @@ module RedirectBehavior
       session: session.to_hash,
       submission: @submission.inspect,
       params: params.as_json,
-      current_user:,
-      lti_exercise_id: session[:lti_exercise_id],
-      lti_parameters_id: session[:lti_parameters_id]
+      current_user:
     )
 
     path = lti_return_path(submission_id: @submission.id)

--- a/app/controllers/concerns/redirect_behavior.rb
+++ b/app/controllers/concerns/redirect_behavior.rb
@@ -16,7 +16,6 @@ module RedirectBehavior
       # redirect 10 percent pseudorandomly to the feedback page
       if current_user.respond_to? :external_id
         if @submission.redirect_to_feedback? && !@embed_options[:disable_redirect_to_feedback]
-          clear_lti_session_data(@submission.exercise_id)
           redirect_to_user_feedback
           return
         end
@@ -27,7 +26,6 @@ module RedirectBehavior
           flash[:notice] = I18n.t('exercises.submit.full_score_redirect_to_own_rfc')
           flash.keep(:notice)
 
-          clear_lti_session_data(@submission.exercise_id)
           respond_to do |format|
             format.html { redirect_to(rfc) }
             format.json { render(json: {redirect: url_for(rfc)}) }
@@ -45,7 +43,6 @@ module RedirectBehavior
           # increase counter 'times_featured' in rfc
           rfc.increment(:times_featured)
 
-          clear_lti_session_data(@submission.exercise_id)
           respond_to do |format|
             format.html { redirect_to(rfc) }
             format.json { render(json: {redirect: url_for(rfc)}) }
@@ -56,7 +53,6 @@ module RedirectBehavior
     else
       # redirect to feedback page if score is less than 100 percent
       if @exercise.needs_more_feedback?(@submission) && !@embed_options[:disable_redirect_to_feedback]
-        clear_lti_session_data(@submission.exercise_id)
         redirect_to_user_feedback
       else
         redirect_to_lti_return_path
@@ -128,7 +124,6 @@ module RedirectBehavior
     )
 
     path = lti_return_path(submission_id: @submission.id)
-    clear_lti_session_data(@submission.exercise_id)
     respond_to do |format|
       format.html { redirect_to(path) }
       format.json { render(json: {redirect: path}) }

--- a/app/controllers/concerns/redirect_behavior.rb
+++ b/app/controllers/concerns/redirect_behavior.rb
@@ -16,7 +16,7 @@ module RedirectBehavior
       # redirect 10 percent pseudorandomly to the feedback page
       if current_user.respond_to? :external_id
         if @submission.redirect_to_feedback? && !@embed_options[:disable_redirect_to_feedback]
-          clear_lti_session_data(@submission.exercise_id, @submission.user_id)
+          clear_lti_session_data(@submission.exercise_id)
           redirect_to_user_feedback
           return
         end
@@ -27,7 +27,7 @@ module RedirectBehavior
           flash[:notice] = I18n.t('exercises.submit.full_score_redirect_to_own_rfc')
           flash.keep(:notice)
 
-          clear_lti_session_data(@submission.exercise_id, @submission.user_id)
+          clear_lti_session_data(@submission.exercise_id)
           respond_to do |format|
             format.html { redirect_to(rfc) }
             format.json { render(json: {redirect: url_for(rfc)}) }
@@ -45,7 +45,7 @@ module RedirectBehavior
           # increase counter 'times_featured' in rfc
           rfc.increment(:times_featured)
 
-          clear_lti_session_data(@submission.exercise_id, @submission.user_id)
+          clear_lti_session_data(@submission.exercise_id)
           respond_to do |format|
             format.html { redirect_to(rfc) }
             format.json { render(json: {redirect: url_for(rfc)}) }
@@ -56,7 +56,7 @@ module RedirectBehavior
     else
       # redirect to feedback page if score is less than 100 percent
       if @exercise.needs_more_feedback?(@submission) && !@embed_options[:disable_redirect_to_feedback]
-        clear_lti_session_data(@submission.exercise_id, @submission.user_id)
+        clear_lti_session_data(@submission.exercise_id)
         redirect_to_user_feedback
       else
         redirect_to_lti_return_path
@@ -118,8 +118,8 @@ module RedirectBehavior
 
   def redirect_to_lti_return_path
     Sentry.set_extras(
-      consumers_id: @submission.user&.consumer,
-      external_users_id: @submission.user_id,
+      consumers_id: current_user.consumer_id,
+      external_users_id: current_user.id,
       exercises_id: @submission.exercise_id,
       session: session.to_hash,
       submission: @submission.inspect,
@@ -128,7 +128,7 @@ module RedirectBehavior
     )
 
     path = lti_return_path(submission_id: @submission.id)
-    clear_lti_session_data(@submission.exercise_id, @submission.user_id)
+    clear_lti_session_data(@submission.exercise_id)
     respond_to do |format|
       format.html { redirect_to(path) }
       format.json { render(json: {redirect: path}) }

--- a/app/controllers/concerns/submission_parameters.rb
+++ b/app/controllers/concerns/submission_parameters.rb
@@ -22,8 +22,7 @@ module SubmissionParameters
   def merge_user(params)
     # The study_group_id might not be present in the session (e.g. for internal users), resulting in session[:study_group_id] = nil which is intended.
     params.merge(
-      contributor_id: current_user.id,
-      contributor_type: current_user.class.name,
+      contributor: current_contributor,
       study_group_id: current_user.current_study_group_id
     )
   end

--- a/app/controllers/concerns/submission_parameters.rb
+++ b/app/controllers/concerns/submission_parameters.rb
@@ -22,7 +22,8 @@ module SubmissionParameters
   def merge_user(params)
     # The study_group_id might not be present in the session (e.g. for internal users), resulting in session[:study_group_id] = nil which is intended.
     params.merge(
-      user: current_user,
+      contributor_id: current_user.id,
+      contributor_type: current_user.class.name,
       study_group_id: current_user.current_study_group_id
     )
   end

--- a/app/controllers/execution_environments_controller.rb
+++ b/app/controllers/execution_environments_controller.rb
@@ -55,32 +55,32 @@ class ExecutionEnvironmentsController < ApplicationController
       SELECT exercise_id, avg(working_time) as average_time, stddev_samp(extract('epoch' from working_time)) * interval '1 second' as stddev_time
       FROM
         (
-      SELECT user_id,
+      SELECT contributor_id,
              exercise_id,
              sum(working_time_new) AS working_time
       FROM
-        (SELECT user_id,
+        (SELECT contributor_id,
                 exercise_id,
                 CASE WHEN #{StatisticsHelper.working_time_larger_delta} THEN '0' ELSE working_time END AS working_time_new
          FROM
-            (SELECT user_id,
+            (SELECT contributor_id,
                     exercise_id,
                     id,
-                    (created_at - lag(created_at) over (PARTITION BY user_id, exercise_id
+                    (created_at - lag(created_at) over (PARTITION BY contributor_id, exercise_id
                                                         ORDER BY created_at)) AS working_time
             FROM submissions
             WHERE exercise_id IN (SELECT ID FROM exercises WHERE #{ExecutionEnvironment.sanitize_sql(['execution_environment_id = ?', @execution_environment.id])})
-            GROUP BY exercise_id, user_id, id) AS foo) AS bar
-      GROUP BY user_id, exercise_id
+            GROUP BY exercise_id, contributor_id, id) AS foo) AS bar
+      GROUP BY contributor_id, exercise_id
     ) AS baz GROUP BY exercise_id;
     "
   end
 
-  def user_query
+  def contributor_query
     "
     SELECT
       id AS exercise_id,
-      COUNT(DISTINCT user_id) AS users,
+      COUNT(DISTINCT contributor_id) AS contributors,
       AVG(score) AS average_score,
       MAX(score) AS maximum_score,
       stddev_samp(score) as stddev_score,
@@ -88,24 +88,24 @@ class ExecutionEnvironmentsController < ApplicationController
         WHEN MAX(score)=0 THEN 0
         ELSE 100 / MAX(score) * AVG(score)
       END AS percent_correct,
-      SUM(submission_count) / COUNT(DISTINCT user_id) AS average_submission_count
+      SUM(submission_count) / COUNT(DISTINCT contributor_id) AS average_submission_count
     FROM
       (SELECT e.id,
-              s.user_id,
+              s.contributor_id,
               MAX(s.score) AS score,
               COUNT(s.id) AS submission_count
        FROM submissions s
        JOIN exercises e ON e.id = s.exercise_id
        WHERE #{ExecutionEnvironment.sanitize_sql(['e.execution_environment_id = ?', @execution_environment.id])}
        GROUP BY e.id,
-                s.user_id) AS inner_query
+                s.contributor_id) AS inner_query
     GROUP BY id;
     "
   end
 
   def statistics
     working_time_statistics = {}
-    user_statistics = {}
+    contributor_statistics = {}
 
     ApplicationRecord.connection.exec_query(working_time_query).each do |tuple|
       tuple = tuple.merge({
@@ -115,13 +115,13 @@ class ExecutionEnvironmentsController < ApplicationController
       working_time_statistics[tuple['exercise_id'].to_i] = tuple
     end
 
-    ApplicationRecord.connection.exec_query(user_query).each do |tuple|
-      user_statistics[tuple['exercise_id'].to_i] = tuple
+    ApplicationRecord.connection.exec_query(contributor_query).each do |tuple|
+      contributor_statistics[tuple['exercise_id'].to_i] = tuple
     end
 
     render locals: {
       working_time_statistics:,
-      user_statistics:,
+      contributor_statistics:,
     }
   end
 

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -525,7 +525,7 @@ class ExercisesController < ApplicationController
 
   def submit
     @submission = Submission.create(submission_params)
-    @submission.calculate_score
+    @submission.calculate_score(current_user)
 
     if @submission.users.map {|user| lti_outcome_service?(@submission.exercise, user, @submission.study_group_id) }.any?
       transmit_lti_score

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -527,7 +527,7 @@ class ExercisesController < ApplicationController
     @submission = Submission.create(submission_params)
     @submission.calculate_score
 
-    if @submission.users.map {|user| user.external_user? && lti_outcome_service?(@submission.exercise_id, user.id) }.any?
+    if @submission.users.map {|user| lti_outcome_service?(@submission.exercise, user, @submission.study_group_id) }.any?
       transmit_lti_score
     else
       redirect_after_submit

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -467,9 +467,9 @@ class ExercisesController < ApplicationController
     # Show general statistic page for specific exercise
     user_statistics = {'InternalUser' => {}, 'ExternalUser' => {}}
 
-    query = Submission.select('user_id, user_type, MAX(score) AS maximum_score, COUNT(id) AS runs')
+    query = Submission.select('contributor_id, contributor_type, MAX(score) AS maximum_score, COUNT(id) AS runs')
       .where(exercise_id: @exercise.id)
-      .group('user_id, user_type')
+      .group('contributor_id, contributor_type')
 
     query = if policy(@exercise).detailed_statistics?
               query
@@ -481,7 +481,7 @@ class ExercisesController < ApplicationController
             end
 
     query.each do |tuple|
-      user_statistics[tuple['user_type']][tuple['user_id'].to_i] = tuple
+      user_statistics[tuple['contributor_type']][tuple['contributor_id'].to_i] = tuple
     end
 
     render locals: {
@@ -493,7 +493,7 @@ class ExercisesController < ApplicationController
     # Render statistics page for one specific external user
 
     if policy(@exercise).detailed_statistics?
-      submissions = Submission.where(user: @external_user, exercise: @exercise)
+      submissions = Submission.where(contributor: @external_user, exercise: @exercise)
         .in_study_group_of(current_user)
         .order('created_at')
       @show_autosaves = params[:show_autosaves] == 'true' || submissions.none? {|s| s.cause != 'autosave' }
@@ -510,7 +510,7 @@ class ExercisesController < ApplicationController
         @working_times_until.push((format_time_difference(@deltas[0..index].sum) if index.positive?))
       end
     else
-      final_submissions = Submission.where(user: @external_user,
+      final_submissions = Submission.where(contributor: @external_user,
         exercise_id: @exercise.id).in_study_group_of(current_user).final
       submissions = []
       %i[before_deadline within_grace_period after_late_deadline].each do |filter|

--- a/app/controllers/flowr_controller.rb
+++ b/app/controllers/flowr_controller.rb
@@ -5,7 +5,7 @@ class FlowrController < ApplicationController
     require_user!
     # get the latest submission for this user that also has a test run (i.e. structured_errors if applicable)
     submission = Submission.joins(:testruns)
-      .where(submissions: {contributor: current_user})
+      .where(submissions: {contributor: current_contributor})
       .includes(structured_errors: [structured_error_attributes: [:error_template_attribute]])
       .merge(Testrun.order(created_at: :desc)).first
 

--- a/app/controllers/flowr_controller.rb
+++ b/app/controllers/flowr_controller.rb
@@ -5,7 +5,7 @@ class FlowrController < ApplicationController
     require_user!
     # get the latest submission for this user that also has a test run (i.e. structured_errors if applicable)
     submission = Submission.joins(:testruns)
-      .where(submissions: {user: current_user})
+      .where(submissions: {contributor: current_user})
       .includes(structured_errors: [structured_error_attributes: [:error_template_attribute]])
       .merge(Testrun.order(created_at: :desc)).first
 

--- a/app/controllers/live_streams_controller.rb
+++ b/app/controllers/live_streams_controller.rb
@@ -15,7 +15,7 @@ class LiveStreamsController < ApplicationController
     redirect_back(fallback_location: root_path, allow_other_host: true, alert: t('exercises.download_file_tree.gone'))
   else
     desired_file = params[:filename].to_s
-    runner = Runner.for(current_user, @submission.exercise.execution_environment)
+    runner = Runner.for(current_contributor, @submission.exercise.execution_environment)
     fallback_location = implement_exercise_path(@submission.exercise)
     send_runner_file(runner, desired_file, fallback_location)
   end

--- a/app/controllers/programming_groups_controller.rb
+++ b/app/controllers/programming_groups_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class ProgrammingGroupsController < ApplicationController
+  include CommonBehavior
+  include LtiHelper
+
+  before_action :set_exercise_and_authorize
+
+  def new
+    @programming_group = ProgrammingGroup.new(exercise: @exercise)
+    authorize!
+    existing_programming_group = current_user.programming_groups.find_by(exercise: @exercise)
+    if existing_programming_group
+      session[:pg_id] = existing_programming_group.id
+      redirect_to(implement_exercise_path(@exercise),
+        notice: t("sessions.create_through_lti.session_#{lti_outcome_service?(@exercise.id, current_user.id) ? 'with' : 'without'}_outcome", consumer: @consumer))
+    end
+  end
+
+  def create
+    programming_partner_ids = programming_group_params[:programming_partner_ids].split(',').map(&:strip).uniq
+    users = programming_partner_ids.map do |partner_id|
+      User.find_by_id_with_type(partner_id)
+    rescue ActiveRecord::RecordNotFound
+      partner_id
+    end
+    @programming_group = ProgrammingGroup.new(exercise: @exercise, users:)
+    authorize!
+
+    unless programming_partner_ids.include? current_user.id_with_type
+      @programming_group.add(current_user)
+    end
+
+    create_and_respond(object: @programming_group, path: proc { implement_exercise_path(@exercise) }) do
+      session[:pg_id] = @programming_group.id
+      nil
+    end
+  end
+
+  private
+
+  def authorize!
+    authorize(@programming_group || @programming_groups)
+  end
+
+  def programming_group_params
+    params.require(:programming_group).permit(:programming_partner_ids)
+  end
+
+  def set_exercise_and_authorize
+    @exercise = Exercise.find(params[:exercise_id])
+    authorize(@exercise, :implement?)
+  end
+end

--- a/app/controllers/programming_groups_controller.rb
+++ b/app/controllers/programming_groups_controller.rb
@@ -13,7 +13,7 @@ class ProgrammingGroupsController < ApplicationController
     if existing_programming_group
       session[:pg_id] = existing_programming_group.id
       redirect_to(implement_exercise_path(@exercise),
-        notice: t("sessions.create_through_lti.session_#{lti_outcome_service?(@exercise.id, current_user.id) ? 'with' : 'without'}_outcome", consumer: @consumer))
+        notice: t("sessions.create_through_lti.session_#{lti_outcome_service?(@exercise, current_user) ? 'with' : 'without'}_outcome", consumer: @consumer))
     end
   end
 

--- a/app/controllers/remote_evaluation_controller.rb
+++ b/app/controllers/remote_evaluation_controller.rb
@@ -66,7 +66,7 @@ class RemoteEvaluationController < ApplicationController
     validation_token = remote_evaluation_params[:validation_token]
     if (remote_evaluation_mapping = RemoteEvaluationMapping.find_by(validation_token:))
       @submission = Submission.create(build_submission_params(cause, remote_evaluation_mapping))
-      @submission.calculate_score
+      @submission.calculate_score(remote_evaluation_mapping.user)
     else
       # TODO: better output
       # TODO: check token expired?

--- a/app/controllers/remote_evaluation_controller.rb
+++ b/app/controllers/remote_evaluation_controller.rb
@@ -35,7 +35,7 @@ class RemoteEvaluationController < ApplicationController
 
   def try_lti
     # TODO: Need to consider and support programming groups
-    if !@submission.user.nil? && lti_outcome_service?(@submission.exercise_id, @submission.user.id)
+    if !@submission.user.nil? && lti_outcome_service?(@submission.exercise, @submission.user, @submission.study_group_id)
       lti_responses = send_scores(@submission)
       process_lti_response(lti_responses.first)
     else

--- a/app/controllers/remote_evaluation_controller.rb
+++ b/app/controllers/remote_evaluation_controller.rb
@@ -34,6 +34,7 @@ class RemoteEvaluationController < ApplicationController
   end
 
   def try_lti
+    # TODO: Need to consider and support programming groups
     if !@submission.user.nil? && lti_outcome_service?(@submission.exercise_id, @submission.user.id)
       lti_response = send_score(@submission)
       process_lti_response(lti_response)

--- a/app/controllers/remote_evaluation_controller.rb
+++ b/app/controllers/remote_evaluation_controller.rb
@@ -36,8 +36,8 @@ class RemoteEvaluationController < ApplicationController
   def try_lti
     # TODO: Need to consider and support programming groups
     if !@submission.user.nil? && lti_outcome_service?(@submission.exercise_id, @submission.user.id)
-      lti_response = send_score(@submission)
-      process_lti_response(lti_response)
+      lti_responses = send_scores(@submission)
+      process_lti_response(lti_responses.first)
     else
       {
         message: "Your submission was successfully scored with #{@submission.normalized_score * 100}%. " \

--- a/app/controllers/request_for_comments_controller.rb
+++ b/app/controllers/request_for_comments_controller.rb
@@ -157,7 +157,7 @@ class RequestForCommentsController < ApplicationController
         # execute the tests here and wait until they finished.
         # As the same runner is used for the score and test run, no parallelization is possible
         # A run is triggered from the frontend and does not need to be handled here.
-        @request_for_comment.submission.calculate_score
+        @request_for_comment.submission.calculate_score(current_user)
         format.json { render :show, status: :created, location: @request_for_comment }
       else
         format.html { render :new }

--- a/app/controllers/request_for_comments_controller.rb
+++ b/app/controllers/request_for_comments_controller.rb
@@ -44,7 +44,11 @@ class RequestForCommentsController < ApplicationController
   # GET /my_request_for_comments
   def my_comment_requests
     @search = policy_scope(RequestForComment)
+      .joins(:submission)
       .where(user: current_user)
+      .or(policy_scope(RequestForComment)
+            .joins(:submission)
+            .where(submission: {contributor: current_user.programming_groups}))
       .order(created_at: :desc) # Order for the LIMIT part of the query
       .ransack(params[:q])
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,6 +17,7 @@ class SessionsController < ApplicationController
   end
 
   def create_through_lti
+    session.delete(:pg_id) # Remove any previous pg_id from the session
     store_lti_session_data(params)
     store_nonce(params[:oauth_nonce])
     if params[:custom_redirect_target]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -42,10 +42,10 @@ class SessionsController < ApplicationController
   def destroy_through_lti
     @submission = Submission.find(params[:submission_id])
     authorize(@submission, :show?)
-    lti_parameter = LtiParameter.where(external_users_id: @submission.user_id, exercises_id: @submission.exercise_id).last
-    @url = consumer_return_url(build_tool_provider(consumer: @submission.user.consumer, parameters: lti_parameter&.lti_parameters))
+    lti_parameter = LtiParameter.where(external_users_id: current_user.id, exercises_id: @submission.exercise_id).last
+    @url = consumer_return_url(build_tool_provider(consumer: current_user.consumer, parameters: lti_parameter&.lti_parameters))
 
-    clear_lti_session_data(@submission.exercise_id, @submission.user_id)
+    clear_lti_session_data(@submission.exercise_id)
   end
 
   def destroy

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -47,13 +47,14 @@ class SessionsController < ApplicationController
     authorize(@submission, :show?)
     lti_parameter = current_user.lti_parameters.find_by(exercise: @submission.exercise, study_group_id: current_user.current_study_group_id)
     @url = consumer_return_url(build_tool_provider(consumer: current_user.consumer, parameters: lti_parameter&.lti_parameters))
-
-    clear_lti_session_data(@submission.exercise_id)
   end
 
   def destroy
     if current_user&.external_user?
-      clear_lti_session_data
+      session.delete(:external_user_id)
+      session.delete(:study_group_id)
+      session.delete(:embed_options)
+      session.delete(:pg_id)
 
       # In case we have another session as an internal user, we set the study group for this one
       internal_user = find_or_login_current_user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,6 +21,8 @@ class SessionsController < ApplicationController
     store_nonce(params[:oauth_nonce])
     if params[:custom_redirect_target]
       redirect_to(URI.parse(params[:custom_redirect_target].to_s).path)
+    elsif PairProgramming23Study.participate?
+      redirect_to(new_exercise_programming_group_path(@exercise))
     else
       redirect_to(implement_exercise_path(@exercise),
         notice: t("sessions.create_through_lti.session_#{lti_outcome_service?(@exercise.id, current_user.id) ? 'with' : 'without'}_outcome",

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -22,7 +22,7 @@ class SubmissionsController < ApplicationController
 
   def index
     @search = Submission.ransack(params[:q])
-    @submissions = @search.result.includes(:exercise, :user).paginate(page: params[:page], per_page: per_page_param)
+    @submissions = @search.result.includes(:exercise, :contributor).paginate(page: params[:page], per_page: per_page_param)
     authorize!
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -249,7 +249,7 @@ class SubmissionsController < ApplicationController
     return true if disable_scoring
 
     # The score is stored separately, we can forward it to the client immediately
-    client_socket&.send_data(JSON.dump(@submission.calculate_score))
+    client_socket&.send_data(JSON.dump(@submission.calculate_score(current_user)))
     # To enable hints when scoring a submission, uncomment the next line:
     # send_hints(client_socket, StructuredError.where(submission: @submission))
   rescue Runner::Error => e
@@ -284,7 +284,7 @@ class SubmissionsController < ApplicationController
     return true if @embed_options[:disable_run]
 
     # The score is stored separately, we can forward it to the client immediately
-    client_socket&.send_data(JSON.dump(@submission.test(@file)))
+    client_socket&.send_data(JSON.dump(@submission.test(@file, current_user)))
   rescue Runner::Error => e
     extract_durations(e)
     send_and_store client_socket, {cmd: :status, status: :container_depleted}
@@ -396,6 +396,7 @@ class SubmissionsController < ApplicationController
       passed: @testrun[:passed],
       cause:,
       submission: @submission,
+      user: current_user,
       exit_code: @testrun[:exit_code], # might be nil, e.g., when the run did not finish
       status: @testrun[:status] || :failed,
       output: @testrun[:output].presence, # TODO: Remove duplicated saving of the output after creating TestrunMessages

--- a/app/controllers/user_exercise_feedbacks_controller.rb
+++ b/app/controllers/user_exercise_feedbacks_controller.rb
@@ -126,7 +126,7 @@ class UserExerciseFeedbacksController < ApplicationController
     user_id = current_user.id
     user_type = current_user.class.name
     latest_submission = Submission
-      .where(user_id:, user_type:, exercise_id:)
+      .where(contributor_id: user_id, contributor_type: user_type, exercise_id:)
       .order(created_at: :desc).final.first
 
     authorize(latest_submission, :show?)

--- a/app/helpers/lti_helper.rb
+++ b/app/helpers/lti_helper.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
-require 'oauth/request_proxy/action_controller_request' # Rails 5 changed `Rack::Request` to `ActionDispatch::Request`
-
 module LtiHelper
-  def lti_outcome_service?(exercise_id, external_user_id)
-    return false if external_user_id == ''
+  # Checks for support of the LTI outcome service for the given exercise and user.
+  # If the user passed is not the `current_user`, a study group id **must** be passed as well.
+  def lti_outcome_service?(exercise, user, study_group_id = user.current_study_group_id)
+    return false unless user.external_user?
 
-    lti_parameters = LtiParameter.where(external_users_id: external_user_id,
-      exercises_id: exercise_id).lis_outcome_service_url?.last
-    !lti_parameters.nil? && lti_parameters.present?
+    lis_outcome_service_parameters(exercise, user, study_group_id).present?
+  end
+
+  private
+
+  def lis_outcome_service_parameters(exercise, external_user, study_group_id)
+    external_user.lti_parameters.lis_outcome_service_url?.find_by(exercise:, study_group_id:)
   end
 end

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -43,7 +43,7 @@ module StatisticsHelper
       {
         key: 'currently_active',
           name: t('statistics.entries.users.currently_active'),
-          data: Submission.where(created_at: 5.minutes.ago.., user_type: ExternalUser.name).distinct.count(:user_id),
+          data: Submission.where(created_at: 5.minutes.ago.., contributor_type: ExternalUser.name).distinct.count(:contributor_id),
           url: statistics_graphs_path,
       },
     ]

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -9,9 +9,9 @@ module StatisticsHelper
   def statistics_data
     [
       {
-        key: 'users',
-          name: t('statistics.sections.users'),
-          entries: user_statistics,
+        key: 'contributors',
+          name: t('statistics.sections.contributors'),
+          entries: contributor_statistics,
       },
       {
         key: 'exercises',
@@ -26,7 +26,7 @@ module StatisticsHelper
     ]
   end
 
-  def user_statistics
+  def contributor_statistics
     [
       {
         key: 'internal_users',
@@ -41,9 +41,14 @@ module StatisticsHelper
           url: external_users_path,
       },
       {
+        key: 'programming_groups',
+        name: t('activerecord.models.programming_group.other'),
+        data: ProgrammingGroup.count,
+      },
+      {
         key: 'currently_active',
           name: t('statistics.entries.users.currently_active'),
-          data: Submission.where(created_at: 5.minutes.ago.., contributor_type: ExternalUser.name).distinct.count(:contributor_id),
+          data: Submission.from(Submission.where(created_at: 5.minutes.ago..).distinct.select(:contributor_id, :contributor_type)).count,
           url: statistics_graphs_path,
       },
     ]
@@ -108,6 +113,7 @@ module StatisticsHelper
     ]
   end
 
+  # TODO: Need to consider and support programming groups
   def user_activity_live_data
     [
       {
@@ -209,6 +215,7 @@ module StatisticsHelper
     ]
   end
 
+  # TODO: Need to consider and support programming groups
   def ranged_user_data(interval = 'year', from = DateTime.new(0), to = DateTime.now)
     [
       {

--- a/app/models/anomaly_notification.rb
+++ b/app/models/anomaly_notification.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AnomalyNotification < ApplicationRecord
-  include Creation
+  include ContributorCreation
   belongs_to :exercise
   belongs_to :exercise_collection
 end

--- a/app/models/anomaly_notification.rb
+++ b/app/models/anomaly_notification.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AnomalyNotification < ApplicationRecord
-  belongs_to :user, polymorphic: true
+  include Creation
   belongs_to :exercise
   belongs_to :exercise_collection
 end

--- a/app/models/code_ocean/file.rb
+++ b/app/models/code_ocean/file.rb
@@ -12,6 +12,7 @@ module CodeOcean
     TEACHER_DEFINED_ROLES = ROLES - %w[user_defined_file]
     OWNER_READ_PERMISSION = 0o400
     OTHER_READ_PERMISSION = 0o004
+    ALLOWED_CONTEXT_TYPES = %w[Exercise Submission CommunitySolution CommunitySolutionContribution].freeze
 
     after_initialize :set_default_values
     before_validation :clear_weight, unless: :teacher_defined_assessment?
@@ -56,6 +57,7 @@ module CodeOcean
     validates :weight, if: :teacher_defined_assessment?, numericality: true, presence: true
     validates :weight, absence: true, unless: :teacher_defined_assessment?
     validates :file, presence: true if :context.is_a?(Submission)
+    validates :context_type, inclusion: {in: ALLOWED_CONTEXT_TYPES}
 
     validates_with FileNameValidator, fields: %i[name path file_type_id]
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -8,7 +8,6 @@ class Comment < ApplicationRecord
   attr_accessor :username, :date, :updated, :editable
 
   belongs_to :file, class_name: 'CodeOcean::File'
-  belongs_to :user, polymorphic: true
   # after_save :trigger_rfc_action_cable_from_comment
 
   def request_for_comment

--- a/app/models/community_solution.rb
+++ b/app/models/community_solution.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class CommunitySolution < ApplicationRecord
+  ALLOWED_USER_TYPES = [InternalUser, ExternalUser].map(&:to_s).freeze
   belongs_to :exercise
   has_many :community_solution_locks
   has_many :community_solution_contributions
   has_and_belongs_to_many :users, polymorphic: true, through: :community_solution_contributions
   has_many :files, class_name: 'CodeOcean::File', through: :community_solution_contributions
+
+  validates :user_type, inclusion: {in: ALLOWED_USER_TYPES}
 
   def to_s
     "Gemeinschaftslösung für #{exercise}"

--- a/app/models/concerns/contributor.rb
+++ b/app/models/concerns/contributor.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Contributor
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :submissions, as: :contributor
+  end
+end

--- a/app/models/concerns/contributor_creation.rb
+++ b/app/models/concerns/contributor_creation.rb
@@ -4,11 +4,15 @@ module ContributorCreation
   extend ActiveSupport::Concern
   include Contributor
 
+  ALLOWED_CONTRIBUTOR_TYPES = [InternalUser, ExternalUser, ProgrammingGroup].map(&:to_s).freeze
+
   included do
     belongs_to :contributor, polymorphic: true
     alias_method :user, :contributor
     alias_method :user=, :contributor=
     alias_method :author, :user
     alias_method :creator, :user
+
+    validates :contributor_type, inclusion: {in: ALLOWED_CONTRIBUTOR_TYPES}
   end
 end

--- a/app/models/concerns/contributor_creation.rb
+++ b/app/models/concerns/contributor_creation.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module ContributorCreation
+  extend ActiveSupport::Concern
+  include Contributor
+
+  included do
+    belongs_to :contributor, polymorphic: true
+    alias_method :user, :contributor
+    alias_method :user=, :contributor=
+    alias_method :author, :user
+    alias_method :creator, :user
+  end
+end

--- a/app/models/concerns/creation.rb
+++ b/app/models/concerns/creation.rb
@@ -3,9 +3,13 @@
 module Creation
   extend ActiveSupport::Concern
 
+  ALLOWED_USER_TYPES = [InternalUser, ExternalUser].map(&:to_s).freeze
+
   included do
     belongs_to :user, polymorphic: true
     alias_method :author, :user
     alias_method :creator, :user
+
+    validates :user_type, inclusion: {in: ALLOWED_USER_TYPES}
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
-  belongs_to :user, polymorphic: true
+  include Creation
   belongs_to :exercise
   belongs_to :file, class_name: 'CodeOcean::File'
 

--- a/app/models/exercise_collection.rb
+++ b/app/models/exercise_collection.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class ExerciseCollection < ApplicationRecord
+  include Creation
   include TimeHelper
 
   has_many :exercise_collection_items, dependent: :delete_all
   alias items exercise_collection_items
   has_many :exercises, through: :exercise_collection_items, inverse_of: :exercise_collections
-  belongs_to :user, polymorphic: true
 
   def collection_statistics
     statistics = {}

--- a/app/models/exercise_collection.rb
+++ b/app/models/exercise_collection.rb
@@ -4,6 +4,7 @@ class ExerciseCollection < ApplicationRecord
   include Creation
   include TimeHelper
 
+  has_many :anomaly_notifications, dependent: :destroy
   has_many :exercise_collection_items, dependent: :delete_all
   alias items exercise_collection_items
   has_many :exercises, through: :exercise_collection_items, inverse_of: :exercise_collections

--- a/app/models/external_user.rb
+++ b/app/models/external_user.rb
@@ -2,6 +2,7 @@
 
 class ExternalUser < User
   validates :external_id, presence: true
+  has_many :lti_parameters, dependent: :destroy
 
   def displayname
     name.presence || "User #{id}"

--- a/app/models/lti_parameter.rb
+++ b/app/models/lti_parameter.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 class LtiParameter < ApplicationRecord
-  belongs_to :consumer, foreign_key: 'consumers_id'
-  belongs_to :exercise, foreign_key: 'exercises_id'
-  belongs_to :external_user, foreign_key: 'external_users_id'
+  belongs_to :exercise
+  belongs_to :external_user
+  belongs_to :study_group, optional: true
+  delegate :consumer, to: :external_user
+
+  validates :external_user_id, uniqueness: {scope: %i[study_group_id exercise_id]}
 
   scope :lis_outcome_service_url?, lambda {
     where("lti_parameters.lti_parameters ? 'lis_outcome_service_url'")

--- a/app/models/programming_group.rb
+++ b/app/models/programming_group.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+class ProgrammingGroup < ApplicationRecord
+  include Contributor
+
+  has_many :programming_group_memberships, dependent: :destroy
+  has_many :external_users, through: :programming_group_memberships, source_type: 'ExternalUser', source: :user
+  has_many :internal_users, through: :programming_group_memberships, source_type: 'InternalUser', source: :user
+  belongs_to :exercise
+
+  validate :group_size
+  validate :no_erroneous_users
+  accepts_nested_attributes_for :programming_group_memberships
+
+  def initialize(attributes = nil)
+    @erroneous_users = []
+    super
+  end
+
+  def external_user?
+    false
+  end
+
+  def internal_user?
+    false
+  end
+
+  def self.nested_resource?
+    true
+  end
+
+  def programming_group?
+    true
+  end
+
+  def add(user)
+    # Accessing the `users` method here will preload all users, which is otherwise done during validation.
+    internal_users << user if user.internal_user? && users.exclude?(user)
+    external_users << user if user.external_user? && users.exclude?(user)
+    user
+  end
+
+  def to_s
+    displayname
+  end
+
+  def displayname
+    "Programming Group #{id}"
+  end
+
+  def programming_partner_ids
+    users.map(&:id_with_type)
+  end
+
+  def users
+    internal_users + external_users
+  end
+
+  def users=(users)
+    self.internal_users = []
+    self.external_users = []
+    users.each do |user|
+      next @erroneous_users << user unless user.is_a?(User)
+
+      add(user)
+    end
+  end
+
+  private
+
+  def group_size
+    if users.size < 2
+      errors.add(:base, :size_too_small)
+    end
+  end
+
+  def no_erroneous_users
+    @erroneous_users.each do |partner_id|
+      errors.add(:base, :invalid_partner_id, partner_id:)
+    end
+  end
+end

--- a/app/models/programming_group.rb
+++ b/app/models/programming_group.rb
@@ -3,6 +3,7 @@
 class ProgrammingGroup < ApplicationRecord
   include Contributor
 
+  has_many :anomaly_notifications, as: :contributor, dependent: :destroy
   has_many :programming_group_memberships, dependent: :destroy
   has_many :external_users, through: :programming_group_memberships, source_type: 'ExternalUser', source: :user
   has_many :internal_users, through: :programming_group_memberships, source_type: 'InternalUser', source: :user

--- a/app/models/programming_group.rb
+++ b/app/models/programming_group.rb
@@ -6,6 +6,7 @@ class ProgrammingGroup < ApplicationRecord
   has_many :programming_group_memberships, dependent: :destroy
   has_many :external_users, through: :programming_group_memberships, source_type: 'ExternalUser', source: :user
   has_many :internal_users, through: :programming_group_memberships, source_type: 'InternalUser', source: :user
+  has_many :testruns, through: :submissions
   belongs_to :exercise
 
   validate :group_size

--- a/app/models/programming_group.rb
+++ b/app/models/programming_group.rb
@@ -7,6 +7,7 @@ class ProgrammingGroup < ApplicationRecord
   has_many :external_users, through: :programming_group_memberships, source_type: 'ExternalUser', source: :user
   has_many :internal_users, through: :programming_group_memberships, source_type: 'InternalUser', source: :user
   has_many :testruns, through: :submissions
+  has_many :runners, as: :contributor, dependent: :destroy
   belongs_to :exercise
 
   validate :group_size

--- a/app/models/programming_group_membership.rb
+++ b/app/models/programming_group_membership.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ProgrammingGroupMembership < ApplicationRecord
+  belongs_to :user, polymorphic: true
+  belongs_to :programming_group
+
+  validate :unique_membership_for_exercise
+  validates :user_id, uniqueness: {scope: %i[programming_group_id user_type]}
+
+  def unique_membership_for_exercise
+    if user.programming_groups.where(exercise: programming_group.exercise).any?
+      errors.add(:base, :already_exists, id_with_type: user.id_with_type)
+    end
+  end
+end

--- a/app/models/programming_group_membership.rb
+++ b/app/models/programming_group_membership.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProgrammingGroupMembership < ApplicationRecord
-  belongs_to :user, polymorphic: true
+  include Creation
   belongs_to :programming_group
 
   validate :unique_membership_for_exercise

--- a/app/models/remote_evaluation_mapping.rb
+++ b/app/models/remote_evaluation_mapping.rb
@@ -2,9 +2,9 @@
 
 # TODO: reference to lti_param_model
 class RemoteEvaluationMapping < ApplicationRecord
+  include Creation
   before_create :generate_token, unless: :validation_token?
   belongs_to :exercise
-  belongs_to :user, polymorphic: true
   belongs_to :study_group, optional: true
 
   def generate_token

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 class Runner < ApplicationRecord
-  include Creation
+  include ContributorCreation
   belongs_to :execution_environment
 
   before_validation :request_id
-
   validates :runner_id, presence: true
 
   attr_accessor :strategy
@@ -30,10 +29,10 @@ class Runner < ApplicationRecord
     end
   end
 
-  def self.for(user, execution_environment)
-    runner = find_by(user:, execution_environment:)
+  def self.for(contributor, execution_environment)
+    runner = find_by(contributor:, execution_environment:)
     if runner.nil?
-      runner = Runner.create(user:, execution_environment:)
+      runner = Runner.create(contributor:, execution_environment:)
       # The `strategy` is added through the before_validation hook `:request_id`.
       raise Runner::Error::Unknown.new("Runner could not be saved: #{runner.errors.inspect}") unless runner.persisted?
     else
@@ -84,7 +83,7 @@ class Runner < ApplicationRecord
   end
 
   def attach_to_execution(command, privileged_execution: false, &block)
-    Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Starting execution with Runner #{id} for #{user_type} #{user_id}." }
+    Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Starting execution with Runner #{id} for #{contributor_type} #{contributor_id}." }
     starting_time = Time.zone.now
     begin
       # As the EventMachine reactor is probably shared with other threads, we cannot use EventMachine.run with
@@ -101,7 +100,7 @@ class Runner < ApplicationRecord
       e.execution_duration = Time.zone.now - starting_time
       raise
     end
-    Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Stopped execution with Runner #{id} for #{user_type} #{user_id}." }
+    Rails.logger.debug { "#{Time.zone.now.getutc.inspect}: Stopped execution with Runner #{id} for #{contributor_type} #{contributor_id}." }
     Time.zone.now - starting_time # execution duration
   end
 

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Runner < ApplicationRecord
+  include Creation
   belongs_to :execution_environment
-  belongs_to :user, polymorphic: true
 
   before_validation :request_id
 

--- a/app/models/study_group.rb
+++ b/app/models/study_group.rb
@@ -8,6 +8,7 @@ class StudyGroup < ApplicationRecord
   has_many :remote_evaluation_mappings, dependent: :nullify
   has_many :subscriptions, dependent: :nullify
   has_many :authentication_tokens, dependent: :nullify
+  has_many :lti_parameters, dependent: :delete_all
   belongs_to :consumer
 
   def users

--- a/app/models/study_group_membership.rb
+++ b/app/models/study_group_membership.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class StudyGroupMembership < ApplicationRecord
-  ROLES = %w[learner teacher].freeze
-
-  belongs_to :user, polymorphic: true
+  include Creation
   belongs_to :study_group
 
   before_save :destroy_if_empty_study_group_or_user
+
+  ROLES = %w[learner teacher].freeze
 
   def destroy_if_empty_study_group_or_user
     destroy if study_group.blank? || user.blank?

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -72,11 +72,11 @@ class Submission < ApplicationRecord
   end
 
   def normalized_score
-    if !score.nil? && !exercise.maximum_score.nil? && exercise.maximum_score.positive?
-      score / exercise.maximum_score
-    else
-      0
-    end
+    @normalized_score ||= if !score.nil? && !exercise.maximum_score.nil? && exercise.maximum_score.positive?
+                            score / exercise.maximum_score
+                          else
+                            0
+                          end
   end
 
   def percentage

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -124,8 +124,8 @@ class Submission < ApplicationRecord
     (contributor_id + exercise.created_at.to_i) % 10 == 1
   end
 
-  def own_unsolved_rfc(user = self.user)
-    Pundit.policy_scope(user, RequestForComment).unsolved.find_by(exercise:, user:)
+  def own_unsolved_rfc(user)
+    Pundit.policy_scope(user, RequestForComment).joins(:submission).where(submission: {contributor:}).unsolved.find_by(exercise:)
   end
 
   def unsolved_rfc(user = self.user)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Subscription < ApplicationRecord
-  belongs_to :user, polymorphic: true
+  include Creation
   belongs_to :request_for_comment
   belongs_to :study_group, optional: true
 end

--- a/app/models/testrun.rb
+++ b/app/models/testrun.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Testrun < ApplicationRecord
+  include Creation
   belongs_to :file, class_name: 'CodeOcean::File', optional: true
   belongs_to :submission
   belongs_to :testrun_execution_environment, optional: true, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ApplicationRecord
   has_many :participations, through: :submissions, source: :exercise, as: :user
   has_many :user_proxy_exercise_exercises, as: :user
   has_many :user_exercise_interventions, as: :user
+  has_many :testruns, as: :user
   has_many :interventions, through: :user_exercise_interventions
   has_many :remote_evaluation_mappings, as: :user
   has_one :codeharbor_link, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   has_many :study_groups, through: :study_group_memberships, as: :user
   has_many :exercises, as: :user
   has_many :file_types, as: :user
-  has_many :submissions, as: :user
+  has_many :submissions, as: :contributor
   has_many :participations, through: :submissions, source: :exercise, as: :user
   has_many :user_proxy_exercise_exercises, as: :user
   has_many :user_exercise_interventions, as: :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   attr_reader :current_study_group_id
 
   belongs_to :consumer
+  has_many :anomaly_notifications, as: :contributor, dependent: :destroy
   has_many :authentication_token, dependent: :destroy
   has_many :study_group_memberships, as: :user
   has_many :study_groups, through: :study_group_memberships, as: :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
   has_many :testruns, as: :user
   has_many :interventions, through: :user_exercise_interventions
   has_many :remote_evaluation_mappings, as: :user
+  has_many :runners, as: :contributor
   has_one :codeharbor_link, dependent: :destroy
   accepts_nested_attributes_for :user_proxy_exercise_exercises
 

--- a/app/models/user_exercise_intervention.rb
+++ b/app/models/user_exercise_intervention.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UserExerciseIntervention < ApplicationRecord
-  belongs_to :user, polymorphic: true
+  include Creation
   belongs_to :intervention
   belongs_to :exercise
 end

--- a/app/models/user_proxy_exercise_exercise.rb
+++ b/app/models/user_proxy_exercise_exercise.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UserProxyExerciseExercise < ApplicationRecord
-  belongs_to :user, polymorphic: true
+  include Creation
   belongs_to :exercise
   belongs_to :proxy_exercise
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -49,6 +49,13 @@ class ApplicationPolicy
   end
   private :teacher_in_study_group?
 
+  def author_in_programming_group?
+    return false unless @record.contributor.programming_group?
+
+    @record.contributor.users.include?(@user)
+  end
+  private :author_in_programming_group?
+
   def initialize(user, record)
     @user = user
     @record = record

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -50,9 +50,21 @@ class ApplicationPolicy
   private :teacher_in_study_group?
 
   def author_in_programming_group?
-    return false unless @record.contributor.programming_group?
+    if @record.respond_to? :contributor # e.g. submission
+      possible_programming_group = @record.contributor
 
-    @record.contributor.users.include?(@user)
+    elsif @record.respond_to? :context # e.g. file
+      possible_programming_group = @record.context.contributor
+
+    elsif @record.respond_to? :submission # e.g. request_for_comment
+      possible_programming_group = @record.submission.contributor
+    else
+      return false
+    end
+
+    return false unless possible_programming_group.programming_group?
+
+    possible_programming_group.users.include?(@user)
   end
   private :author_in_programming_group?
 

--- a/app/policies/code_ocean/file_policy.rb
+++ b/app/policies/code_ocean/file_policy.rb
@@ -38,7 +38,7 @@ module CodeOcean
       if @record.context.is_a?(Exercise)
         admin? || author?
       elsif @record.context.is_a?(Submission) && @record.context.exercise.allow_file_creation
-        author?
+        author? || author_in_programming_group?
       else
         no_one
       end

--- a/app/policies/programming_group_policy.rb
+++ b/app/policies/programming_group_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ProgrammingGroupPolicy < ApplicationPolicy
+  def new?
+    everyone
+  end
+
+  def create?
+    everyone
+  end
+end

--- a/app/policies/request_for_comment_policy.rb
+++ b/app/policies/request_for_comment_policy.rb
@@ -6,7 +6,7 @@ class RequestForCommentPolicy < ApplicationPolicy
   end
 
   def show?
-    admin? || author? || rfc_visibility
+    admin? || author? || author_in_programming_group? || rfc_visibility
   end
 
   def destroy?
@@ -14,11 +14,11 @@ class RequestForCommentPolicy < ApplicationPolicy
   end
 
   def mark_as_solved?
-    admin? || author?
+    admin? || author? || author_in_programming_group?
   end
 
   def set_thank_you_note?
-    admin? || author?
+    admin? || author? || author_in_programming_group?
   end
 
   def clear_question?

--- a/app/policies/submission_policy.rb
+++ b/app/policies/submission_policy.rb
@@ -9,7 +9,7 @@ class SubmissionPolicy < ApplicationPolicy
   # download_submission_file? is used in the live_streams_controller.rb
   %i[download? download_file? download_submission_file? run? score? show? statistics? stop? test?
      insights?].each do |action|
-    define_method(action) { admin? || author? }
+    define_method(action) { admin? || author? || author_in_programming_group? }
   end
 
   def render_file?

--- a/app/views/execution_environments/statistics.html.slim
+++ b/app/views/execution_environments/statistics.html.slim
@@ -4,7 +4,7 @@ h1 = @execution_environment
   table.table.table-striped class="#{@execution_environment.present? ? 'sortable' : ''}"
     thead
       tr
-        - ['.exercise', '.users', '.score', '.maximum_score', '.stddev_score', '.percentage_correct', '.runs', '.worktime', '.stddev_worktime'].each do |title|
+        - ['.exercise', '.users_and_programming_groups', '.score', '.maximum_score', '.stddev_score', '.percentage_correct', '.runs', '.worktime', '.stddev_worktime'].each do |title|
           th.header = t(title)
     tbody
       - @execution_environment.exercises.each do |exercise|

--- a/app/views/execution_environments/statistics.html.slim
+++ b/app/views/execution_environments/statistics.html.slim
@@ -8,14 +8,14 @@ h1 = @execution_environment
           th.header = t(title)
     tbody
       - @execution_environment.exercises.each do |exercise|
-        - us = user_statistics[exercise.id]
-        - if not us then us = {"users" => 0, "average_score" => 0.0, "maximum_score" => 0, "stddev_score" => 0.0, "percent_correct" => nil, "average_submission_count" => 0}
+        - us = contributor_statistics[exercise.id]
+        - if not us then us = {"contributors" => 0, "average_score" => 0.0, "maximum_score" => 0, "stddev_score" => 0.0, "percent_correct" => nil, "average_submission_count" => 0}
         - wts = working_time_statistics[exercise.id]
         - if wts then average_time = wts["average_time"] else 0
         - if wts then stddev_time = wts["stddev_time"] else 0
         tr
           td = link_to_if policy(exercise).statistics?, exercise.title, controller: "exercises", action: "statistics", id: exercise.id, 'data-turbolinks' => "false"
-          td = us["users"]
+          td = us["contributors"]
           td = us["average_score"].to_f.round(4)
           td = us["maximum_score"].to_f.round(2)
           td = us["stddev_score"].to_f.round(4)

--- a/app/views/exercise_collections/statistics.html.slim
+++ b/app/views/exercise_collections/statistics.html.slim
@@ -33,7 +33,7 @@ h4.mt-4 = t('activerecord.attributes.exercise_collections.exercises')
       tr
         th = '#'
         th = t('activerecord.attributes.exercise.title')
-        th = t('activerecord.attributes.exercise.number_of_users')
+        th = t('activerecord.attributes.exercise.number_of_users_and_programming_groups')
         th = t('activerecord.attributes.exercise.distinct_final_submissions')
         th = t('activerecord.attributes.exercise.finishing_rate')
         th = t('activerecord.attributes.exercise.average_score_percentage')
@@ -44,8 +44,8 @@ h4.mt-4 = t('activerecord.attributes.exercise_collections.exercises')
         tr
           td = exercise_collection_item.position
           td = link_to_if(policy(exercise).show?, exercise.title, exercise)
-          td = exercise.users.distinct.count
-          td = exercise.submissions.send(:final).distinct.count(:user_id)
+          td = exercise.contributors.size
+          td = exercise.submissions.send(:final).distinct.count(:contributor_id)
           td = exercise.finishers_percentage
           td = exercise.average_percentage
           td = link_to(t('shared.statistics'), statistics_exercise_path(exercise), 'data-turbolinks' => "false") if policy(exercise).statistics?

--- a/app/views/exercise_collections/statistics.html.slim
+++ b/app/views/exercise_collections/statistics.html.slim
@@ -3,14 +3,14 @@ h1 = @exercise_collection
 = row(label: 'exercise_collections.name', value: @exercise_collection.name)
 = row(label: 'exercise_collections.updated_at', value: @exercise_collection.updated_at)
 = row(label: 'exercise_collections.exercises', value: @exercise_collection.exercises.count)
-= row(label: 'exercise_collections.users', value: @exercise_collection.exercises.joins(:submissions).group("submissions.user_id").count.count)
-= row(label: 'exercise_collections.solutions', value: @exercise_collection.exercises.joins(:submissions).group("submissions.user_id").group("id").count.count)
+= row(label: 'exercise_collections.users_and_programming_groups', value: Submission.from(@exercise_collection.exercises.joins(:submissions).group(:contributor_id, :contributor_type).select(:contributor_id, :contributor_type)).count)
+= row(label: 'exercise_collections.solutions', value: Submission.from(@exercise_collection.exercises.joins(:submissions).group(:contributor_id, :contributor_type, :id).select(:contributor_id, :contributor_type)).count)
 = row(label: 'exercise_collections.submissions', value: @exercise_collection.exercises.joins(:submissions).count)
 / further metrics:
-/   number of users that attempted at least one exercise @exercise_collection.exercises.joins(:submissions).group("submissions.user_id").count.count
-/   number of solutions:                                  @exercise_collection.exercises.joins(:submissions).group("submissions.user_id").group("id").count.count
+/   number of contributors that attempted at least one exercise @exercise_collection.exercises.joins(:submissions).group("submissions.contributor_id", "submissions.contributor_type").count.count
+/   number of solutions:                                  @exercise_collection.exercises.joins(:submissions).group("submissions.contributor_id", "submissions.contributor_type").group("id").count.count
 / further filters:
-/     Only before specific date: date = DateTime.parse("2015-01-01 00:00:00.000000") ;  @exercise_collection.exercises.joins(:submissions).where(["submissions.created_at > ?", date]).group("submissions.user_id").count.count
+/     Only before specific date: date = DateTime.parse("2015-01-01 00:00:00.000000") ;  @exercise_collection.exercises.joins(:submissions).where(["submissions.created_at > ?", date]).group("submissions.contributor_id", "submissions.contributor_type").count.count
 /     Only with specific cause: @exercise_collection.exercises.joins(:submissions).where("submissions.cause" == 'assess').count
 
 = row(label: 'exercises.statistics.average_worktime', value: @exercise_collection.average_working_time.round(3).to_s + 's')

--- a/app/views/exercises/_editor.html.slim
+++ b/app/views/exercises/_editor.html.slim
@@ -1,6 +1,4 @@
 - external_user_external_id = current_user.respond_to?(:external_id) ? current_user.external_id : ''
-- external_user_id = current_user.respond_to?(:external_id) ? current_user.id : ''
-- consumer_id = current_user.respond_to?(:external_id) ? current_user.consumer_id : ''
 - show_break_interventions = @show_break_interventions || "false"
 - show_rfc_interventions = @show_rfc_interventions || "false"
 - show_tips_interventions = @show_tips_interventions || "false"
@@ -53,7 +51,7 @@
           = t('exercises.editor.start_over_active_file')
 
   - unless @embed_options[:disable_run] && @embed_options[:disable_score]
-    div id='output_sidebar' class='output-col-collapsed' = render('exercises/editor_output', external_user_id: external_user_id, consumer_id: consumer_id )
+    div id='output_sidebar' class='output-col-collapsed' = render('exercises/editor_output')
 
 
 = render('shared/modal', id: 'comment-modal', title: t('exercises.implement.comment.request'), template: 'exercises/_request_comment_dialogcontent') unless @embed_options[:disable_rfc]

--- a/app/views/exercises/_editor_output.html.slim
+++ b/app/views/exercises/_editor_output.html.slim
@@ -60,7 +60,7 @@ div.d-grid id='output_sidebar_uncollapsed' class='d-none col-sm-12 enforce-botto
           .progress-bar role='progressbar'
 
       br
-      - if lti_outcome_service?(@exercise.id, external_user_id)
+      - if lti_outcome_service?(@exercise, current_user)
         p.text-center = render('editor_button', classes: 'btn-lg btn-success d-none', data: {:'data-url' => submit_exercise_path(@exercise)}, icon: 'fa-solid fa-paper-plane', id: 'submit', label: t('exercises.editor.submit'))
         - if @exercise.submission_deadline.present? || @exercise.late_submission_deadline.present?
           #deadline data-submission-deadline=@exercise.submission_deadline&.rfc2822 data-late-submission-deadline=@exercise.late_submission_deadline&.rfc2822

--- a/app/views/exercises/_editor_output.html.slim
+++ b/app/views/exercises/_editor_output.html.slim
@@ -52,7 +52,7 @@ div.d-grid id='output_sidebar_uncollapsed' class='d-none col-sm-12 enforce-botto
                     | 0
                 = row(label: 'exercises.implement.feedback')
                 = row(label: 'exercises.implement.messages')
-      #score data-maximum-score=@exercise.maximum_score data-score=@exercise.final_submission(current_user).try(:score)
+      #score data-maximum-score=@exercise.maximum_score data-score=@exercise.final_submission(current_contributor).try(:score)
         h4
           span == "#{t('activerecord.attributes.submission.score')}:&nbsp;"
           span.score

--- a/app/views/exercises/statistics.html.slim
+++ b/app/views/exercises/statistics.html.slim
@@ -5,25 +5,26 @@
   - append_javascript_pack_tag('d3-tip')
 h1 = @exercise
 
-= row(label: '.participants', value: @exercise.users.distinct.count)
+= row(label: '.participants', value: @exercise.contributors.size)
 
 - [:intermediate, :final].each do |scope|
   = row(label: ".#{scope}_submissions") do
-    = "#{@exercise.submissions.send(scope).count} (#{t('.users', count: @exercise.submissions.send(scope).distinct.count(:contributor_id))})"
+    /TODO: Refactor next line
+    = "#{@exercise.submissions.send(scope).count} (#{t('.users_and_programming_groups', count: Submission.from(@exercise.submissions.send(scope).group(:contributor_id, :contributor_type).select(:contributor_id, :contributor_type)).count)})"
 
 = row(label: '.finishing_rate') do
   p
-    - if @exercise.finishers.count
+    - if @exercise.finishers_count
       span.number
-        = @exercise.finishers.count
+        = @exercise.finishers_count
       =<> t('shared.out_of')
       span.number
-        = @exercise.users.distinct.count
+        = @exercise.contributors.size
       =< t('exercises.statistics.external_users')
     - else
       = empty
-  - finishers_count = @exercise.users.distinct.count
-  - finishers_percentage = finishers_count == 0 ? 0 : (100.0 / finishers_count * @exercise.finishers.count).round(2)
+  - finishers_count = @exercise.contributors.size
+  - finishers_percentage = finishers_count == 0 ? 0 : (100.0 / finishers_count * @exercise.finishers_count).round(2)
   p = progress_bar(finishers_percentage)
 
 = row(label: '.average_score') do
@@ -42,7 +43,7 @@ h1 = @exercise
   = row(label: '.average_worktime') do
     p = @exercise.average_working_time
 
-- Hash[:internal_users => t('.internal_users'), :external_users => t('.external_users')].each_pair do |symbol, label|
+- Hash[:internal_users => t('.internal_users'), :external_users => t('.external_users'), :programming_groups => t('.programming_groups')].each_pair do |symbol, label|
   - submissions = Submission.where(contributor: @exercise.send(symbol), exercise: @exercise).in_study_group_of(current_user)
   - if !policy(@exercise).detailed_statistics?
     - submissions = submissions.final

--- a/app/views/exercises/statistics.html.slim
+++ b/app/views/exercises/statistics.html.slim
@@ -9,7 +9,7 @@ h1 = @exercise
 
 - [:intermediate, :final].each do |scope|
   = row(label: ".#{scope}_submissions") do
-    = "#{@exercise.submissions.send(scope).count} (#{t('.users', count: @exercise.submissions.send(scope).distinct.count(:user_id))})"
+    = "#{@exercise.submissions.send(scope).count} (#{t('.users', count: @exercise.submissions.send(scope).distinct.count(:contributor_id))})"
 
 = row(label: '.finishing_rate') do
   p
@@ -43,7 +43,7 @@ h1 = @exercise
     p = @exercise.average_working_time
 
 - Hash[:internal_users => t('.internal_users'), :external_users => t('.external_users')].each_pair do |symbol, label|
-  - submissions = Submission.where(user: @exercise.send(symbol), exercise: @exercise).in_study_group_of(current_user)
+  - submissions = Submission.where(contributor: @exercise.send(symbol), exercise: @exercise).in_study_group_of(current_user)
   - if !policy(@exercise).detailed_statistics?
     - submissions = submissions.final
   - if submissions.any?
@@ -60,9 +60,9 @@ h1 = @exercise
       hr
       div#chart_2
       hr
-    - users = symbol.to_s.classify.constantize.where(id: submissions.joins(symbol).group(:user_id).select(:user_id).distinct)
+    - contributors = symbol.to_s.classify.constantize.where(id: submissions.joins(symbol).group(:contributor_id).select(:contributor_id).distinct)
     .table-responsive.mb-4
-      table.table.table-striped class="#{users.present? ? 'sortable' : ''}"
+      table.table.table-striped class="#{contributors.present? ? 'sortable' : ''}"
         thead
           tr
             th.header = t('.user')
@@ -71,14 +71,14 @@ h1 = @exercise
             th.header = t('.runs') if policy(@exercise).detailed_statistics?
             th.header = t('.worktime') if policy(@exercise).detailed_statistics?
         tbody
-          - users.each do |user|
-            - if user_statistics[user.class.name][user.id] then us = user_statistics[user.class.name][user.id] else us = {"maximum_score" => nil, "runs" => nil}
-            - label = "#{user.displayname}"
+          - contributors.each do |contributor|
+            - if contributor_statistics[contributor.class.name][contributor.id] then us = contributor_statistics[contributor.class.name][contributor.id] else us = {"maximum_score" => nil, "runs" => nil}
+            - label = "#{contributor.displayname}"
             tr
-              td = link_to_if symbol==:external_users && policy(user).statistics?, label, {controller: "exercises", action: "external_user_statistics", external_user_id: user.id, id: @exercise.id}
+              td = link_to_if symbol==:external_users && policy(contributor).statistics?, label, {controller: "exercises", action: "external_user_statistics", external_user_id: contributor.id, id: @exercise.id}
               td = us['maximum_score'] or 0
               td.align-middle
-                - latest_user_submission = submissions.where(user: user).final.latest
+                - latest_user_submission = submissions.where(contributor:).final.latest
                 - if latest_user_submission.present?
                   - if latest_user_submission.before_deadline?
                     .unit-test-result.positive-result
@@ -87,4 +87,4 @@ h1 = @exercise
                   - elsif latest_user_submission.after_late_deadline?
                     .unit-test-result.negative-result
               td = us['runs'] if policy(@exercise).detailed_statistics?
-              td = @exercise.average_working_time_for(user) or 0 if policy(@exercise).detailed_statistics?
+              td = @exercise.average_working_time_for(contributor) or 0 if policy(@exercise).detailed_statistics?

--- a/app/views/programming_groups/_form.html.slim
+++ b/app/views/programming_groups/_form.html.slim
@@ -1,0 +1,7 @@
+= form_for(@programming_group, url: exercise_programming_groups_path) do |f|
+  = render('shared/form_errors', object: @programming_group)
+  .mb-3
+    = f.label(:programming_partner_ids, class: 'form-label')
+    = f.text_field(:programming_partner_ids, class: 'form-control', required: true, value: (@programming_group.programming_partner_ids - [current_user.id_with_type]).join(', '))
+    .help-block.form-text = t('.hints.programming_partner_ids')
+  .actions.mb-0 = render('shared/submit_button', f: f, object: @programming_group)

--- a/app/views/programming_groups/new.html.slim
+++ b/app/views/programming_groups/new.html.slim
@@ -1,0 +1,14 @@
+h1 = t('shared.new_model', model: ProgrammingGroup.model_name.human)
+p
+  => t('programming_groups.new.own_user_id')
+  b
+    = current_user.id_with_type
+p
+  = t('programming_groups.new.enter_partner_id', exercise_title: @exercise.title)
+= render('form')
+
+div.mt-4
+  a.btn.btn-success href=new_exercise_programming_group_path(@exercise) == t('programming_groups.new.check_invitation')
+
+  p.mt-4
+    == t('programming_groups.new.work_alone', path: implement_exercise_path(@exercise))

--- a/app/views/sessions/destroy_through_lti.html.slim
+++ b/app/views/sessions/destroy_through_lti.html.slim
@@ -1,6 +1,6 @@
 h1 = t('.headline')
 
-- consumer = @submission.user.consumer
+- consumer = current_user.consumer
 
 p
   = t(".success_#{consumer ? 'with' : 'without'}_outcome", consumer: consumer)

--- a/app/views/submissions/index.html.slim
+++ b/app/views/submissions/index.html.slim
@@ -13,7 +13,7 @@ h1 = Submission.model_name.human(count: 2)
     thead
       tr
         th = sort_link(@search, :exercise_id, t('activerecord.attributes.submission.exercise'))
-        th = sort_link(@search, :user_id, t('activerecord.attributes.submission.user'))
+        th = sort_link(@search, :user_id, t('activerecord.attributes.submission.contributor'))
         th = sort_link(@search, :cause, t('activerecord.attributes.submission.cause'))
         th = sort_link(@search, :score, t('activerecord.attributes.submission.score'))
         th = sort_link(@search, :created_at, t('shared.created_at'))
@@ -22,7 +22,7 @@ h1 = Submission.model_name.human(count: 2)
       - @submissions.each do |submission|
         tr
           td = link_to_if(submission.exercise && policy(submission.exercise).show?, submission.exercise, submission.exercise)
-          td = link_to_if(policy(submission.user).show?, submission.user, submission.user)
+          td = link_to_if(policy(submission.contributor).show?, submission.contributor, submission.contributor)
           td = t("submissions.causes.#{submission.cause}")
           td = submission.score
           td = l(submission.created_at, format: :short)

--- a/app/views/submissions/index.html.slim
+++ b/app/views/submissions/index.html.slim
@@ -22,7 +22,7 @@ h1 = Submission.model_name.human(count: 2)
       - @submissions.each do |submission|
         tr
           td = link_to_if(submission.exercise && policy(submission.exercise).show?, submission.exercise, submission.exercise)
-          td = link_to_if(policy(submission.contributor).show?, submission.contributor, submission.contributor)
+          td = link_to_if(submission.contributor.is_a?(User) && policy(submission.contributor).show?, submission.contributor, submission.contributor)
           td = t("submissions.causes.#{submission.cause}")
           td = submission.score
           td = l(submission.created_at, format: :short)

--- a/app/views/submissions/show.html.slim
+++ b/app/views/submissions/show.html.slim
@@ -8,7 +8,7 @@
 h1 = @submission
 
 = row(label: 'submission.exercise', value: link_to_if(policy(@submission.exercise).show?, @submission.exercise, @submission.exercise))
-= row(label: 'submission.user', value: link_to_if(policy(@submission.user).show?, @submission.user, @submission.user))
+= row(label: 'submission.contributor', value: link_to_if(policy(@submission.contributor).show?, @submission.contributor, @submission.contributor))
 = row(label: 'submission.study_group', value: link_to_if(@submission.study_group.present? && policy(@submission.study_group).show?, @submission.study_group, @submission.study_group))
 = row(label: 'submission.cause', value: t("submissions.causes.#{@submission.cause}"))
 = row(label: 'submission.score', value: @submission.score)

--- a/app/views/submissions/show.html.slim
+++ b/app/views/submissions/show.html.slim
@@ -8,7 +8,7 @@
 h1 = @submission
 
 = row(label: 'submission.exercise', value: link_to_if(policy(@submission.exercise).show?, @submission.exercise, @submission.exercise))
-= row(label: 'submission.contributor', value: link_to_if(policy(@submission.contributor).show?, @submission.contributor, @submission.contributor))
+= row(label: 'submission.contributor', value: link_to_if(@submission.contributor.is_a?(User) && policy(@submission.contributor).show?, @submission.contributor, @submission.contributor))
 = row(label: 'submission.study_group', value: link_to_if(@submission.study_group.present? && policy(@submission.study_group).show?, @submission.study_group, @submission.study_group))
 = row(label: 'submission.cause', value: t("submissions.causes.#{@submission.cause}"))
 = row(label: 'submission.score', value: @submission.score)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -119,10 +119,10 @@ de:
       submission:
         cause: Anlass
         code: Code
+        contributor: Mitwirkende:r
         exercise: Aufgabe
         files: Dateien
         score: Punktzahl
-        user: Autor
         study_group: Lerngruppe
       study_group:
         name: Name

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -550,6 +550,7 @@ de:
       too_late: Ihre Abgabe wurde erfolgreich gespeichert, ging jedoch nach der Abgabefrist ein.
       full_score_redirect_to_rfc: Herzlichen Glückwunsch! Sie haben die maximale Punktzahl für diese Aufgabe an den Kurs übertragen. Ein anderer Teilnehmer hat eine Frage zu der von Ihnen gelösten Aufgabe. Er würde sich sicherlich sehr über ihre Hilfe und Kommentare freuen.
       full_score_redirect_to_own_rfc: Herzlichen Glückwunsch! Sie haben die maximale Punktzahl für diese Aufgabe an den Kurs übertragen. Ihre Frage ist damit wahrscheinlich gelöst? Falls ja, fügen Sie doch den entscheidenden Kniff als Antwort hinzu und markieren die Frage als gelöst, bevor sie das Fenster schließen.
+      warning_not_for_all_users_submitted: "Die Punkteübertragung war nur teilweise erfolgreich. Die Punkte konnten nicht für %{user} übertragen werden. Diese Person(en) sollte die Aufgabe über die e-Learning Platform erneut öffnen und anschließend die Punkte selbst übermitteln."
     study_group_dashboard:
       live_dashboard: Live Dashboard
       time_spent_per_learner: Verwendete Zeit pro Lerner

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -45,7 +45,7 @@ de:
         maximum_score: Erreichbare Punktzahl
         submission_deadline: Abgabefrist
         late_submission_deadline: Verspätete Abgabefrist
-        number_of_users: "# Nutzer"
+        number_of_users_and_programming_groups: "# Nutzer und Programmiergruppen"
         public: Öffentlich
         selection: Ausgewählt
         title: Titel
@@ -56,6 +56,10 @@ de:
         token: "Aufgaben-Token"
         uuid: UUID
         unpublished: Deaktiviert
+      programming_group:
+        programming_partner_ids: Nutzer-IDs der Programmierpartner
+      programming_group/programming_group_memberships:
+        base: Programmiergruppenmitgliedschaft
       proxy_exercise:
         title: Title
         files_count: Anzahl der Aufgaben
@@ -172,7 +176,7 @@ de:
         exercises: "Aufgaben"
         solutions: "Gesamtanzahl Lösungsversuche"
         submissions: "Gesamtanzahl Submissions"
-        users: "Teilnehmer"
+        users_and_programming_groups: "Teilnehmer und Programmiergruppen"
       user_exercise_feedback:
         user: "Autor"
         exercise: "Aufgabe"
@@ -225,6 +229,12 @@ de:
       internal_user:
         one: Interner Nutzer
         other: Interne Nutzer
+      programming_group:
+        one: Programmiergruppe
+        other: Programmiergruppen
+      programming_group_membership:
+        one: Programmiergruppenmitgliedschaft
+        other: Programmiergruppenmitgliedschaften
       request_for_comment:
         one: Kommentaranfrage
         other: Kommentaranfragen
@@ -259,6 +269,11 @@ de:
           attributes:
             password:
               weak: ist zu schwach. Versuchen Sie es mit einem  langen Passwort, welches Groß-, Kleinbuchstaben, Zahlen und Sonderzeichen enthält.
+        programming_group:
+          size_too_small: Die Größe dieser Programmiergruppe ist zu klein. Geben Sie mindestens eine andere Nutzer-ID an.
+          invalid_partner_id: Die Nutzer-ID '%{partner_id}' ist ungültig und wurde entfernt. Bitte überprüfen Sie die Nutzer-IDs der Programmierpartner.
+        programming_group_membership:
+          already_exists: 'existiert bereits für diese Aufgabe für den Nutzer mit der ID %{id_with_type}.'
   admin:
     dashboard:
       show:
@@ -346,7 +361,7 @@ de:
         permission_denied: Der Zugriff auf die angeforderte Datei wurde verweigert. Bitte überprüfen Sie, dass die Datei existiert, der aktuelle Benutzer Leseberechtigungen besitzt und versuchen Sie ggf. die Datei mit "root"-Rechten anzufordern. Dazu müssen Sie den "sudo"-Schalter neben der Befehlszeile aktivieren und anschließend das Dateisystem vor dem Herunterladen einer Datei aktualisieren.
     statistics:
       exercise: Übung
-      users: Anzahl (externer) Nutzer
+      users_and_programming_groups: Anzahl Nutzer und Programmiergruppen
       score: Durchschnittliche Punktzahl
       stddev_score: stdabw (Punktzahl)
       stddev_worktime: stdabw (Arbeitszeit)
@@ -519,7 +534,7 @@ de:
       final_submissions: Finale Abgaben
       intermediate_submissions: Intermediäre Abgaben
       participants: Bearbeitende Nutzer
-      users: '%{count} verschiedene Nutzer'
+      users_and_programming_groups: '%{count} verschiedene Nutzer und Programmiergruppen'
       user: Nutzer
       score: Maximale Punktzahl
       deadline: Abgabefrist
@@ -528,6 +543,7 @@ de:
       average_worktime: Durchschnittliche Arbeitszeit
       internal_users: Interne Nutzer
       external_users: Externe Nutzer
+      programming_groups: Programmiergruppen
       finishing_rate: Abschlussrate
     submit:
       failure: Beim Übermitteln Ihrer Punktzahl ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.
@@ -563,6 +579,15 @@ de:
   proxy_exercises:
       index:
         clone: Duplizieren
+  programming_groups:
+    form:
+      hints:
+        programming_partner_ids: "Sie können mehrere Nutzer-IDs mit Kommata getrennt eingeben, wie z.B.: 'e123, e234'."
+    new:
+      check_invitation: "Einladung prüfen"
+      enter_partner_id: "Bitte geben Sie hier die Nutzer-IDs der Personen ein, mit denen Sie zusammen die Aufgabe '%{exercise_title}' lösen möchten. Beachten Sie jedoch, dass anschließend keiner aus der Gruppe austreten kann. Alle Teammitglieder können also sehen, was Sie in dieser Aufgabe schreiben und umgekehrt. Für die nächste Aufgabe können Sie sich erneuert entscheiden, ob und mit wem Sie zusammen arbeiten möchten."
+      own_user_id: "Ihre Nutzer-ID:"
+      work_alone: "Sie können sich einmalig dafür entscheiden, die Aufgabe alleine zu bearbeiten. Anschließend können Sie jedoch nicht mehr in die Gruppenarbeit für diese Aufgabe wechseln. Klicken Sie <a href=%{path})>hier</a>, um die Aufgabe im Einzelmodus zu starten."
   external_users:
     statistics:
       title: Statistiken für Externe Benutzer
@@ -967,7 +992,7 @@ de:
     subscription_not_existent: "Das Abonnement, von dem Sie sich abmelden wollen, existiert nicht."
   statistics:
     sections:
-      users: "Benutzer"
+      contributors: "Mitwirkende"
       exercises: "Aufgaben"
       request_for_comments: "Kommentaranfragen"
     entries:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -465,6 +465,7 @@ de:
       default_test_feedback: Sehr gut. Alle Tests waren erfolgreich.
       default_linter_feedback: Sehr gut. Der Linter hat nichts mehr zu beanstanden.
       error_messages: Fehlermeldungen
+      existing_programming_group: Sie arbeiten gerade an der Übung mit dem Titel '%{exercise}' als Teil einer Programmiergruppe. Bitte schließen Sie Ihre Arbeit dort ab, indem Sie Ihren Code bewerten und abgeben, bevor Sie mit der Bearbeitung dieser Übung beginnen.
       messages: Meldungen
       feedback: Feedback
       test_file: 'Test-Datei <span class="number">%{number}</span> (<span class="filename">%{filename}</span>)'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -550,6 +550,7 @@ en:
       too_late: Your submission was saved successfully but was received after the deadline passed.
       full_score_redirect_to_rfc: Congratulations! You achieved and submitted the highest possible score for this exercise. Another participant has a question concerning the exercise you just solved. Your help and comments will be greatly appreciated!
       full_score_redirect_to_own_rfc: Congratulations! You achieved and submitted the highest possible score for this exercise. Your question concerning the exercise is solved? If so, please share the essential insight with your fellows and mark the question as solved, before you close this window!
+      warning_not_for_all_users_submitted: "The transmission of points was only partially successful. The score was not transmitted for %{user}. The user(s) should reopen the exercise via the e-learning platform and then try to submit the points themselves."
     study_group_dashboard:
       live_dashboard: Live Dashboard
       time_spent_per_learner: Time spent per Learner

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,7 +45,7 @@ en:
         maximum_score: Maximum Score
         submission_deadline: Submission Deadline
         late_submission_deadline: Late Submission Deadline
-        number_of_users: "# Users"
+        number_of_users_and_programming_groups: "# Users and Programming Groups"
         public: Public
         selection: Selected
         title: Title
@@ -56,6 +56,10 @@ en:
         token: "Exercise Token"
         uuid: UUID
         unpublished: Unpublished
+      programming_group:
+        programming_partner_ids: Programming Partner IDs
+      programming_group/programming_group_memberships:
+        base: Programming Group Membership
       proxy_exercise:
         title: Title
         files_count: Exercises Count
@@ -172,7 +176,7 @@ en:
         exercises: "Exercises"
         solutions: "Solution Attempts (accumulated)"
         submissions: "Submissions (accumulated)"
-        users: "Users"
+        users_and_programming_groups: "Users and Programming Groups"
       user_exercise_feedback:
         user: "Author"
         exercise: "Exercise"
@@ -225,6 +229,12 @@ en:
       internal_user:
         one: Internal User
         other: Internal Users
+      programming_group:
+        one: Programming Group
+        other: Programming Groups
+      programming_group_membership:
+        one: Programming Group Membership
+        other: Programming Group Memberships
       request_for_comment:
         one: Request for Comments
         other: Requests for Comments
@@ -259,6 +269,11 @@ en:
           attributes:
             password:
               weak: is too weak. Try to use a long password with upper and lower case letters, numbers and special characters.
+        programming_group:
+          size_too_small: The size of this programming group is too small. Enter at least one other user ID to work with.
+          invalid_partner_id: The user ID '%{partner_id}' is invalid and was removed. Please check the user IDs of your programming partners.
+        programming_group_membership:
+          already_exists: 'already exists for this exercise for the user with ID %{id_with_type}.'
   admin:
     dashboard:
       show:
@@ -346,7 +361,7 @@ en:
         permission_denied: Access to the requested file has been denied. Please verify that the file exists, the current user has read permissions, and try requesting the file with "root" privileges if necessary.  To retrieve files as "root", you must enable the "sudo" switch shown next to the command input and then reload the file system before accessing any file.
     statistics:
       exercise: Exercise
-      users: (External) Users Count
+      users_and_programming_groups: Users and Programming Groups Count
       score: Average Score
       stddev_score: stddev (score)
       stddev_worktime: stddev (working time)
@@ -519,7 +534,7 @@ en:
       final_submissions: Final Submissions
       intermediate_submissions: Intermediate Submissions
       participants: Participating Users
-      users: '%{count} distinct users'
+      users_and_programming_groups: '%{count} distinct users and programming groups'
       user: User
       score: Maximum Score
       deadline: Deadline
@@ -528,6 +543,7 @@ en:
       average_worktime: Average Working Time
       internal_users: Internal Users
       external_users: External Users
+      programming_groups: Programming Groups
       finishing_rate: Finishing Rate
     submit:
       failure: An error occurred while transmitting your score. Please try again later.
@@ -563,6 +579,15 @@ en:
   proxy_exercises:
       index:
         clone: Duplicate
+  programming_groups:
+    form:
+      hints:
+        programming_partner_ids: "You can enter several user IDs separated by commas such as 'e123, e234'."
+    new:
+      check_invitation: "Check invitation"
+      enter_partner_id: "Please enter the user IDs from the practice partners with whom you want to solve the exercise '%{exercise_title}'. However, note that no one can leave the group afterward. Hence, all team members can see what you write in this exercise and vice versa. For the next exercise, you can decide again whether and with whom you want to work together."
+      own_user_id: "Your user ID:"
+      work_alone: "You can choose once to work on the exercise alone. Afterward, however, you will not be able to switch to group work for this exercise. Click <a href=%{path}>here</a> to get to the exercise in single mode."
   external_users:
     statistics:
       title: External User Statistics
@@ -967,7 +992,7 @@ en:
     subscription_not_existent: "The subscription you want to unsubscribe from does not exist."
   statistics:
     sections:
-      users: "Users"
+      contributors: "Contributors"
       exercises: "Exercises"
       request_for_comments: "Requests for Comment"
     entries:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -465,6 +465,7 @@ en:
       default_test_feedback: Well done. All tests have been passed.
       default_linter_feedback: Well done. The linter is completly satisfied.
       error_messages: Error Messages
+      existing_programming_group: You are currently working on the exercise entitled '%{exercise}' as part of a programming group. Please finish your work there by scoring and submitting your code before you start implementing this exercise.
       messages: Messages
       feedback: Feedback
       test_file: 'Test File <span class="number">%{number}</span> (<span class="filename">%{filename}</span>)'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,10 +119,10 @@ en:
       submission:
         cause: Cause
         code: Code
+        contributor: Contributor
         exercise: Exercise
         files: Files
         score: Score
-        user: Author
         study_group: Study Group
       study_group:
         name: Name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,8 @@ Rails.application.routes.draw do
       post :export_external_check
       post :export_external_confirm
     end
+
+    resources :programming_groups, only: %i[new create]
   end
 
   resources :exercise_collections do

--- a/db/migrate/20230710130036_rename_user_columns_to_contributor_in_submissions.rb
+++ b/db/migrate/20230710130036_rename_user_columns_to_contributor_in_submissions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RenameUserColumnsToContributorInSubmissions < ActiveRecord::Migration[7.0]
+  def change
+    change_table :submissions do |t|
+      t.rename :user_id, :contributor_id
+      t.rename :user_type, :contributor_type
+    end
+  end
+end

--- a/db/migrate/20230710130037_require_contributor_on_submission.rb
+++ b/db/migrate/20230710130037_require_contributor_on_submission.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RequireContributorOnSubmission < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :submissions, :contributor_id, false
+    change_column_null :submissions, :contributor_type, false
+  end
+end

--- a/db/migrate/20230710130038_require_submission_on_testrun.rb
+++ b/db/migrate/20230710130038_require_submission_on_testrun.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RequireSubmissionOnTestrun < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :testruns, :submission_id, false
+    add_foreign_key :testruns, :submissions
+  end
+end

--- a/db/migrate/20230710130039_add_user_to_testrun.rb
+++ b/db/migrate/20230710130039_add_user_to_testrun.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddUserToTestrun < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :testruns, :user, polymorphic: true, index: true
+
+    up_only do
+      # Since we do not have programming groups, we can assume that the user who triggered a testrun is the same as the author of the corresponding submission.
+      # For programming groups, this assumption is not valid (the author of a submission would the group, whereas an individual user would trigger the testrun).
+      execute <<~SQL.squish
+        UPDATE testruns
+        SET user_id   = submissions.contributor_id,
+            user_type = submissions.contributor_type
+        FROM submissions
+        WHERE submissions.id = testruns.submission_id;
+      SQL
+    end
+
+    change_column_null :testruns, :user_id, false
+    change_column_null :testruns, :user_type, false
+  end
+end

--- a/db/migrate/20230710131250_create_programming_groups.rb
+++ b/db/migrate/20230710131250_create_programming_groups.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateProgrammingGroups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :programming_groups do |t|
+      t.belongs_to :exercise, foreign_key: true, null: false, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230710132428_create_programming_group_memberships.rb
+++ b/db/migrate/20230710132428_create_programming_group_memberships.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateProgrammingGroupMemberships < ActiveRecord::Migration[7.0]
+  def change
+    create_table :programming_group_memberships, id: :uuid do |t|
+      t.belongs_to :programming_group, foreign_key: true, null: false, index: true
+      t.belongs_to :user, polymorphic: true, null: false, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230819084916_add_study_group_to_lti_parameters.rb
+++ b/db/migrate/20230819084916_add_study_group_to_lti_parameters.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStudyGroupToLtiParameters < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :lti_parameters, :study_group, index: true, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20230819084917_unify_lti_parameters.rb
+++ b/db/migrate/20230819084917_unify_lti_parameters.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class UnifyLtiParameters < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        # We cannot add a foreign key to a table that has rows that violate the constraint.
+        LtiParameter.where(external_users_id: nil)
+          .or(LtiParameter.where.not(external_users_id: ExternalUser.all.select(:id)))
+          .or(LtiParameter.where(exercises_id: nil))
+          .or(LtiParameter.where.not(exercises_id: Exercise.all.select(:id)))
+          .delete_all
+
+        # For each user/exercise pair, keep the most recent LtiParameter.
+        LtiParameter.all.group(:external_users_id, :exercises_id).having('count(*) > 1').count.each do |ids, count|
+          LtiParameter.where(external_users_id: ids.first, exercises_id: ids.second).order(updated_at: :asc).limit(count - 1).delete_all
+        end
+        change_column :lti_parameters, :id, :bigint
+      end
+
+      dir.down do
+        change_column :lti_parameters, :id, :integer
+      end
+    end
+
+    remove_column :lti_parameters, :consumers_id, :bigint
+
+    rename_column :lti_parameters, :external_users_id, :external_user_id
+    change_column_null :lti_parameters, :external_user_id, false
+    add_foreign_key :lti_parameters, :external_users
+
+    rename_column :lti_parameters, :exercises_id, :exercise_id
+    change_column_null :lti_parameters, :exercise_id, false
+    add_foreign_key :lti_parameters, :exercises
+
+    add_index :lti_parameters, %i[external_user_id study_group_id exercise_id], unique: true, name: 'index_lti_params_on_external_user_and_study_group_and_exercise'
+  end
+
+  class LtiParameter < ActiveRecord::Base; end
+
+  class ExternalUser < ActiveRecord::Base; end
+
+  class Exercise < ActiveRecord::Base; end
+end

--- a/db/migrate/20230820182149_rename_user_to_contributor_in_runners.rb
+++ b/db/migrate/20230820182149_rename_user_to_contributor_in_runners.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RenameUserToContributorInRunners < ActiveRecord::Migration[7.0]
+  def change
+    change_table :runners do |t|
+      t.rename :user_id, :contributor_id
+      t.rename :user_type, :contributor_type
+    end
+  end
+end

--- a/db/migrate/20230821062816_rename_user_to_contributor_in_anomaly_notifications.rb
+++ b/db/migrate/20230821062816_rename_user_to_contributor_in_anomaly_notifications.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class RenameUserToContributorInAnomalyNotifications < ActiveRecord::Migration[7.0]
+  def change
+    # We need to drop and recreate the index because the name would be too long otherwise.
+    # Renaming is not possible because the index can have two different names.
+
+    change_table :anomaly_notifications do |t|
+      t.remove_index %i[user_type user_id]
+      t.rename :user_id, :contributor_id
+      t.rename :user_type, :contributor_type
+    end
+
+    add_index :anomaly_notifications, %i[contributor_type contributor_id], name: 'index_anomaly_notifications_on_contributor'
+  end
+end

--- a/db/migrate/20230821062901_add_foreign_keys_to_anomaly_notifications.rb
+++ b/db/migrate/20230821062901_add_foreign_keys_to_anomaly_notifications.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddForeignKeysToAnomalyNotifications < ActiveRecord::Migration[7.0]
+  def change
+    up_only do
+      # We cannot add a foreign key to a table that has rows that violate the constraint.
+      AnomalyNotification.where.not(exercise_id: Exercise.all.select(:id)).delete_all
+    end
+
+    change_column_null :anomaly_notifications, :contributor_id, false
+    change_column_null :anomaly_notifications, :contributor_type, false
+
+    change_column_null :anomaly_notifications, :exercise_id, false
+    add_foreign_key :anomaly_notifications, :exercises
+
+    change_column_null :anomaly_notifications, :exercise_collection_id, false
+    add_foreign_key :anomaly_notifications, :exercise_collections
+  end
+
+  class AnomalyNotification < ActiveRecord::Base; end
+  class Exercise < ActiveRecord::Base; end
+  class ExerciseCollection < ActiveRecord::Base; end
+end

--- a/db/migrate/20230821063101_convert_reason_to_json_in_anomaly_notifications.rb
+++ b/db/migrate/20230821063101_convert_reason_to_json_in_anomaly_notifications.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ConvertReasonToJsonInAnomalyNotifications < ActiveRecord::Migration[7.0]
+  def up
+    AnomalyNotification.where("reason LIKE '%value:%'").each do |anomaly_notification|
+      reason = anomaly_notification.reason
+      reason = reason.gsub('value:', '"value":')
+      reason = reason.gsub(/"(\d+\.\d+)"/) {|_| Regexp.last_match(1) }
+      anomaly_notification.update!(reason:)
+    end
+    change_column :anomaly_notifications, :reason, :jsonb, using: 'reason::jsonb'
+  end
+
+  def down
+    change_column :anomaly_notifications, :reason, :string
+  end
+
+  class AnomalyNotification < ActiveRecord::Base; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,23 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_20_182149) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_21_063101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "anomaly_notifications", id: :serial, force: :cascade do |t|
-    t.integer "user_id"
-    t.string "user_type"
-    t.integer "exercise_id"
-    t.integer "exercise_collection_id"
-    t.string "reason"
+    t.integer "contributor_id", null: false
+    t.string "contributor_type", null: false
+    t.integer "exercise_id", null: false
+    t.integer "exercise_collection_id", null: false
+    t.jsonb "reason"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["contributor_type", "contributor_id"], name: "index_anomaly_notifications_on_contributor"
     t.index ["exercise_collection_id"], name: "index_anomaly_notifications_on_exercise_collection_id"
     t.index ["exercise_id"], name: "index_anomaly_notifications_on_exercise_id"
-    t.index ["user_type", "user_id"], name: "index_anomaly_notifications_on_user"
   end
 
   create_table "authentication_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -595,6 +595,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_20_182149) do
     t.index ["user_type", "user_id"], name: "index_user_proxy_exercise_exercises_on_user"
   end
 
+  add_foreign_key "anomaly_notifications", "exercise_collections"
+  add_foreign_key "anomaly_notifications", "exercises"
   add_foreign_key "authentication_tokens", "study_groups"
   add_foreign_key "community_solution_contributions", "community_solution_locks"
   add_foreign_key "community_solution_contributions", "community_solutions"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_19_084917) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_20_182149) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -416,12 +416,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_19_084917) do
   create_table "runners", force: :cascade do |t|
     t.string "runner_id"
     t.bigint "execution_environment_id"
-    t.string "user_type"
-    t.bigint "user_id"
+    t.string "contributor_type"
+    t.bigint "contributor_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["contributor_type", "contributor_id"], name: "index_runners_on_user"
     t.index ["execution_environment_id"], name: "index_runners_on_execution_environment_id"
-    t.index ["user_type", "user_id"], name: "index_runners_on_user"
   end
 
   create_table "searches", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -351,6 +351,23 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_080619) do
     t.index ["external_users_id"], name: "index_lti_parameters_on_external_users_id"
   end
 
+  create_table "programming_group_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "programming_group_id", null: false
+    t.string "user_type", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["programming_group_id"], name: "index_programming_group_memberships_on_programming_group_id"
+    t.index ["user_type", "user_id"], name: "index_programming_group_memberships_on_user"
+  end
+
+  create_table "programming_groups", force: :cascade do |t|
+    t.bigint "exercise_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["exercise_id"], name: "index_programming_groups_on_exercise_id"
+  end
+
   create_table "proxy_exercises", id: :serial, force: :cascade do |t|
     t.string "title"
     t.string "description"
@@ -582,6 +599,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_080619) do
   add_foreign_key "exercise_tips", "exercise_tips", column: "parent_exercise_tip_id"
   add_foreign_key "exercise_tips", "exercises"
   add_foreign_key "exercise_tips", "tips"
+  add_foreign_key "programming_group_memberships", "programming_groups"
+  add_foreign_key "programming_groups", "exercises"
   add_foreign_key "remote_evaluation_mappings", "study_groups"
   add_foreign_key "structured_error_attributes", "error_template_attributes"
   add_foreign_key "structured_error_attributes", "structured_errors"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -473,11 +473,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_19_084917) do
   create_table "submissions", id: :serial, force: :cascade do |t|
     t.integer "exercise_id"
     t.float "score"
-    t.integer "contributor_id"
+    t.integer "contributor_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "cause"
-    t.string "contributor_type"
+    t.string "contributor_type", null: false
     t.bigint "study_group_id"
     t.index ["contributor_id"], name: "index_submissions_on_contributor_id"
     t.index ["exercise_id"], name: "index_submissions_on_exercise_id"
@@ -528,7 +528,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_19_084917) do
     t.boolean "passed"
     t.text "output"
     t.integer "file_id"
-    t.integer "submission_id"
+    t.integer "submission_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "cause"
@@ -536,7 +536,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_19_084917) do
     t.interval "waiting_for_container_time"
     t.integer "exit_code", limit: 2, comment: "No exit code is available in case of a timeout"
     t.integer "status", limit: 2, default: 0, null: false, comment: "Used as enum in Rails"
+    t.string "user_type", null: false
+    t.bigint "user_id", null: false
     t.index ["submission_id"], name: "index_testruns_on_submission_id"
+    t.index ["user_type", "user_id"], name: "index_testruns_on_user"
     t.check_constraint "exit_code >= 0 AND exit_code <= 255", name: "exit_code_constraint"
   end
 
@@ -616,6 +619,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_19_084917) do
   add_foreign_key "testrun_execution_environments", "execution_environments"
   add_foreign_key "testrun_execution_environments", "testruns"
   add_foreign_key "testrun_messages", "testruns"
+  add_foreign_key "testruns", "submissions"
   add_foreign_key "tips", "file_types"
   add_foreign_key "user_exercise_feedbacks", "submissions"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_27_080619) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_19_084917) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -341,14 +341,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_080619) do
     t.string "severity"
   end
 
-  create_table "lti_parameters", id: :serial, force: :cascade do |t|
-    t.integer "external_users_id"
-    t.integer "consumers_id"
-    t.integer "exercises_id"
+  create_table "lti_parameters", force: :cascade do |t|
+    t.integer "external_user_id", null: false
+    t.integer "exercise_id", null: false
     t.jsonb "lti_parameters", default: {}, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["external_users_id"], name: "index_lti_parameters_on_external_users_id"
+    t.bigint "study_group_id"
+    t.index ["external_user_id", "study_group_id", "exercise_id"], name: "index_lti_params_on_external_user_and_study_group_and_exercise", unique: true
+    t.index ["external_user_id"], name: "index_lti_parameters_on_external_user_id"
+    t.index ["study_group_id"], name: "index_lti_parameters_on_study_group_id"
   end
 
   create_table "programming_group_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -599,6 +601,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_080619) do
   add_foreign_key "exercise_tips", "exercise_tips", column: "parent_exercise_tip_id"
   add_foreign_key "exercise_tips", "exercises"
   add_foreign_key "exercise_tips", "tips"
+  add_foreign_key "lti_parameters", "exercises"
+  add_foreign_key "lti_parameters", "external_users"
+  add_foreign_key "lti_parameters", "study_groups"
   add_foreign_key "programming_group_memberships", "programming_groups"
   add_foreign_key "programming_groups", "exercises"
   add_foreign_key "remote_evaluation_mappings", "study_groups"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -454,15 +454,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_080619) do
   create_table "submissions", id: :serial, force: :cascade do |t|
     t.integer "exercise_id"
     t.float "score"
-    t.integer "user_id"
+    t.integer "contributor_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "cause"
-    t.string "user_type"
+    t.string "contributor_type"
     t.bigint "study_group_id"
+    t.index ["contributor_id"], name: "index_submissions_on_contributor_id"
     t.index ["exercise_id"], name: "index_submissions_on_exercise_id"
     t.index ["study_group_id"], name: "index_submissions_on_study_group_id"
-    t.index ["user_id"], name: "index_submissions_on_user_id"
   end
 
   create_table "subscriptions", id: :serial, force: :cascade do |t|

--- a/db/scripts/migrate_exercise.sql
+++ b/db/scripts/migrate_exercise.sql
@@ -40,7 +40,7 @@ BEGIN
 
     DELETE FROM anomaly_notifications WHERE exercise_id = duplicated_exercise;
     DELETE FROM exercise_tags WHERE exercise_id = duplicated_exercise;
-    DELETE FROM lti_parameters WHERE exercises_id = duplicated_exercise;
+    DELETE FROM lti_parameters WHERE exercise_id = duplicated_exercise;
     DELETE FROM remote_evaluation_mappings WHERE exercise_id = duplicated_exercise;
 
     -- Preventing duplicated entries in exercise_collection_items

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -28,7 +28,7 @@ ExecutionEnvironment.create_factories user: admin
 @exercises = find_factories_by_class(Exercise).map(&:name).index_with {|factory_name| FactoryBot.create(factory_name, user: teacher) }
 
 # submissions
-FactoryBot.create(:submission, exercise: @exercises[:fibonacci], user: external_user)
+FactoryBot.create(:submission, exercise: @exercises[:fibonacci], contributor: external_user)
 
 # The old images included in the seed data do not feature a dedicated `user` and therefore require a privileged execution.
 ExecutionEnvironment.update_all privileged_execution: true # rubocop:disable Rails/SkipsModelValidations

--- a/lib/pair_programming23_study.rb
+++ b/lib/pair_programming23_study.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class PairProgramming23Study
+  def self.participate?
+    # TODO: Decide which users are in the study
+    false
+  end
+end

--- a/lib/tasks/detect_exercise_anomalies.rake
+++ b/lib/tasks/detect_exercise_anomalies.rake
@@ -12,11 +12,11 @@ namespace :detect_exercise_anomalies do
   MIN_TIME_FACTOR = 0.1
   MAX_TIME_FACTOR = 2
 
-  # Determines how many users are picked from the best/average/worst performers of each anomaly for feedback
-  NUMBER_OF_USERS_PER_CLASS = 10
+  # Determines how many contributors are picked from the best/average/worst performers of each anomaly for feedback
+  NUMBER_OF_CONTRIBUTORS_PER_CLASS = 10
 
-  # Determines margin below which user working times will be considered data errors (e.g. copy/paste solutions)
-  MIN_USER_WORKING_TIME = 0.0
+  # Determines margin below which contributor working times will be considered data errors (e.g. copy/paste solutions)
+  MIN_CONTRIBUTOR_WORKING_TIME = 0.0
 
   # Cache exercise working times, because queries are expensive and values do not change between collections
   # rubocop:disable Style/MutableConstant
@@ -25,16 +25,19 @@ namespace :detect_exercise_anomalies do
   # rubocop:enable Style/MutableConstant
   # rubocop:enable Lint/ConstantDefinitionInBlock
 
-  task :with_at_least, %i[number_of_exercises number_of_users] => :environment do |_task, args|
+  task :with_at_least, %i[number_of_exercises number_of_contributors] => :environment do |_task, args|
     include TimeHelper
 
-    number_of_exercises = args[:number_of_exercises]
-    number_of_users = args[:number_of_users]
+    # Set intervalstyle to iso_8601 to avoid problems with time parsing.
+    ApplicationRecord.connection.exec_query("SET intervalstyle = 'iso_8601';")
 
-    log "Searching for exercise collections with at least #{number_of_exercises} exercises and #{number_of_users} users."
+    number_of_exercises = args[:number_of_exercises]
+    number_of_contributors = args[:number_of_contributors]
+
+    log "Searching for exercise collections with at least #{number_of_exercises} exercises and #{number_of_contributors} contributors."
     # Get all exercise collections that have at least the specified amount of exercises and at least the specified
-    # number of users AND are flagged for anomaly detection
-    collections = get_collections(number_of_exercises, number_of_users)
+    # number of contributors AND are flagged for anomaly detection
+    collections = get_collections(number_of_exercises, number_of_contributors)
     log "Found #{collections.length}."
 
     collections.each do |collection|
@@ -44,7 +47,7 @@ namespace :detect_exercise_anomalies do
       next unless anomalies.length.positive?
 
       notify_collection_author(collection, anomalies) unless collection.user.nil?
-      notify_users(collection, anomalies)
+      notify_contributors(collection, anomalies)
       reset_anomaly_detection_flag(collection)
     end
     log 'Done.'
@@ -56,17 +59,18 @@ namespace :detect_exercise_anomalies do
 
   def get_collections(number_of_exercises, number_of_solutions)
     ExerciseCollection
+      .joins(:exercises)
       .where(use_anomaly_detection: true)
-      .joins("join exercise_collection_items eci on exercise_collections.id = eci.exercise_collection_id
-                            join
-                              (select e.id
-                               from exercises e
-                                 join submissions s on s.exercise_id = e.id
-                               group by e.id
-                               having #{ExerciseCollection.sanitize_sql(['count(s.user_id) > ?', number_of_solutions])}
-                              ) as exercises_with_submissions on exercises_with_submissions.id = eci.exercise_id")
-      .group('exercise_collections.id')
-      .having('count(exercises_with_submissions.id) > ?', number_of_exercises)
+      .where(
+        exercises: Submission.from(
+          Submission.group(:contributor_id, :contributor_type, :exercise_id)
+                    .select(:contributor_id, :contributor_type, :exercise_id),
+          'submissions'
+        ).group(:exercise_id)
+        .having('count(submissions.exercise_id) >= ?', number_of_solutions)
+        .select(:exercise_id)
+      ).group(:id)
+      .having('count(exercises.id) >= ?', number_of_exercises)
   end
 
   def collect_working_times(collection)
@@ -97,10 +101,14 @@ namespace :detect_exercise_anomalies do
     AVERAGE_WORKING_TIME_CACHE[exercise.id]
   end
 
-  def get_user_working_times(exercise)
+  def get_contributor_working_times(exercise)
     unless WORKING_TIME_CACHE.key?(exercise.id)
       exercise.retrieve_working_time_statistics
-      WORKING_TIME_CACHE[exercise.id] = exercise.working_time_statistics
+      WORKING_TIME_CACHE[exercise.id] = exercise.working_time_statistics.filter_map do |contributor_type, contributor_id_with_result|
+        contributor_id_with_result.flat_map do |contributor_id, result|
+          [[contributor_type, contributor_id], result]
+        end.presence
+      end.to_h
     end
     WORKING_TIME_CACHE[exercise.id]
   end
@@ -110,64 +118,69 @@ namespace :detect_exercise_anomalies do
     UserMailer.exercise_anomaly_detected(collection, anomalies).deliver_now
   end
 
-  def notify_users(collection, anomalies)
-    by_id_and_type = proc {|u| {user_id: u[:user_id], user_type: u[:user_type]} }
+  def notify_contributors(collection, anomalies)
+    by_id_and_type = proc {|u| {contributor_id: u[:contributor_id], contributor_type: u[:contributor_type]} }
 
-    log('Sending E-Mails to best and worst performing users of each anomaly...', 2)
+    log('Sending E-Mails to best and worst performing contributors of each anomaly...', 2)
     anomalies.each do |exercise_id, average_working_time|
       log("Anomaly in exercise #{exercise_id} (avg: #{average_working_time} seconds):", 2)
       exercise = Exercise.find(exercise_id)
-      users_to_notify = []
+      contributors_to_notify = []
 
-      users = {}
+      contributors = {}
       methods = %i[performers_by_time performers_by_score]
       methods.each do |method|
-        # merge users found by multiple methods returning a hash {best: [], worst: []}
-        users = users.merge(send(method, exercise, NUMBER_OF_USERS_PER_CLASS)) {|_key, this, other| this + other }
+        # merge contributors found by multiple methods returning a hash {best: [], worst: []}
+        contributors = contributors.merge(send(method, exercise, NUMBER_OF_CONTRIBUTORS_PER_CLASS)) {|_key, this, other| this + other }
       end
 
       # write reasons for feedback emails to db
-      users.each_key do |key|
-        segment = users[key].uniq(&by_id_and_type)
-        users_to_notify += segment
-        segment.each do |user|
-          reason = "{\"segment\": \"#{key}\", \"feature\": \"#{user[:reason]}\", value: \"#{user[:value]}\"}"
-          AnomalyNotification.create(user_id: user[:user_id], user_type: user[:user_type],
+      contributors.each_key do |key|
+        segment = contributors[key].uniq(&by_id_and_type)
+        contributors_to_notify += segment
+        segment.each do |contributor|
+          reason = {segment: key, feature: contributor[:reason], value: contributor[:value]}
+          AnomalyNotification.create(contributor_id: contributor[:contributor_id], contributor_type: contributor[:contributor_type],
             exercise:, exercise_collection: collection, reason:)
         end
       end
 
-      users_to_notify.uniq!(&by_id_and_type)
-      users_to_notify.each do |u|
-        user = u[:user_type] == InternalUser.name ? InternalUser.find(u[:user_id]) : ExternalUser.find(u[:user_id])
-        host = CodeOcean::Application.config.action_mailer.default_url_options[:host]
-        feedback_link = Rails.application.routes.url_helpers.url_for(action: :new,
-          controller: :user_exercise_feedbacks, exercise_id: exercise.id, host:)
-        UserMailer.exercise_anomaly_needs_feedback(user, exercise, feedback_link).deliver
+      # send feedback emails
+      # Potentially, a user that solved the exercise alone and as part of a study group is notified multiple times.
+      contributors_to_notify.uniq!(&by_id_and_type)
+      contributors_to_notify.each do |c|
+        contributor = c[:contributor_type].constantize.find(c[:contributor_id])
+        users = contributor.try(:users) || [contributor]
+        users.each do |user|
+          host = CodeOcean::Application.config.action_mailer.default_url_options[:host]
+          feedback_link = Rails.application.routes.url_helpers.url_for(action: :new,
+            controller: :user_exercise_feedbacks, exercise_id: exercise.id, host:)
+          UserMailer.exercise_anomaly_needs_feedback(user, exercise, feedback_link).deliver
+        end
       end
-      log("Asked #{users_to_notify.size} users for feedback.", 2)
+      log("Asked #{contributors_to_notify.size} contributors for feedback.", 2)
     end
   end
 
-  def performers_by_score(exercise, users)
-    submissions = exercise.last_submission_per_user.where.not(score: nil).order(score: :desc)
-    map_block = proc {|item| {user_id: item.user_id, user_type: item.user_type, value: item.score, reason: 'score'} }
-    best_performers = submissions.first(users).to_a.map(&map_block)
-    worst_performers = submissions.last(users).to_a.map(&map_block)
+  def performers_by_score(exercise, contributors)
+    submissions = exercise.last_submission_per_contributor.where.not(score: nil).order(score: :desc)
+    map_block = proc {|item| {contributor_id: item.contributor_id, contributor_type: item.contributor_type, value: item.score, reason: 'score'} }
+    best_performers = submissions.first(contributors).to_a.map(&map_block)
+    worst_performers = submissions.last(contributors).to_a.map(&map_block)
     {best: best_performers, worst: worst_performers}
   end
 
-  def performers_by_time(exercise, users)
-    working_times = get_user_working_times(exercise).values.map do |item|
-      {user_id: item['user_id'], user_type: item['user_type'], score: item['score'].to_f,
+  def performers_by_time(exercise, contributors)
+    working_times = get_contributor_working_times(exercise).values.map do |item|
+      {contributor_id: item['contributor_id'], contributor_type: item['contributor_type'], score: item['score'].to_f,
        value: time_to_f(item['working_time']), reason: 'time'}
     end
     avg_score = exercise.average_score
     working_times.reject! do |item|
-      item[:value].nil? or item[:value] <= MIN_USER_WORKING_TIME or item[:score] < avg_score
+      item[:value].nil? or item[:value] <= MIN_CONTRIBUTOR_WORKING_TIME or item[:score] < avg_score
     end
     working_times.sort_by! {|item| item[:value] }
-    {best: working_times.first(users), worst: working_times.last(users)}
+    {best: working_times.first(contributors), worst: working_times.last(contributors)}
   end
 
   def reset_anomaly_detection_flag(collection)

--- a/spec/concerns/file_parameters_spec.rb
+++ b/spec/concerns/file_parameters_spec.rb
@@ -25,7 +25,7 @@ describe FileParameters do
 
       it 'new file' do
         submission = create(:submission, exercise: hello_world, id: 1337)
-        controller.instance_variable_set(:@current_user, submission.user)
+        controller.instance_variable_set(:@current_user, submission.contributor)
 
         new_file = create(:file, context: submission)
         expect(file_accepted?(new_file)).to be true
@@ -58,8 +58,8 @@ describe FileParameters do
       it 'file of another submission' do
         learner1 = create(:learner)
         learner2 = create(:learner)
-        submission_learner1 = create(:submission, exercise: hello_world, user: learner1)
-        _submission_learner2 = create(:submission, exercise: hello_world, user: learner2)
+        submission_learner1 = create(:submission, exercise: hello_world, contributor: learner1)
+        _submission_learner2 = create(:submission, exercise: hello_world, contributor: learner2)
 
         controller.instance_variable_set(:@current_user, learner2)
         other_submissions_file = create(:file, context: submission_learner1)

--- a/spec/concerns/file_parameters_spec.rb
+++ b/spec/concerns/file_parameters_spec.rb
@@ -25,7 +25,7 @@ describe FileParameters do
 
       it 'new file' do
         submission = create(:submission, exercise: hello_world, id: 1337)
-        controller.instance_variable_set(:@current_user, submission.contributor)
+        controller.instance_variable_set(:@current_contributor, submission.contributor)
 
         new_file = create(:file, context: submission)
         expect(file_accepted?(new_file)).to be true
@@ -61,7 +61,7 @@ describe FileParameters do
         submission_learner1 = create(:submission, exercise: hello_world, contributor: learner1)
         _submission_learner2 = create(:submission, exercise: hello_world, contributor: learner2)
 
-        controller.instance_variable_set(:@current_user, learner2)
+        controller.instance_variable_set(:@current_contributor, learner2)
         other_submissions_file = create(:file, context: submission_learner1)
         expect(file_accepted?(other_submissions_file)).to be false
       end

--- a/spec/concerns/lti_spec.rb
+++ b/spec/concerns/lti_spec.rb
@@ -22,6 +22,7 @@ describe Lti do
       expect(controller.session).to receive(:delete).with(:external_user_id)
       expect(controller.session).to receive(:delete).with(:study_group_id)
       expect(controller.session).to receive(:delete).with(:embed_options)
+      expect(controller.session).to receive(:delete).with(:pg_id)
       controller.send(:clear_lti_session_data)
     end
   end

--- a/spec/concerns/lti_spec.rb
+++ b/spec/concerns/lti_spec.rb
@@ -108,7 +108,7 @@ describe Lti do
     let(:submission) { create(:submission) }
 
     before do
-      create(:lti_parameter, consumers_id: consumer.id, external_users_id: submission.contributor_id, exercises_id: submission.exercise_id)
+      create(:lti_parameter, external_user: submission.contributor, exercise: submission.exercise)
     end
 
     context 'with an invalid score' do
@@ -173,15 +173,15 @@ describe Lti do
       controller.instance_variable_set(:@current_user, create(:external_user))
       controller.instance_variable_set(:@exercise, create(:fibonacci))
       expect(controller.session).to receive(:[]=).with(:external_user_id, anything)
-      controller.send(:store_lti_session_data, consumer: build(:consumer), parameters:)
+      controller.send(:store_lti_session_data, parameters)
     end
 
     it 'creates an LtiParameter Object' do
-      before_count = LtiParameter.count
-      controller.instance_variable_set(:@current_user, create(:external_user))
-      controller.instance_variable_set(:@exercise, create(:fibonacci))
-      controller.send(:store_lti_session_data, consumer: build(:consumer), parameters:)
-      expect(LtiParameter.count).to eq(before_count + 1)
+      expect do
+        controller.instance_variable_set(:@current_user, create(:external_user))
+        controller.instance_variable_set(:@exercise, create(:fibonacci))
+        controller.send(:store_lti_session_data, parameters)
+      end.to change(LtiParameter, :count).by(1)
     end
   end
 

--- a/spec/concerns/lti_spec.rb
+++ b/spec/concerns/lti_spec.rb
@@ -107,7 +107,7 @@ describe Lti do
     let(:submission) { create(:submission) }
 
     before do
-      create(:lti_parameter, consumers_id: consumer.id, external_users_id: submission.user_id, exercises_id: submission.exercise_id)
+      create(:lti_parameter, consumers_id: consumer.id, external_users_id: submission.contributor_id, exercises_id: submission.exercise_id)
     end
 
     context 'with an invalid score' do
@@ -156,7 +156,7 @@ describe Lti do
 
       context 'without a tool consumer' do
         it 'returns a corresponding status' do
-          submission.user.consumer = nil
+          submission.contributor.consumer = nil
 
           allow(submission).to receive(:normalized_score).and_return score
           expect(controller.send(:send_score, submission)[:status]).to eq('error')

--- a/spec/concerns/lti_spec.rb
+++ b/spec/concerns/lti_spec.rb
@@ -22,8 +22,6 @@ describe Lti do
       expect(controller.session).to receive(:delete).with(:external_user_id)
       expect(controller.session).to receive(:delete).with(:study_group_id)
       expect(controller.session).to receive(:delete).with(:embed_options)
-      expect(controller.session).to receive(:delete).with(:lti_exercise_id)
-      expect(controller.session).to receive(:delete).with(:lti_parameters_id)
       controller.send(:clear_lti_session_data)
     end
   end
@@ -174,7 +172,6 @@ describe Lti do
       controller.instance_variable_set(:@current_user, create(:external_user))
       controller.instance_variable_set(:@exercise, create(:fibonacci))
       expect(controller.session).to receive(:[]=).with(:external_user_id, anything)
-      expect(controller.session).to receive(:[]=).with(:lti_parameters_id, anything)
       controller.send(:store_lti_session_data, consumer: build(:consumer), parameters:)
     end
 

--- a/spec/concerns/lti_spec.rb
+++ b/spec/concerns/lti_spec.rb
@@ -17,16 +17,6 @@ describe Lti do
     end
   end
 
-  describe '#clear_lti_session_data' do
-    it 'clears the session' do
-      expect(controller.session).to receive(:delete).with(:external_user_id)
-      expect(controller.session).to receive(:delete).with(:study_group_id)
-      expect(controller.session).to receive(:delete).with(:embed_options)
-      expect(controller.session).to receive(:delete).with(:pg_id)
-      controller.send(:clear_lti_session_data)
-    end
-  end
-
   describe '#external_user_name' do
     let(:first_name) { 'Jane' }
     let(:last_name) { 'Doe' }

--- a/spec/controllers/code_ocean/files_controller_spec.rb
+++ b/spec/controllers/code_ocean/files_controller_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 describe CodeOcean::FilesController do
   render_views
 
-  let(:user) { create(:admin) }
+  let(:contributor) { create(:admin) }
 
-  before { allow(controller).to receive(:current_user).and_return(user) }
+  before { allow(controller).to receive(:current_user).and_return(contributor) }
 
   describe 'GET #show_protected_upload' do
     context 'with a valid filename' do
@@ -30,7 +30,7 @@ describe CodeOcean::FilesController do
   end
 
   describe 'POST #create' do
-    let(:submission) { create(:submission, user:) }
+    let(:submission) { create(:submission, contributor:) }
 
     context 'with a valid file' do
       let(:perform_request) { proc { post :create, params: {code_ocean_file: build(:file, context: submission).attributes, format: :json} } }

--- a/spec/controllers/exercises_controller_spec.rb
+++ b/spec/controllers/exercises_controller_spec.rb
@@ -325,7 +325,7 @@ describe ExercisesController do
 
       context 'when the score transmission succeeds' do
         before do
-          allow(controller).to receive(:send_score).and_return(status: 'success')
+          allow(controller).to receive(:send_scores).and_return([{status: 'success'}])
           perform_request
         end
 
@@ -341,7 +341,7 @@ describe ExercisesController do
 
       context 'when the score transmission fails' do
         before do
-          allow(controller).to receive(:send_score).and_return(status: 'unsupported')
+          allow(controller).to receive(:send_scores).and_return([{status: 'unsupported'}])
           perform_request
         end
 
@@ -351,8 +351,11 @@ describe ExercisesController do
           expect(assigns(:submission)).to be_a(Submission)
         end
 
+        it 'returns an error message' do
+          expect(response.parsed_body).to eq('danger' => I18n.t('exercises.submit.failure'))
+        end
+
         expect_json
-        expect_http_status(:service_unavailable)
       end
     end
 
@@ -369,7 +372,7 @@ describe ExercisesController do
       end
 
       it 'does not send scores' do
-        expect(controller).not_to receive(:send_score)
+        expect(controller).not_to receive(:send_scores)
       end
 
       expect_json

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -190,7 +190,10 @@ describe SessionsController do
       end
 
       it 'clears the session' do
-        expect(controller).to receive(:clear_lti_session_data)
+        expect(controller.session).to receive(:delete).with(:external_user_id)
+        expect(controller.session).to receive(:delete).with(:study_group_id)
+        expect(controller.session).to receive(:delete).with(:embed_options)
+        expect(controller.session).to receive(:delete).with(:pg_id)
         delete :destroy
       end
 
@@ -207,11 +210,6 @@ describe SessionsController do
     before do
       create(:lti_parameter, external_user: submission.contributor)
       allow(controller).to receive(:current_user).and_return(submission.contributor)
-      perform_request.call
-    end
-
-    it 'clears the session' do
-      expect(controller).to receive(:clear_lti_session_data)
       perform_request.call
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -101,7 +101,6 @@ describe SessionsController do
       end
 
       it 'stores LTI parameters in the session' do
-        # Todo replace session with lti_parameter /should be done already
         expect(controller).to receive(:store_lti_session_data)
         perform_request
       end
@@ -191,7 +190,6 @@ describe SessionsController do
       end
 
       it 'clears the session' do
-        # Todo replace session with lti_parameter /should be done already
         expect(controller).to receive(:clear_lti_session_data)
         delete :destroy
       end
@@ -207,15 +205,12 @@ describe SessionsController do
     let(:submission) { create(:submission, exercise: create(:dummy)) }
 
     before do
-      # Todo replace session with lti_parameter
-      # Todo create LtiParameter Object
-      # session[:lti_parameters] = {}
+      create(:lti_parameter, external_user: submission.contributor)
       allow(controller).to receive(:current_user).and_return(submission.contributor)
       perform_request.call
     end
 
     it 'clears the session' do
-      # Todo replace session with lti_parameter /should be done already
       expect(controller).to receive(:clear_lti_session_data)
       perform_request.call
     end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -210,7 +210,7 @@ describe SessionsController do
       # Todo replace session with lti_parameter
       # Todo create LtiParameter Object
       # session[:lti_parameters] = {}
-      allow(controller).to receive(:current_user).and_return(submission.user)
+      allow(controller).to receive(:current_user).and_return(submission.contributor)
       perform_request.call
     end
 

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -5,166 +5,243 @@ require 'rails_helper'
 describe SubmissionsController do
   render_views
 
-  let(:submission) { create(:submission) }
-  let(:contributor) { create(:admin) }
+  let(:exercise) { create(:math) }
+  let(:submission) { create(:submission, exercise:, contributor:) }
 
-  before { allow(controller).to receive(:current_user).and_return(contributor) }
-
-  describe 'POST #create' do
-    before do
-      controller.request.accept = 'application/json'
-    end
-
-    context 'with a valid submission' do
-      let(:exercise) { create(:hello_world) }
-      let(:perform_request) { proc { post :create, format: :json, params: {submission: attributes_for(:submission, exercise_id: exercise.id)} } }
-
-      before { perform_request.call }
-
-      expect_assigns(submission: Submission)
-
-      it 'creates the submission' do
-        expect { perform_request.call }.to change(Submission, :count).by(1)
+  shared_examples 'a regular user' do |record_not_found_status_code|
+    describe 'POST #create' do
+      before do
+        controller.request.accept = 'application/json'
       end
 
-      expect_json
-      expect_http_status(:created)
+      context 'with a valid submission' do
+        let(:exercise) { create(:hello_world) }
+        let(:perform_request) { proc { post :create, format: :json, params: {submission: attributes_for(:submission, exercise_id: exercise.id)} } }
+
+        before { perform_request.call }
+
+        expect_assigns(submission: Submission)
+
+        it 'creates the submission' do
+          expect { perform_request.call }.to change(Submission, :count).by(1)
+        end
+
+        expect_json
+        expect_http_status(:created)
+      end
+
+      context 'with an invalid submission' do
+        before { post :create, params: {submission: {}} }
+
+        expect_assigns(submission: Submission)
+        expect_json
+        expect_http_status(:unprocessable_entity)
+      end
     end
 
-    context 'with an invalid submission' do
-      before { post :create, params: {submission: {}} }
+    describe 'GET #download_file' do
+      context 'with an invalid filename' do
+        before { get :download_file, params: {filename: SecureRandom.hex, id: submission.id, format: :json} }
 
-      expect_assigns(submission: Submission)
-      expect_json
-      expect_http_status(:unprocessable_entity)
-    end
-  end
+        expect_http_status(record_not_found_status_code)
+      end
 
-  describe 'GET #download_file' do
-    context 'with an invalid filename' do
-      before { get :download_file, params: {filename: SecureRandom.hex, id: submission.id, format: :json} }
+      context 'with a valid binary filename' do
+        let(:exercise) { create(:sql_select) }
+        let(:submission) { create(:submission, exercise:, contributor:) }
 
-      expect_http_status(:not_found)
-    end
+        before { get :download_file, params: {filename: file.name_with_extension, id: submission.id} }
 
-    context 'with a valid binary filename' do
-      let(:submission) { create(:submission, exercise: create(:sql_select)) }
+        context 'with a binary file' do
+          let(:file) { submission.collect_files.detect {|file| file.name == 'exercise' && file.file_type.file_extension == '.sql' } }
 
-      before { get :download_file, params: {filename: file.name_with_extension, id: submission.id} }
+          expect_assigns(file: :file)
+          expect_assigns(submission: :submission)
+          expect_content_type('application/octet-stream')
+          expect_http_status(:ok)
 
-      context 'with a binary file' do
-        let(:file) { submission.collect_files.detect {|file| file.name == 'exercise' && file.file_type.file_extension == '.sql' } }
+          it 'sets the correct filename' do
+            expect(response.headers['Content-Disposition']).to include("attachment; filename=\"#{file.name_with_extension}\"")
+          end
+        end
+      end
 
-        expect_assigns(file: :file)
-        expect_assigns(submission: :submission)
-        expect_content_type('application/octet-stream')
-        expect_http_status(:ok)
+      context 'with a valid filename' do
+        let(:exercise) { create(:audio_video) }
+        let(:submission) { create(:submission, exercise:, contributor:) }
 
-        it 'sets the correct filename' do
-          expect(response.headers['Content-Disposition']).to include("attachment; filename=\"#{file.name_with_extension}\"")
+        before { get :download_file, params: {filename: file.name_with_extension, id: submission.id} }
+
+        context 'with a binary file' do
+          let(:file) { submission.collect_files.detect {|file| file.file_type.file_extension == '.mp4' } }
+
+          expect_assigns(file: :file)
+          expect_assigns(submission: :submission)
+
+          it 'sets the correct redirect' do
+            expect(response.location).to eq protected_upload_url(id: file, filename: file.filepath)
+          end
+        end
+
+        context 'with a non-binary file' do
+          let(:file) { submission.collect_files.detect {|file| file.file_type.file_extension == '.js' } }
+
+          expect_assigns(file: :file)
+          expect_assigns(submission: :submission)
+          expect_content_type('application/octet-stream')
+          expect_http_status(:ok)
+
+          it 'sets the correct filename' do
+            expect(response.headers['Content-Disposition']).to include("attachment; filename=\"#{file.name_with_extension}\"")
+          end
         end
       end
     end
 
-    context 'with a valid filename' do
-      let(:submission) { create(:submission, exercise: create(:audio_video)) }
+    describe 'GET #render_file' do
+      let(:file) { submission.files.first }
+      let(:signed_url) { AuthenticatedUrlHelper.sign(render_submission_url(submission, filename), submission) }
+      let(:token) { Rack::Utils.parse_nested_query(URI.parse(signed_url).query)['token'] }
 
-      before { get :download_file, params: {filename: file.name_with_extension, id: submission.id} }
+      context 'with an invalid filename' do
+        let(:filename) { SecureRandom.hex }
 
-      context 'with a binary file' do
-        let(:file) { submission.collect_files.detect {|file| file.file_type.file_extension == '.mp4' } }
+        before { get :render_file, params: {filename:, id: submission.id, token:} }
 
-        expect_assigns(file: :file)
-        expect_assigns(submission: :submission)
-
-        it 'sets the correct redirect' do
-          expect(response.location).to eq protected_upload_url(id: file, filename: file.filepath)
-        end
+        expect_http_status(record_not_found_status_code)
       end
 
-      context 'with a non-binary file' do
-        let(:file) { submission.collect_files.detect {|file| file.file_type.file_extension == '.js' } }
+      context 'with a valid filename' do
+        let(:exercise) { create(:audio_video) }
+        let(:submission) { create(:submission, exercise:, contributor:) }
+        let(:filename) { file.name_with_extension }
 
-        expect_assigns(file: :file)
-        expect_assigns(submission: :submission)
-        expect_content_type('application/octet-stream')
-        expect_http_status(:ok)
+        before { get :render_file, params: {filename:, id: submission.id, token:} }
 
-        it 'sets the correct filename' do
-          expect(response.headers['Content-Disposition']).to include("attachment; filename=\"#{file.name_with_extension}\"")
+        context 'with a binary file' do
+          let(:file) { submission.collect_files.detect {|file| file.file_type.file_extension == '.mp4' } }
+          let(:signed_url_video) { AuthenticatedUrlHelper.sign(render_protected_upload_url(id: file, filename: file.filepath), file) }
+
+          expect_assigns(file: :file)
+          expect_assigns(submission: :submission)
+
+          it 'sets the correct redirect' do
+            expect(response.location).to eq signed_url_video
+          end
         end
-      end
-    end
-  end
 
-  describe 'GET #index' do
-    before do
-      create_pair(:submission)
-      get :index
-    end
+        context 'with a non-binary file' do
+          let(:file) { submission.collect_files.detect {|file| file.file_type.file_extension == '.js' } }
 
-    expect_assigns(submissions: Submission.all)
-    expect_http_status(:ok)
-    expect_template(:index)
-  end
+          expect_assigns(file: :file)
+          expect_assigns(submission: :submission)
+          expect_content_type('text/javascript')
+          expect_http_status(:ok)
 
-  describe 'GET #render_file' do
-    let(:file) { submission.files.first }
-    let(:signed_url) { AuthenticatedUrlHelper.sign(render_submission_url(submission, filename), submission) }
-    let(:token) { Rack::Utils.parse_nested_query(URI.parse(signed_url).query)['token'] }
-
-    context 'with an invalid filename' do
-      let(:filename) { SecureRandom.hex }
-
-      before { get :render_file, params: {filename:, id: submission.id, token:} }
-
-      expect_http_status(:not_found)
-    end
-
-    context 'with a valid filename' do
-      let(:submission) { create(:submission, exercise: create(:audio_video)) }
-      let(:filename) { file.name_with_extension }
-
-      before { get :render_file, params: {filename:, id: submission.id, token:} }
-
-      context 'with a binary file' do
-        let(:file) { submission.collect_files.detect {|file| file.file_type.file_extension == '.mp4' } }
-        let(:signed_url_video) { AuthenticatedUrlHelper.sign(render_protected_upload_url(id: file, filename: file.filepath), file) }
-
-        expect_assigns(file: :file)
-        expect_assigns(submission: :submission)
-
-        it 'sets the correct redirect' do
-          expect(response.location).to eq signed_url_video
-        end
-      end
-
-      context 'with a non-binary file' do
-        let(:file) { submission.collect_files.detect {|file| file.file_type.file_extension == '.js' } }
-
-        expect_assigns(file: :file)
-        expect_assigns(submission: :submission)
-        expect_content_type('text/javascript')
-        expect_http_status(:ok)
-
-        it 'renders the file content' do
-          expect(response.body).to eq(file.content)
+          it 'renders the file content' do
+            expect(response.body).to eq(file.content)
+          end
         end
       end
     end
-  end
 
-  describe 'GET #run' do
-    let(:file) { submission.collect_files.detect(&:main_file?) }
-    let(:perform_request) { get :run, format: :json, params: {filename: file.filepath, id: submission.id} }
+    describe 'GET #run' do
+      let(:file) { submission.collect_files.detect(&:main_file?) }
+      let(:perform_request) { get :run, format: :json, params: {filename: file.filepath, id: submission.id} }
 
-    context 'when no errors occur during execution' do
+      context 'when no errors occur during execution' do
+        before do
+          allow_any_instance_of(described_class).to receive(:hijack)
+          allow_any_instance_of(described_class).to receive(:close_client_connection)
+          allow_any_instance_of(Submission).to receive(:run).and_return({})
+          allow_any_instance_of(described_class).to receive(:save_testrun_output)
+          perform_request
+        end
+
+        expect_assigns(submission: :submission)
+        expect_assigns(file: :file)
+        expect_http_status(204)
+      end
+    end
+
+    describe 'GET #score' do
+      let(:perform_request) { proc { get :score, format: :json, params: {id: submission.id} } }
+
       before do
         allow_any_instance_of(described_class).to receive(:hijack)
-        allow_any_instance_of(described_class).to receive(:close_client_connection)
-        allow_any_instance_of(Submission).to receive(:run).and_return({})
-        allow_any_instance_of(described_class).to receive(:save_testrun_output)
-        perform_request
+        allow_any_instance_of(described_class).to receive(:kill_client_socket)
+        perform_request.call
+      end
+
+      expect_assigns(submission: :submission)
+      expect_http_status(204)
+    end
+
+    describe 'GET #show' do
+      before { get :show, params: {id: submission.id} }
+
+      expect_assigns(submission: :submission)
+      expect_http_status(:ok)
+      expect_template(:show)
+    end
+
+    describe 'GET #show.json' do
+      # Render views requested in controller tests in order to get json responses
+      # https://github.com/rails/jbuilder/issues/32
+      render_views
+
+      before { get :show, params: {id: submission.id}, format: :json }
+
+      expect_assigns(submission: :submission)
+      expect_http_status(:ok)
+
+      %i[run test].each do |action|
+        describe "##{action}_url" do
+          let(:url) { response.parsed_body.with_indifferent_access.fetch("#{action}_url") }
+
+          it "starts like the #{action} path" do
+            filename = File.basename(__FILE__)
+            expect(url).to start_with(Rails.application.routes.url_helpers.send(:"#{action}_submission_path", submission, filename).sub(filename, ''))
+          end
+
+          it 'ends with a placeholder' do
+            expect(url).to end_with("#{Submission::FILENAME_URL_PLACEHOLDER}.json")
+          end
+        end
+      end
+
+      describe '#render_url' do
+        let(:supported_urls) { response.parsed_body.with_indifferent_access.fetch('render_url') }
+        let(:file) { submission.collect_files.detect(&:main_file?) }
+        let(:url) { supported_urls.find {|hash| hash[:filepath] == file.filepath }['url'] }
+
+        it 'starts like the render path' do
+          expect(url).to start_with(Rails.application.routes.url_helpers.render_submission_url(submission, file.filepath, host: request.host))
+        end
+
+        it 'includes a token' do
+          expect(url).to include '?token='
+        end
+      end
+
+      describe '#score_url' do
+        let(:url) { response.parsed_body.with_indifferent_access.fetch('score_url') }
+
+        it 'corresponds to the score path' do
+          expect(url).to eq(Rails.application.routes.url_helpers.score_submission_path(submission, format: :json))
+        end
+      end
+    end
+
+    describe 'GET #test' do
+      let(:file) { submission.collect_files.detect(&:teacher_defined_assessment?) }
+      let(:output) { {} }
+
+      before do
+        file.update(hidden: false)
+        allow_any_instance_of(described_class).to receive(:hijack)
+        allow_any_instance_of(described_class).to receive(:kill_client_socket)
+        get :test, params: {filename: "#{file.filepath}.json", id: submission.id}
       end
 
       expect_assigns(submission: :submission)
@@ -173,88 +250,57 @@ describe SubmissionsController do
     end
   end
 
-  describe 'GET #show' do
-    before { get :show, params: {id: submission.id} }
-
-    expect_assigns(submission: :submission)
-    expect_http_status(:ok)
-    expect_template(:show)
-  end
-
-  describe 'GET #show.json' do
-    # Render views requested in controller tests in order to get json responses
-    # https://github.com/rails/jbuilder/issues/32
-    render_views
-
-    before { get :show, params: {id: submission.id}, format: :json }
-
-    expect_assigns(submission: :submission)
-    expect_http_status(:ok)
-
-    %i[run test].each do |action|
-      describe "##{action}_url" do
-        let(:url) { response.parsed_body.with_indifferent_access.fetch("#{action}_url") }
-
-        it "starts like the #{action} path" do
-          filename = File.basename(__FILE__)
-          expect(url).to start_with(Rails.application.routes.url_helpers.send(:"#{action}_submission_path", submission, filename).sub(filename, ''))
-        end
-
-        it 'ends with a placeholder' do
-          expect(url).to end_with("#{Submission::FILENAME_URL_PLACEHOLDER}.json")
-        end
-      end
-    end
-
-    describe '#render_url' do
-      let(:supported_urls) { response.parsed_body.with_indifferent_access.fetch('render_url') }
-      let(:file) { submission.collect_files.detect(&:main_file?) }
-      let(:url) { supported_urls.find {|hash| hash[:filepath] == file.filepath }['url'] }
-
-      it 'starts like the render path' do
-        expect(url).to start_with(Rails.application.routes.url_helpers.render_submission_url(submission, file.filepath, host: request.host))
+  shared_examples 'denies access for regular, non-admin users' do # rubocop:disable RSpec/SharedContext
+    describe 'GET #index' do
+      before do
+        create_pair(:submission, contributor:, exercise:)
+        get :index
       end
 
-      it 'includes a token' do
-        expect(url).to include '?token='
-      end
-    end
-
-    describe '#score_url' do
-      let(:url) { response.parsed_body.with_indifferent_access.fetch('score_url') }
-
-      it 'corresponds to the score path' do
-        expect(url).to eq(Rails.application.routes.url_helpers.score_submission_path(submission, format: :json))
-      end
+      expect_redirect(:root)
     end
   end
 
-  describe 'GET #score' do
-    let(:perform_request) { proc { get :score, format: :json, params: {id: submission.id} } }
+  context 'with an admin user' do
+    let(:contributor) { create(:admin) }
+
+    before { allow(controller).to receive(:current_user).and_return(contributor) }
+
+    describe 'GET #index' do
+      before do
+        create_pair(:submission, contributor:, exercise:)
+        get :index
+      end
+
+      expect_assigns(submissions: Submission.all)
+      expect_http_status(:ok)
+      expect_template(:index)
+    end
+
+    it_behaves_like 'a regular user', :not_found
+  end
+
+  context 'with a programming group' do
+    let(:group_author) { create(:external_user) }
+    let(:other_group_author) { create(:external_user) }
+    let(:contributor) { create(:programming_group, exercise:, users: [group_author, other_group_author]) }
 
     before do
-      allow_any_instance_of(described_class).to receive(:hijack)
-      allow_any_instance_of(described_class).to receive(:kill_client_socket)
-      perform_request.call
+      allow(controller).to receive_messages(current_contributor: contributor, current_user: group_author)
     end
 
-    expect_assigns(submission: :submission)
-    expect_http_status(204)
+    it_behaves_like 'a regular user', :unauthorized
+    it_behaves_like 'denies access for regular, non-admin users'
   end
 
-  describe 'GET #test' do
-    let(:file) { submission.collect_files.detect(&:teacher_defined_assessment?) }
-    let(:output) { {} }
+  context 'with a learner' do
+    let(:contributor) { create(:external_user) }
 
     before do
-      file.update(hidden: false)
-      allow_any_instance_of(described_class).to receive(:hijack)
-      allow_any_instance_of(described_class).to receive(:kill_client_socket)
-      get :test, params: {filename: "#{file.filepath}.json", id: submission.id}
+      allow(controller).to receive_messages(current_user: contributor)
     end
 
-    expect_assigns(submission: :submission)
-    expect_assigns(file: :file)
-    expect_http_status(204)
+    it_behaves_like 'a regular user', :unauthorized
+    it_behaves_like 'denies access for regular, non-admin users'
   end
 end

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -6,9 +6,9 @@ describe SubmissionsController do
   render_views
 
   let(:submission) { create(:submission) }
-  let(:user) { create(:admin) }
+  let(:contributor) { create(:admin) }
 
-  before { allow(controller).to receive(:current_user).and_return(user) }
+  before { allow(controller).to receive(:current_user).and_return(contributor) }
 
   describe 'POST #create' do
     before do

--- a/spec/factories/lti_parameter.rb
+++ b/spec/factories/lti_parameter.rb
@@ -8,11 +8,17 @@ FactoryBot.define do
   }.freeze
 
   factory :lti_parameter do
-    consumer
     exercise factory: :math
     external_user
 
     lti_parameters { lti_params }
+
+    after(:create) do |lti_parameter|
+      # Do not change anything if a study group was provided explicitly or user has no study groups
+      next if lti_parameter.study_group.present? || lti_parameter.external_user.study_groups.blank?
+
+      lti_parameter.update!(study_group: lti_parameter.external_user.study_groups.first)
+    end
 
     trait :without_outcome_service_url do
       lti_parameters { lti_params.except(:lis_outcome_service_url) }

--- a/spec/factories/programming_group.rb
+++ b/spec/factories/programming_group.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :programming_group do
+    exercise factory: :math
+
+    after(:build) do |programming_group|
+      # Do not change anything if users were provided explicitly
+      next if programming_group.users.present?
+
+      programming_group.users = build_list(:external_user, 2)
+    end
+  end
+end

--- a/spec/factories/runner.rb
+++ b/spec/factories/runner.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
   factory :runner do
     runner_id { SecureRandom.uuid }
     execution_environment factory: :ruby
-    user factory: :external_user
+    contributor factory: :external_user
   end
 end

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -10,6 +10,11 @@ FactoryBot.define do
       submission.exercise.files.editable.visible.each do |file|
         submission.add_file(content: file.content, file_id: file.id)
       end
+
+      # Do not change anything if a study group was provided explicitly or user has no study groups
+      next if submission.study_group.present? || submission.users.first.study_groups.blank?
+
+      submission.update!(study_group: submission.users.first.study_groups.first)
     end
   end
 end

--- a/spec/features/editor_spec.rb
+++ b/spec/features/editor_spec.rb
@@ -22,12 +22,12 @@ describe 'Editor', js: true do
       weight: 2.0,
     }]
   end
-  let(:user) { create(:teacher) }
+  let(:contributor) { create(:teacher) }
   let(:exercise_without_test) { create(:tdd) }
 
   before do
     visit(sign_in_path)
-    fill_in('email', with: user.email)
+    fill_in('email', with: contributor.email)
     fill_in('password', with: attributes_for(:teacher)[:password])
     click_button(I18n.t('sessions.new.link'))
     allow_any_instance_of(LtiHelper).to receive(:lti_outcome_service?).and_return(true)
@@ -111,7 +111,7 @@ describe 'Editor', js: true do
   end
 
   it 'contains a button for submitting the exercise' do
-    submission = build(:submission, user:, exercise:)
+    submission = build(:submission, contributor:, exercise:)
     allow(submission).to receive(:calculate_score).and_return(scoring_response)
     allow(Submission).to receive(:find).and_return(submission)
     click_button(I18n.t('exercises.editor.score'))

--- a/spec/features/external_user_statistics_spec.rb
+++ b/spec/features/external_user_statistics_spec.rb
@@ -9,10 +9,10 @@ describe 'ExternalUserStatistics', js: true do
   let(:password) { 'password123456' }
 
   before do
-    2.times { create(:submission, cause: 'autosave', user: learner, exercise:, study_group:) }
-    2.times { create(:submission, cause: 'run', user: learner, exercise:, study_group:) }
-    create(:submission, cause: 'assess', user: learner, exercise:, study_group:)
-    create(:submission, cause: 'submit', user: learner, exercise:, study_group:)
+    2.times { create(:submission, cause: 'autosave', contributor: learner, exercise:, study_group:) }
+    2.times { create(:submission, cause: 'run', contributor: learner, exercise:, study_group:) }
+    create(:submission, cause: 'assess', contributor: learner, exercise:, study_group:)
+    create(:submission, cause: 'submit', contributor: learner, exercise:, study_group:)
 
     study_group.external_users << learner
     study_group.internal_users << user

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -91,7 +91,7 @@ describe Exercise do
 
     context 'without submissions' do
       it 'returns nil' do
-        expect(exercise.average_score).to be 0
+        expect(exercise.average_score).to be 0.0
       end
     end
 

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -7,7 +7,7 @@ describe Exercise do
   let(:users) { create_list(:external_user, 10) }
 
   def create_submissions
-    create_list(:submission, 10, cause: 'submit', exercise:, score: Forgery(:basic).number, user: users.sample)
+    create_list(:submission, 10, cause: 'submit', exercise:, score: Forgery(:basic).number, contributor: users.sample)
   end
 
   it 'validates the number of main files' do
@@ -77,7 +77,10 @@ describe Exercise do
       before { create_submissions }
 
       it 'returns the average score expressed as a percentage' do
-        maximum_percentages = exercise.submissions.group_by(&:user_id).values.map {|submission| submission.max_by(&:score).score / exercise.maximum_score * 100 }
+        maximum_percentages = exercise.submissions.group_by do |s|
+                                [s.contributor_type,
+                                 s.contributor_id]
+                              end.values.map {|submission| submission.max_by(&:score).score / exercise.maximum_score * 100 }
         expect(exercise.average_percentage).to eq(maximum_percentages.average.round(2))
       end
     end
@@ -96,7 +99,10 @@ describe Exercise do
       before { create_submissions }
 
       it "returns the average of all users' maximum scores" do
-        maximum_scores = exercise.submissions.group_by(&:user_id).values.map {|submission| submission.max_by(&:score).score }
+        maximum_scores = exercise.submissions.group_by do |s|
+                           [s.contributor_type,
+                            s.contributor_id]
+                         end.values.map {|submission| submission.max_by(&:score).score }
         expect(exercise.average_score).to be_within(0.1).of(maximum_scores.average)
       end
     end

--- a/spec/models/runner_spec.rb
+++ b/spec/models/runner_spec.rb
@@ -22,9 +22,9 @@ describe Runner do
       expect(runner.errors[:execution_environment]).to be_present
     end
 
-    it 'validates the presence of a user' do
-      runner.update(user: nil)
-      expect(runner.errors[:user]).to be_present
+    it 'validates the presence of a contributor' do
+      runner.update(contributor: nil)
+      expect(runner.errors[:contributor]).to be_present
     end
   end
 
@@ -159,9 +159,9 @@ describe Runner do
   end
 
   describe 'creation' do
-    let(:user) { create(:external_user) }
+    let(:contributor) { create(:external_user) }
     let(:execution_environment) { create(:ruby) }
-    let(:create_action) { -> { described_class.create(user:, execution_environment:) } }
+    let(:create_action) { -> { described_class.create(contributor:, execution_environment:) } }
 
     it 'requests a runner id from the runner management' do
       expect(strategy_class).to receive(:request_from_management)
@@ -184,7 +184,7 @@ describe Runner do
     it 'does not call the runner management again while a runner id is set' do
       expect(strategy_class).to receive(:request_from_management).and_return(runner_id).once
       runner = create_action.call
-      runner.update(user: create(:external_user))
+      runner.update(contributor: create(:external_user))
     end
   end
 
@@ -237,27 +237,27 @@ describe Runner do
   end
 
   describe '::for' do
-    let(:user) { create(:external_user) }
+    let(:contributor) { create(:external_user) }
     let(:exercise) { create(:fibonacci) }
 
     context 'when the runner could not be saved' do
       before { allow(strategy_class).to receive(:request_from_management).and_return(nil) }
 
       it 'raises an error' do
-        expect { described_class.for(user, exercise.execution_environment) }.to raise_error(Runner::Error::Unknown, /could not be saved/)
+        expect { described_class.for(contributor, exercise.execution_environment) }.to raise_error(Runner::Error::Unknown, /could not be saved/)
       end
     end
 
     context 'when a runner already exists' do
-      let!(:existing_runner) { create(:runner, user:, execution_environment: exercise.execution_environment) }
+      let!(:existing_runner) { create(:runner, contributor:, execution_environment: exercise.execution_environment) }
 
       it 'returns the existing runner' do
-        new_runner = described_class.for(user, exercise.execution_environment)
+        new_runner = described_class.for(contributor, exercise.execution_environment)
         expect(new_runner).to eq(existing_runner)
       end
 
       it 'sets the strategy' do
-        runner = described_class.for(user, exercise.execution_environment)
+        runner = described_class.for(contributor, exercise.execution_environment)
         expect(runner.strategy).to be_present
       end
     end
@@ -266,7 +266,7 @@ describe Runner do
       before { allow(strategy_class).to receive(:request_from_management).and_return(runner_id) }
 
       it 'returns a new runner' do
-        runner = described_class.for(user, exercise.execution_environment)
+        runner = described_class.for(contributor, exercise.execution_environment)
         expect(runner).to be_valid
       end
     end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -13,8 +13,8 @@ describe Submission do
     expect(described_class.create.errors[:exercise]).to be_present
   end
 
-  it 'validates the presence of a user' do
-    expect(described_class.create.errors[:user]).to be_present
+  it 'validates the presence of a contributor' do
+    expect(described_class.create.errors[:contributor]).to be_present
   end
 
   describe '#main_file' do
@@ -67,19 +67,19 @@ describe Submission do
   end
 
   describe '#siblings' do
-    let(:siblings) { described_class.find_by(user:).siblings }
-    let(:user) { create(:external_user) }
+    let(:siblings) { described_class.find_by(contributor:).siblings }
+    let(:contributor) { create(:external_user) }
 
     before do
       10.times.each_with_index do |_, index|
-        create(:submission, exercise: submission.exercise, user: (index.even? ? user : create(:external_user)))
+        create(:submission, exercise: submission.exercise, contributor: (index.even? ? contributor : create(:external_user)))
       end
     end
 
     it "returns all the creator's submissions for the same exercise" do
       expect(siblings).to be_an(ActiveRecord::Relation)
       expect(siblings.map(&:exercise).uniq).to eq([submission.exercise])
-      expect(siblings.map(&:user).uniq).to eq([user])
+      expect(siblings.map(&:contributor).uniq).to eq([contributor])
     end
   end
 
@@ -92,8 +92,8 @@ describe Submission do
   describe '#redirect_to_feedback?' do
     context 'with no exercise feedback' do
       let(:exercise) { create(:dummy) }
-      let(:user) { build(:external_user, id: (11 - (exercise.created_at.to_i % 10)) % 10) }
-      let(:submission) { build(:submission, exercise:, user:) }
+      let(:contributor) { build(:external_user, id: (11 - (exercise.created_at.to_i % 10)) % 10) }
+      let(:submission) { build(:submission, exercise:, contributor:) }
 
       it 'sends 10% of users to feedback page' do
         expect(submission.send(:redirect_to_feedback?)).to be_truthy
@@ -101,7 +101,7 @@ describe Submission do
 
       it 'does not redirect other users' do
         9.times do |i|
-          submission = build(:submission, exercise:, user: build(:external_user, id: (11 - (exercise.created_at.to_i % 10)) - i - 1))
+          submission = build(:submission, exercise:, contributor: build(:external_user, id: (11 - (exercise.created_at.to_i % 10)) - i - 1))
           expect(submission.send(:redirect_to_feedback?)).to be_falsey
         end
       end
@@ -109,8 +109,8 @@ describe Submission do
 
     context 'with little exercise feedback' do
       let(:exercise) { create(:dummy_with_user_feedbacks) }
-      let(:user) { build(:external_user, id: (11 - (exercise.created_at.to_i % 10)) % 10) }
-      let(:submission) { build(:submission, exercise:, user:) }
+      let(:contributor) { build(:external_user, id: (11 - (exercise.created_at.to_i % 10)) % 10) }
+      let(:submission) { build(:submission, exercise:, contributor:) }
 
       it 'sends 10% of users to feedback page' do
         expect(submission.send(:redirect_to_feedback?)).to be_truthy
@@ -118,7 +118,7 @@ describe Submission do
 
       it 'does not redirect other users' do
         9.times do |i|
-          submission = build(:submission, exercise:, user: build(:external_user, id: (11 - (exercise.created_at.to_i % 10)) - i - 1))
+          submission = build(:submission, exercise:, contributor: build(:external_user, id: (11 - (exercise.created_at.to_i % 10)) - i - 1))
           expect(submission.send(:redirect_to_feedback?)).to be_falsey
         end
       end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -134,12 +134,12 @@ describe Submission do
       allow(runner).to receive(:attach_to_execution).and_return(1.0)
     end
 
-    after { submission.calculate_score }
+    after { submission.calculate_score(submission.contributor) }
 
     it 'executes every teacher-defined test file' do
       allow(submission).to receive(:combine_file_scores)
       submission.collect_files.select(&:teacher_defined_assessment?).each do |file|
-        expect(submission).to receive(:score_file).with(any_args, file)
+        expect(submission).to receive(:score_file).with(any_args, file, submission.contributor)
       end
     end
 

--- a/spec/policies/code_ocean/file_policy_spec.rb
+++ b/spec/policies/code_ocean/file_policy_spec.rb
@@ -30,31 +30,81 @@ describe CodeOcean::FilePolicy do
     context 'when being part of a submission' do
       let(:file) { submission.files.first }
 
-      context 'when file creation is allowed' do
+      shared_context 'when file creation is allowed' do
         before do
           submission.exercise.update(allow_file_creation: true)
         end
-
-        it 'grants access to authors' do
-          expect(policy).to permit(submission.author, file)
-        end
       end
 
-      context 'when file creation is not allowed' do
+      shared_context 'when file creation is not allowed' do
         before do
           submission.exercise.update(allow_file_creation: false)
         end
+      end
 
-        it 'grants access to authors' do
-          expect(policy).not_to permit(submission.author, file)
+      shared_examples 'no other user allowed to access' do
+        it 'does not grant access to all other users' do
+          %i[admin external_user teacher].each do |factory_name|
+            expect(policy).not_to permit(create(factory_name), file)
+          end
         end
       end
 
-      it 'does not grant access to all other users' do
-        %i[admin external_user teacher].each do |factory_name|
-          expect(policy).not_to permit(create(factory_name), file)
+      context 'when a single user authored' do
+        context 'when file creation is allowed' do
+          include_context 'when file creation is allowed'
+
+          it 'grants access to authors' do
+            expect(policy).to permit(submission.author, file)
+          end
+
+          it_behaves_like 'no other user allowed to access'
+        end
+
+        context 'when file creation is not allowed' do
+          include_context 'when file creation is not allowed'
+
+          it 'does not grant access to authors' do
+            expect(policy).not_to permit(submission.author, file)
+          end
+
+          it_behaves_like 'no other user allowed to access'
         end
       end
+
+      context 'when a programming group authored' do
+        let(:group_author) { create(:external_user) }
+        let(:other_group_author) { create(:external_user) }
+        let(:programming_group) { create(:programming_group, exercise: submission.exercise, users: [group_author, other_group_author]) }
+
+        before do
+          submission.update(contributor: programming_group)
+        end
+
+        context 'when file creation is allowed' do
+          include_context 'when file creation is allowed'
+
+          it 'grants access to authors' do
+            expect(policy).to permit(group_author, file)
+            expect(policy).to permit(other_group_author, file)
+          end
+
+          it_behaves_like 'no other user allowed to access'
+        end
+
+        context 'when file creation is not allowed' do
+          include_context 'when file creation is not allowed'
+
+          it 'does not grant access to authors' do
+            expect(policy).not_to permit(group_author, file)
+            expect(policy).not_to permit(other_group_author, file)
+          end
+
+          it_behaves_like 'no other user allowed to access'
+        end
+      end
+
+      it_behaves_like 'no other user allowed to access'
     end
   end
 

--- a/spec/policies/programming_group_policy_spec.rb
+++ b/spec/policies/programming_group_policy_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ProgrammingGroupPolicy do
+  subject(:policy) { described_class }
+
+  let(:programming_group) { build(:programming_group) }
+
+  %i[new? create?].each do |action|
+    permissions(action) do
+      it 'grants access to everyone' do
+        %i[external_user teacher admin].each do |factory_name|
+          expect(policy).to permit(create(factory_name), programming_group)
+        end
+      end
+    end
+  end
+end

--- a/spec/policies/request_for_comment_policy_spec.rb
+++ b/spec/policies/request_for_comment_policy_spec.rb
@@ -7,7 +7,7 @@ describe RequestForCommentPolicy do
 
   context 'when the RfC visibility is not considered' do
     let(:submission) { create(:submission, study_group: create(:study_group)) }
-    let(:rfc) { create(:rfc, submission:, user: submission.user) }
+    let(:rfc) { create(:rfc, submission:, user: submission.contributor) }
 
     %i[destroy? edit?].each do |action|
       permissions(action) do

--- a/spec/policies/request_for_comment_policy_spec.rb
+++ b/spec/policies/request_for_comment_policy_spec.rb
@@ -59,6 +59,12 @@ describe RequestForCommentPolicy do
       it 'grants access to authors' do
         expect(policy).to permit(rfc.author, rfc)
       end
+
+      it 'grant access to other authors of the programming group' do
+        rfc.submission.update(contributor: programming_group)
+        expect(policy).to permit(author_other_group_member, rfc)
+        expect(policy).to permit(viewer_other_group_member, rfc)
+      end
     end
 
     shared_examples 'grants access to admins and authors only' do
@@ -68,6 +74,12 @@ describe RequestForCommentPolicy do
 
       it 'grants access to authors' do
         expect(policy).to permit(rfc.author, rfc)
+      end
+
+      it 'grant access to other authors of the programming group' do
+        rfc.submission.update(contributor: programming_group)
+        expect(policy).to permit(author_other_group_member, rfc)
+        expect(policy).to permit(viewer_other_group_member, rfc)
       end
 
       it 'does not grant access to all other users' do
@@ -80,6 +92,10 @@ describe RequestForCommentPolicy do
     let(:rfc_author) { create(:learner, consumer: author_consumer, study_groups: author_study_groups) }
     let(:author_study_groups) { create_list(:study_group, 1, consumer: author_consumer) }
     let(:rfc) { create(:rfc, user: rfc_author) }
+
+    let(:author_other_group_member) { create(:external_user, consumer: author_consumer) }
+    let(:viewer_other_group_member) { create(:external_user, consumer: viewer_consumer) }
+    let(:programming_group) { create(:programming_group, exercise: rfc.submission.exercise, users: [rfc.author, author_other_group_member, viewer_other_group_member]) }
 
     context "when the author's rfc_visibility is set to all" do
       let(:author_consumer) { create(:consumer, rfc_visibility: 'all') }

--- a/spec/policies/submission_policy_spec.rb
+++ b/spec/policies/submission_policy_spec.rb
@@ -20,8 +20,8 @@ describe SubmissionPolicy do
       end
 
       it 'grants access to authors' do
-        user = create(:external_user)
-        expect(policy).to permit(user, build(:submission, exercise: Exercise.new, user_id: user.id, user_type: user.class.name))
+        contributor = create(:external_user)
+        expect(policy).to permit(contributor, build(:submission, exercise: Exercise.new, contributor:))
       end
     end
   end

--- a/spec/policies/submission_policy_spec.rb
+++ b/spec/policies/submission_policy_spec.rb
@@ -15,13 +15,23 @@ describe SubmissionPolicy do
 
   %i[download_file? render_file? run? score? show? statistics? stop? test?].each do |action|
     permissions(action) do
+      let(:exercise) { build(:math) }
+      let(:group_author) { build(:external_user) }
+      let(:other_group_author) { build(:external_user) }
+
       it 'grants access to admins' do
         expect(policy).to permit(build(:admin), Submission.new)
       end
 
       it 'grants access to authors' do
         contributor = create(:external_user)
-        expect(policy).to permit(contributor, build(:submission, exercise: Exercise.new, contributor:))
+        expect(policy).to permit(contributor, build(:submission, exercise:, contributor:))
+      end
+
+      it 'grants access to other authors of the programming group' do
+        contributor = build(:programming_group, exercise:, users: [group_author, other_group_author])
+        expect(policy).to permit(group_author, build(:submission, exercise:, contributor:))
+        expect(policy).to permit(other_group_author, build(:submission, exercise:, contributor:))
       end
     end
   end

--- a/spec/views/exercises/implement.html.slim_spec.rb
+++ b/spec/views/exercises/implement.html.slim_spec.rb
@@ -6,9 +6,12 @@ describe 'exercises/implement.html.slim' do
   let(:exercise) { create(:fibonacci) }
   let(:files) { exercise.files.visible }
   let(:non_binary_files) { files.reject {|file| file.file_type.binary? } }
+  let(:user) { create(:admin) }
 
   before do
-    allow(view).to receive(:current_user).and_return(create(:admin))
+    without_partial_double_verification do
+      allow(view).to receive_messages(current_user: user, current_contributor: user)
+    end
     assign(:exercise, exercise)
     assign(:files, files)
     assign(:paths, [])


### PR DESCRIPTION
What does this change?
* Rename user to contributor in submission
  - because submissions can now belong to a single user or to a ProgrammingGroup consisting of several users
* Add ProgrammingGroup & ProgrammigGroupMembership
  - allows you to create programming_groups by specifying the user_ids of the people you want to work with
  - you can be in one programming_group per exercise
* Add PairProgrammingStudy
  - the feature should only be used for one part of the course participants
* Send score for all members of a ProgrammingGroup
  - when one team member submits the score the score is submitted for all team members who opened the exercise once
  - it is not possible to submit the points for people who haven't opened the exercise once because we need the lti parameters

Decisions/Choices I made
* use bigint for programming_group_id instead of uuid
  - because user_id is also a bigint and it is complicated to only change it for the programming_group_id to uuid
  - we could change it in the future all together for the users and programming_groups to uuid