### PR TITLE
Further changes for pair programming

### DIFF
--- a/app/assets/javascripts/channels/synchronized_editor_channel.js
+++ b/app/assets/javascripts/channels/synchronized_editor_channel.js
@@ -24,12 +24,12 @@ $(document).on('turbolinks:load', function () {
         received(data) {
           // Called when there's incoming data on the websocket for this channel
           if (current_user_id !== data['current_user_id']) {
-            CodeOceanEditor.applyChanges(data['delta']['data']);
+            CodeOceanEditor.applyChanges(data['delta']['data'], data['active_file']);
           }
         },
 
-        send_changes(delta) {
-          const delta_with_user_id = {current_user_id: current_user_id, delta: delta}
+        send_changes(delta, active_file) {
+          const delta_with_user_id = {current_user_id: current_user_id, active_file: active_file, delta: delta}
           this.perform('send_changes', {delta_with_user_id: delta_with_user_id});
         }
       });

--- a/app/assets/javascripts/channels/synchronized_editor_channel.js
+++ b/app/assets/javascripts/channels/synchronized_editor_channel.js
@@ -23,13 +23,24 @@ $(document).on('turbolinks:load', function () {
 
         received(data) {
           // Called when there's incoming data on the websocket for this channel
-          if (current_user_id !== data['current_user_id']) {
-            CodeOceanEditor.applyChanges(data['delta']['data'], data['active_file']);
+          if (current_user_id !== data.current_user_id) {
+            switch(data.command) {
+              case 'editor_change':
+                CodeOceanEditor.applyChanges(data.delta.data, data.active_file);
+                break;
+              case 'connection_change':
+                CodeOceanEditor.showPartnersConnectionStatus(data.status, data.current_user_name);
+                this.perform('send_hello');
+                break;
+              case 'hello':
+                CodeOceanEditor.showPartnersConnectionStatus(data.status, data.current_user_name);
+                break;
+            }
           }
         },
 
         send_changes(delta, active_file) {
-          const delta_with_user_id = {current_user_id: current_user_id, active_file: active_file, delta: delta}
+          const delta_with_user_id = {command: 'editor_change', current_user_id: current_user_id, active_file: active_file, delta: delta}
           this.perform('send_changes', {delta_with_user_id: delta_with_user_id});
         }
       });

--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -1064,6 +1064,9 @@ var CodeOceanEditor = {
         this.initializeDeadlines();
         CodeOceanEditorTips.initializeEventHandlers();
 
+        window.addEventListener("turbolinks:before-render", App.synchronized_editor?.unsubscribe.bind(App.synchronized_editor));
+        window.addEventListener("beforeunload", App.synchronized_editor?.unsubscribe.bind(App.synchronized_editor));
+
         window.addEventListener("turbolinks:before-render", this.autosaveIfChanged.bind(this));
         window.addEventListener("beforeunload", this.autosaveIfChanged.bind(this));
         // create autosave when the editor is opened the first time

--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -339,7 +339,7 @@ var CodeOceanEditor = {
                     CodeOceanEditor.lastDeltaObject = null;
                     return;
                 }
-                App.synchronized_editor?.send_changes(deltaObject);
+                App.synchronized_editor?.send_changes(deltaObject, this.active_file);
 
                 // TODO: This is a workaround for a bug in Ace. Remove when upgrading Ace.
                 this.handleUTF16Surrogates(deltaObject, session);
@@ -1022,9 +1022,10 @@ var CodeOceanEditor = {
         }
     },
 
-    applyChanges: function (delta) {
+    applyChanges: function (delta, active_file) {
         this.lastDeltaObject = delta;
-        this.editors[0].session.doc.applyDeltas([delta]);
+        const editor = this.editor_for_file.get(active_file.filename)
+        editor.session.doc.applyDeltas([delta]);
     },
 
     compareDeltaObjects: function (delta, last_delta) {

--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -1044,6 +1044,17 @@ var CodeOceanEditor = {
           delta_data.text === last_delta.text;
     },
 
+    showPartnersConnectionStatus: function (status, username) {
+        switch(status) {
+            case 'connected':
+                $('#pg_session').text(I18n.t('exercises.editor.is_online', {name: username}));
+                break;
+            case 'disconnected':
+                $('#pg_session').text(I18n.t('exercises.editor.is_offline', {name: username}));
+                break;
+        }
+    },
+
     initializeEverything: function () {
         CodeOceanEditor.editors = [];
         this.initializeRegexes();

--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -382,6 +382,20 @@ var CodeOceanEditor = {
         $(document).on('click', '#results a', this.showOutput.bind(this));
         $(document).on('keydown', this.handleKeyPress.bind(this));
         $(document).on('theme:change:ace', this.handleAceThemeChangeEvent.bind(this));
+        $('#start_chat').on('click', function(event) {
+            this.createEventHandler('pp_start_chat', null)(event)
+            // Allow to open the new tab even in Safari.
+            // See: https://stackoverflow.com/a/70463940
+            setTimeout(() => {
+                var pop_up_window = window.open($('#start_chat').data('url'), '_blank');
+                if (pop_up_window) {
+                    pop_up_window.onerror = function (message) {
+                        $.flash.danger({text: message});
+                        this.sendError(message, null);
+                    };
+                }
+            })
+        }.bind(this));
         this.initializeFileTreeButtons();
         this.initializeWorkspaceButtons();
         this.initializeRequestForComments()

--- a/app/assets/javascripts/editor/submissions.js
+++ b/app/assets/javascripts/editor/submissions.js
@@ -204,6 +204,7 @@ CodeOceanEditorSubmissions = {
     this.teardownEventHandlers();
     this.createSubmission(button, null, function (response) {
       if (response.redirect) {
+        App.synchronized_editor?.unsubscribe();
         this.autosaveIfChanged();
         this.stopCode(event);
         this.editors = [];

--- a/app/assets/javascripts/editor/submissions.js
+++ b/app/assets/javascripts/editor/submissions.js
@@ -3,7 +3,7 @@ CodeOceanEditorSubmissions = {
 
   AUTOSAVE_INTERVAL: 15 * 1000,
   autosaveTimer: null,
-  autosaveLabel: "#statusbar span",
+  autosaveLabel: "#statusbar #autosave",
 
   /**
    * Submission-Creation

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -24,6 +24,7 @@ module ApplicationCable
     def find_verified_user
       # Finding the current_user is similar to the code used in application_controller.rb#current_user
       current_user = ExternalUser.find_by(id: session[:external_user_id]) || InternalUser.find_by(id: session[:user_id])
+      current_user&.store_current_study_group_id(session[:study_group_id])
       current_user || reject_unauthorized_connection
     end
 

--- a/app/channels/synchronized_editor_channel.rb
+++ b/app/channels/synchronized_editor_channel.rb
@@ -3,11 +3,13 @@
 class SynchronizedEditorChannel < ApplicationCable::Channel
   def subscribed
     stream_from specific_channel
+    ActionCable.server.broadcast(specific_channel, {command: 'connection_change', status: 'connected', current_user_id: current_user.id, current_user_name: current_user.name})
   end
 
   def unsubscribed
     # Any cleanup needed when channel is unsubscribed
     stop_all_streams
+    ActionCable.server.broadcast(specific_channel, {command: 'connection_change', status: 'disconnected', current_user_id: current_user.id, current_user_name: current_user.name})
   end
 
   def specific_channel
@@ -21,5 +23,9 @@ class SynchronizedEditorChannel < ApplicationCable::Channel
 
   def send_changes(message)
     ActionCable.server.broadcast(specific_channel, message['delta_with_user_id'])
+  end
+
+  def send_hello
+    ActionCable.server.broadcast(specific_channel, {command: 'hello', status: 'connected', current_user_id: current_user.id, current_user_name: current_user.name})
   end
 end

--- a/app/channels/synchronized_editor_channel.rb
+++ b/app/channels/synchronized_editor_channel.rb
@@ -22,7 +22,10 @@ class SynchronizedEditorChannel < ApplicationCable::Channel
   end
 
   def send_changes(message)
-    ActionCable.server.broadcast(specific_channel, message['delta_with_user_id'])
+    change = message['delta_with_user_id'].deep_symbolize_keys
+
+    Event::SynchronizedEditor.create_for_editor_change(change, current_user, programming_group)
+    ActionCable.server.broadcast(specific_channel, change)
   end
 
   def send_hello

--- a/app/controllers/concerns/redirect_behavior.rb
+++ b/app/controllers/concerns/redirect_behavior.rb
@@ -5,6 +5,13 @@ module RedirectBehavior
 
   def redirect_after_submit
     Rails.logger.debug { "Redirecting user with score:s #{@submission.normalized_score}" }
+
+    # TEMPORARY: For the pythonjunior2023 course, we want to have a lot of feedback!
+    if @submission.redirect_to_survey?
+      redirect_to_pair_programming_survey
+      return
+    end
+
     if @submission.normalized_score.to_d == BigDecimal('1.0')
       if redirect_to_community_solution?
         redirect_to_community_solution
@@ -96,6 +103,16 @@ module RedirectBehavior
     end
 
     @community_solution_lock.user == current_user
+  end
+
+  # TEMPORARY: For the pythonjunior2023 course, we introduced a pair programming survey
+  def redirect_to_pair_programming_survey
+    url = new_pair_programming_exercise_feedback_path(pair_programming_exercise_feedback: {exercise_id: @exercise.id, submission_id: @submission.id})
+
+    respond_to do |format|
+      format.html { redirect_to(url) }
+      format.json { render(json: {redirect: url}) }
+    end
   end
 
   def redirect_to_user_feedback

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 class EventsController < ApplicationController
-  def authorize!
-    authorize(@event || @events)
-  end
-  private :authorize!
+  before_action :require_user!
 
   def create
     @event = Event.new(event_params)
@@ -20,12 +17,21 @@ class EventsController < ApplicationController
     end
   end
 
+  private
+
+  def authorize!
+    authorize(@event || @events)
+  end
+
   def event_params
     # The file ID processed here is the context of the exercise (template),
     # not in the context of the submission!
     params[:event]
       &.permit(:category, :data, :exercise_id, :file_id)
-      &.merge(user: current_user)
+      &.merge(user: current_user, programming_group:, study_group_id: current_user.current_study_group_id)
   end
-  private :event_params
+
+  def programming_group
+    current_contributor if current_contributor.programming_group?
+  end
 end

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -315,6 +315,8 @@ class ExercisesController < ApplicationController
       # we are just acting on behalf of a single user who has already worked on this exercise as part of a programming group **in the context of the current study group**
       session[:pg_id] = pg.id
       @current_contributor = pg
+    elsif PairProgramming23Study.participate?(current_user, @exercise) && current_user.submissions.where(study_group_id: current_user.current_study_group_id, exercise: @exercise).any?
+      Event.create(category: 'pp_work_alone', user: current_user, exercise: @exercise, data: nil, file_id: nil)
     end
 
     user_solved_exercise = @exercise.solved_by?(current_contributor)

--- a/app/controllers/pair_programming_exercise_feedbacks_controller.rb
+++ b/app/controllers/pair_programming_exercise_feedbacks_controller.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+class PairProgrammingExerciseFeedbacksController < ApplicationController
+  include CommonBehavior
+  include RedirectBehavior
+
+  before_action :set_presets, only: %i[new create]
+
+  def comment_presets
+    [[0, t('pair_programming_exercise_feedback.difficulty_easy')],
+     [1, t('pair_programming_exercise_feedback.difficulty_some_what_easy')],
+     [2, t('pair_programming_exercise_feedback.difficulty_ok')],
+     [3, t('pair_programming_exercise_feedback.difficulty_some_what_difficult')],
+     [4, t('pair_programming_exercise_feedback.difficult_too_difficult')]]
+  end
+
+  def time_presets
+    [[0, t('pair_programming_exercise_feedback.estimated_time_less_5')],
+     [1, t('pair_programming_exercise_feedback.estimated_time_5_to_10')],
+     [2, t('pair_programming_exercise_feedback.estimated_time_10_to_20')],
+     [3, t('pair_programming_exercise_feedback.estimated_time_20_to_30')],
+     [4, t('pair_programming_exercise_feedback.estimated_time_more_30')]]
+  end
+
+  def new
+    exercise_id = if params[:pair_programming_exercise_feedback].nil?
+                    params[:exercise_id]
+                  else
+                    params[:pair_programming_exercise_feedback][:exercise_id]
+                  end
+    @exercise = Exercise.find(exercise_id)
+
+    @submission = Submission.find(params[:pair_programming_exercise_feedback][:submission_id])
+    authorize(@submission, :show?)
+
+    @uef = PairProgrammingExerciseFeedback.new(user: current_user, exercise: @exercise, programming_group:, submission: @submission)
+    authorize!
+  end
+
+  def create
+    Sentry.set_extras(params: uef_params)
+
+    @exercise = Exercise.find(uef_params[:exercise_id])
+
+    if @exercise
+      @uef = PairProgrammingExerciseFeedback.new(exercise: @exercise, programming_group:, study_group_id: current_user.current_study_group_id)
+      @uef.update(uef_params)
+      authorize!
+      if validate_inputs(uef_params) && @uef.save
+        redirect_after_submit
+      else
+        flash.now[:danger] = t('shared.message_failure')
+        redirect_back fallback_location: pair_programming_exercise_feedback_path(@uef)
+      end
+    end
+  end
+
+  private
+
+  def authorize!
+    authorize(@uef || @uefs)
+  end
+
+  def set_presets
+    @texts = comment_presets.to_a
+    @times = time_presets.to_a
+  end
+
+  def uef_params
+    return if params[:pair_programming_exercise_feedback].blank?
+
+    @submission = Submission.find(params[:pair_programming_exercise_feedback][:submission_id])
+
+    authorize(@submission, :show?)
+
+    params[:pair_programming_exercise_feedback]
+      .permit(:difficulty, :user_estimated_worktime, :exercise_id)
+      .merge(user: current_user,
+        submission: @submission,
+        normalized_score: @submission&.normalized_score)
+  end
+
+  def validate_inputs(uef_params)
+    if uef_params[:difficulty].to_i.negative? || uef_params[:difficulty].to_i >= comment_presets.size
+      false
+    else
+      !(uef_params[:user_estimated_worktime].to_i.negative? || uef_params[:user_estimated_worktime].to_i >= time_presets.size)
+    end
+  rescue StandardError
+    false
+  end
+
+  def programming_group
+    current_contributor if current_contributor.programming_group?
+  end
+end

--- a/app/controllers/programming_groups_controller.rb
+++ b/app/controllers/programming_groups_controller.rb
@@ -7,6 +7,7 @@ class ProgrammingGroupsController < ApplicationController
   before_action :set_exercise_and_authorize
 
   def new
+    Event.create(category: 'page_visit', user: current_user, exercise: @exercise, data: 'programming_groups_new', file_id: nil)
     if current_user.submissions.where(exercise: @exercise, study_group_id: current_user.current_study_group_id).any?
       # A learner has worked on this exercise **alone** in the context of the **current study group**, so we redirect them to their progress.
       redirect_to_exercise
@@ -34,6 +35,10 @@ class ProgrammingGroupsController < ApplicationController
 
     unless programming_partner_ids.include? current_user.id_with_type
       @programming_group.add(current_user)
+    end
+
+    unless @programming_group.valid?
+      Event.create(category: 'pp_invalid_partners', user: current_user, exercise: @exercise, data: programming_group_params[:programming_partner_ids], file_id: nil)
     end
 
     create_and_respond(object: @programming_group, path: proc { implement_exercise_path(@exercise) }) do

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,7 +22,7 @@ class SessionsController < ApplicationController
     store_nonce(params[:oauth_nonce])
     if params[:custom_redirect_target]
       redirect_to(URI.parse(params[:custom_redirect_target].to_s).path)
-    elsif PairProgramming23Study.participate?
+    elsif PairProgramming23Study.participate?(current_user, @exercise)
       redirect_to(new_exercise_programming_group_path(@exercise))
     else
       redirect_to(implement_exercise_path(@exercise),

--- a/app/models/code_ocean/file.rb
+++ b/app/models/code_ocean/file.rb
@@ -32,6 +32,7 @@ module CodeOcean
     has_many :files, class_name: 'CodeOcean::File'
     has_many :testruns
     has_many :comments
+    has_many :events_synchronized_editor, class_name: 'Event::SynchronizedEditor'
     alias descendants files
 
     mount_uploader :native_file, FileUploader

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,8 +3,19 @@
 class Event < ApplicationRecord
   include Creation
   belongs_to :exercise
-  belongs_to :file, class_name: 'CodeOcean::File'
+  belongs_to :file, class_name: 'CodeOcean::File', optional: true
+  belongs_to :study_group, optional: true
+  belongs_to :programming_group, optional: true
 
   validates :category, presence: true
-  validates :data, presence: true
+
+  # We temporary allow an event to be stored without data.
+  # This is useful if the category (together with the user and exercise) is already enough.
+  validates :data, presence: true, if: -> { %w[pp_start_chat pp_invalid_partners pp_work_alone].exclude?(category) }
+
+  before_validation :data_presence
+
+  def data_presence
+    self.data = data.presence
+  end
 end

--- a/app/models/event/synchronized_editor.rb
+++ b/app/models/event/synchronized_editor.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+class Event::SynchronizedEditor < ApplicationRecord
+  self.table_name = 'events_synchronized_editor'
+
+  include Creation
+
+  belongs_to :programming_group
+  belongs_to :study_group
+  belongs_to :file, class_name: 'CodeOcean::File'
+
+  enum command: {
+    editor_change: 0,
+    connection_change: 1,
+    hello: 2,
+    ### TODO: Kira's commands
+  }, _prefix: true
+
+  enum status: {
+    connected: 0,
+    disconnected: 1,
+    ### TODO: connected, disconnected ...
+  }, _prefix: true
+
+  enum action: {
+    insertText: 0,
+    insertLines: 1,
+    removeText: 2,
+    removeLines: 3,
+    changeFold: 4,
+    removeFold: 5,
+    ### TODO: AceEditor Actions: insertText, insertLines, removeText, removesLines, ...
+  }, _prefix: true
+
+  validates :status, presence: true, if: -> { command_connection_change? }
+  validates :action, presence: true, if: -> { command_editor_change? }
+  validates :range_start_row, numericality: {only_integer: true, greater_than_or_equal_to: 0}, if: -> { command_editor_change? }
+  validates :range_start_column, numericality: {only_integer: true, greater_than_or_equal_to: 0}, if: -> { command_editor_change? }
+  validates :range_end_row, numericality: {only_integer: true, greater_than_or_equal_to: 0}, if: -> { command_editor_change? }
+  validates :range_end_column, numericality: {only_integer: true, greater_than_or_equal_to: 0}, if: -> { command_editor_change? }
+  validates :nl, inclusion: {in: %W[\n \r\n]}, if: -> { action_removeLines? }
+
+  validate :either_lines_or_text
+
+  def self.create_for_editor_change(event, user, programming_group)
+    event_copy = event.deep_dup
+    file = event_copy.delete(:active_file)
+    delta = event_copy.delete(:delta)[:data]
+    range = delta.delete(:range)
+
+    create!(
+      user:,
+      programming_group:,
+      study_group_id: user.current_study_group_id,
+      command: event_copy.delete(:command),
+      action: delta.delete(:action),
+      file_id: file[:id],
+      range_start_row: range[:start][:row],
+      range_start_column: range[:start][:column],
+      range_end_row: range[:end][:row],
+      range_end_column: range[:end][:column],
+      text: delta.delete(:text),
+      nl: delta.delete(:nl),
+      lines: delta.delete(:lines),
+      data: data_attribute(event_copy, delta)
+    )
+  end
+
+  def self.data_attribute(event, delta)
+    event[:delta] = {data: delta} if delta.present?
+    event.presence if event.present? # TODO: As of now, we are storing the `current_user_id` most of the times. Intended?
+  end
+  private_class_method :data_attribute
+
+  private
+
+  def strip_strings
+    # trim whitespace from beginning and end of string attributes
+    # except the `text` and `nl` of Event::SynchronizedEditor
+    attribute_names.without('text', 'nl').each do |name|
+      if send(name.to_sym).respond_to?(:strip)
+        send("#{name}=".to_sym, send(name).strip)
+      end
+    end
+  end
+
+  def either_lines_or_text
+    if [lines, text].count(&:present?) > 1
+      errors.add(:text, "can't be present if lines is also present")
+    end
+  end
+end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -25,6 +25,7 @@ class Exercise < ApplicationRecord
   has_many :tags, through: :exercise_tags
   accepts_nested_attributes_for :exercise_tags
   has_many :user_exercise_feedbacks
+  has_many :pair_programming_exercise_feedbacks
   has_many :exercise_tips
   has_many :tips, through: :exercise_tips
 
@@ -590,6 +591,8 @@ class Exercise < ApplicationRecord
   private :valid_submission_deadlines?
 
   def needs_more_feedback?(submission)
+    return false if PairProgramming23Study.experiment_course?(submission.study_group_id)
+
     if submission.normalized_score.to_d == BigDecimal('1.0')
       user_exercise_feedbacks.final.size <= MAX_GROUP_EXERCISE_FEEDBACKS
     else

--- a/app/models/pair_programming_exercise_feedback.rb
+++ b/app/models/pair_programming_exercise_feedback.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class PairProgrammingExerciseFeedback < ApplicationRecord
+  include Creation
+
+  belongs_to :exercise
+  belongs_to :submission
+  belongs_to :study_group
+  belongs_to :programming_group, optional: true
+  has_one :execution_environment, through: :exercise
+
+  scope :intermediate, -> { where.not(normalized_score: 1.00) }
+  scope :final, -> { where(normalized_score: 1.00) }
+
+  def to_s
+    'Pair Programming Exercise Feedback'
+  end
+end

--- a/app/models/programming_group.rb
+++ b/app/models/programming_group.rb
@@ -11,7 +11,8 @@ class ProgrammingGroup < ApplicationRecord
   has_many :runners, as: :contributor, dependent: :destroy
   belongs_to :exercise
 
-  validate :group_size
+  validate :min_group_size
+  validate :max_group_size
   validate :no_erroneous_users
   accepts_nested_attributes_for :programming_group_memberships
 
@@ -71,9 +72,15 @@ class ProgrammingGroup < ApplicationRecord
 
   private
 
-  def group_size
+  def min_group_size
     if users.size < 2
       errors.add(:base, :size_too_small)
+    end
+  end
+
+  def max_group_size
+    if users.size > 2
+      errors.add(:base, :size_too_large)
     end
   end
 

--- a/app/models/programming_group.rb
+++ b/app/models/programming_group.rb
@@ -11,6 +11,7 @@ class ProgrammingGroup < ApplicationRecord
   has_many :runners, as: :contributor, dependent: :destroy
   has_many :events
   has_many :events_synchronized_editor, class_name: 'Event::SynchronizedEditor'
+  has_many :pair_programming_exercise_feedbacks
   belongs_to :exercise
 
   validate :min_group_size

--- a/app/models/programming_group.rb
+++ b/app/models/programming_group.rb
@@ -9,6 +9,8 @@ class ProgrammingGroup < ApplicationRecord
   has_many :internal_users, through: :programming_group_memberships, source_type: 'InternalUser', source: :user
   has_many :testruns, through: :submissions
   has_many :runners, as: :contributor, dependent: :destroy
+  has_many :events
+  has_many :events_synchronized_editor, class_name: 'Event::SynchronizedEditor'
   belongs_to :exercise
 
   validate :min_group_size

--- a/app/models/study_group.rb
+++ b/app/models/study_group.rb
@@ -11,6 +11,7 @@ class StudyGroup < ApplicationRecord
   has_many :lti_parameters, dependent: :delete_all
   has_many :events
   has_many :events_synchronized_editor, class_name: 'Event::SynchronizedEditor'
+  has_many :pair_programming_exercise_feedbacks
   belongs_to :consumer
 
   def users

--- a/app/models/study_group.rb
+++ b/app/models/study_group.rb
@@ -9,6 +9,8 @@ class StudyGroup < ApplicationRecord
   has_many :subscriptions, dependent: :nullify
   has_many :authentication_tokens, dependent: :nullify
   has_many :lti_parameters, dependent: :delete_all
+  has_many :events
+  has_many :events_synchronized_editor, class_name: 'Event::SynchronizedEditor'
   belongs_to :consumer
 
   def users

--- a/app/policies/pair_programming_exercise_feedback_policy.rb
+++ b/app/policies/pair_programming_exercise_feedback_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class PairProgrammingExerciseFeedbackPolicy < AdminOnlyPolicy
+  def create?
+    everyone
+  end
+
+  def new?
+    everyone
+  end
+end

--- a/app/views/exercises/_editor.html.slim
+++ b/app/views/exercises/_editor.html.slim
@@ -39,6 +39,9 @@
             = t('exercises.editor.download')
 
       div
+        - if current_contributor.programming_group?
+          = t('exercises.editor.pair_programming_session')
+          = " | "
         = t('exercises.editor.lastsaved')
         span
         button style="display:none" id="autosave"

--- a/app/views/exercises/_editor.html.slim
+++ b/app/views/exercises/_editor.html.slim
@@ -4,7 +4,7 @@
 - show_tips_interventions = @show_tips_interventions || "false"
 - hide_rfc_button = @hide_rfc_button || false
 
-#editor.row data-exercise-id=@exercise.id data-message-depleted=t('exercises.editor.depleted') data-message-timeout=t('exercises.editor.timeout',  permitted_execution_time: @exercise.execution_environment.permitted_execution_time) data-message-out-of-memory=t('exercises.editor.out_of_memory',  memory_limit: @exercise.execution_environment.memory_limit) data-submissions-url=submissions_path data-user-id=current_user.id data-contributor-id=current_contributor.id data-user-external-id=external_user_external_id data-working-times-url=working_times_exercise_path(@exercise) data-intervention-save-url=intervention_exercise_path(@exercise) data-rfc-interventions=show_rfc_interventions data-break-interventions=show_break_interventions data-tips-interventions=show_tips_interventions
+#editor.row data-exercise-id=@exercise.id data-message-depleted=t('exercises.editor.depleted') data-message-timeout=t('exercises.editor.timeout',  permitted_execution_time: @exercise.execution_environment.permitted_execution_time) data-message-out-of-memory=t('exercises.editor.out_of_memory',  memory_limit: @exercise.execution_environment.memory_limit) data-submissions-url=submissions_path data-user-id=current_user.id data-user-name=current_user.name data-contributor-id=current_contributor.id data-user-external-id=external_user_external_id data-working-times-url=working_times_exercise_path(@exercise) data-intervention-save-url=intervention_exercise_path(@exercise) data-rfc-interventions=show_rfc_interventions data-break-interventions=show_break_interventions data-tips-interventions=show_tips_interventions
   - unless @embed_options[:hide_sidebar]
     - additional_classes = 'sidebar-col'
     - if @tips.blank?
@@ -39,12 +39,22 @@
             = t('exercises.editor.download')
 
       div
+        ruby:
+          if current_contributor.programming_group?
+            current_contributor.users.each do |user|
+              if user.id != current_user.id
+                @programming_partners_name = user.name
+              end
+            end
+          end
         - if current_contributor.programming_group?
+          span#pg_session
+            = t('exercises.editor.is_offline', name: @programming_partners_name)
+          = " | "
           = t('exercises.editor.pair_programming_session')
           = " | "
         = t('exercises.editor.lastsaved')
-        span
-        button style="display:none" id="autosave"
+        span id="autosave"
 
         = " | "
 

--- a/app/views/exercises/implement.html.slim
+++ b/app/views/exercises/implement.html.slim
@@ -6,12 +6,19 @@
 #editor-column
   - unless @embed_options[:hide_exercise_description]
     .exercise.clearfix
-      div
-        span.badge.rounded-pill.bg-primary.float-end.score
+      div.col-3.float-end
+        span.badge.rounded-pill.bg-primary.float-end.mt-2.score
+        - if current_contributor.programming_group?
+            a.btn.btn-sm.btn-primary.me-3.mt-1(href='https://jitsi.fem.tu-ilmenau.de/openHPI_ProgrammingGroup#{current_contributor.id}', target='_blank')
+              i.fa-solid.fa-video
+              span = t('exercises.editor.start_video')
 
-        h1 id="exercise-headline"
-          i id="description-symbol" class=(@embed_options[:collapse_exercise_description] ? 'fa-solid fa-chevron-right' : 'fa-solid fa-chevron-down')
-          = @exercise.title
+            div.small.text-body-tertiary.mt-1
+              == t('exercises.implement.external_privacy_policy', url:'https://www.tu-ilmenau.de/datenschutz')
+
+      h1 id="exercise-headline"
+        i id="description-symbol" class=(@embed_options[:collapse_exercise_description] ? 'fa-solid fa-chevron-right' : 'fa-solid fa-chevron-down')
+        = @exercise.title
 
       #description-card.lead class=(@embed_options[:collapse_exercise_description] ? 'description-card-collapsed' : 'description-card')
         = render_markdown(@exercise.description)

--- a/app/views/exercises/implement.html.slim
+++ b/app/views/exercises/implement.html.slim
@@ -23,6 +23,10 @@
       #description-card.lead class=(@embed_options[:collapse_exercise_description] ? 'description-card-collapsed' : 'description-card')
         = render_markdown(@exercise.description)
 
+      - if current_contributor.programming_group?
+        .small.text-body-tertiary
+          == t('exercises.implement.pair_programming_feedback', url: 'https://etherpad.xopic.de/p/openHPI_PairProgrammingFeedback')
+
       a#toggle href="#" data-show=t('shared.show') data-hide=t('shared.hide')
         - if @embed_options[:collapse_exercise_description]
           = t('shared.show')

--- a/app/views/exercises/implement.html.slim
+++ b/app/views/exercises/implement.html.slim
@@ -9,12 +9,13 @@
       div.col-3.float-end
         span.badge.rounded-pill.bg-primary.float-end.mt-2.score
         - if current_contributor.programming_group?
-            a.btn.btn-sm.btn-primary.me-3.mt-1(href='https://jitsi.fem.tu-ilmenau.de/openHPI_ProgrammingGroup#{current_contributor.id}', target='_blank')
-              i.fa-solid.fa-video
-              span = t('exercises.editor.start_video')
+          button.btn.btn-sm.btn-primary.me-3.mt-1#start_chat  data= {url: "https://jitsi.fem.tu-ilmenau.de/openHPI_ProgrammingGroup#{current_contributor.id}"}
+            i.fa-solid.fa-video
 
-            div.small.text-body-tertiary.mt-1
-              == t('exercises.implement.external_privacy_policy', url:'https://www.tu-ilmenau.de/datenschutz')
+            span = t('exercises.editor.start_video')
+
+          div.small.text-body-tertiary.mt-1
+            == t('exercises.implement.external_privacy_policy', url:'https://www.tu-ilmenau.de/datenschutz')
 
       h1 id="exercise-headline"
         i id="description-symbol" class=(@embed_options[:collapse_exercise_description] ? 'fa-solid fa-chevron-right' : 'fa-solid fa-chevron-down')

--- a/app/views/pair_programming_exercise_feedbacks/_form.html.slim
+++ b/app/views/pair_programming_exercise_feedbacks/_form.html.slim
@@ -1,0 +1,22 @@
+= form_for(@uef) do |f|
+  div
+    h1 id="exercise-headline"
+      = t('activerecord.models.user_exercise_feedback.one') + " " + @exercise.title
+  = render('shared/form_errors', object: @uef)
+  p
+    == t('pair_programming_exercise_feedback.description')
+  .mb-3
+    h5.mt-4 = t('pair_programming_exercise_feedback.difficulty')
+    = f.collection_radio_buttons :difficulty, @texts, :first, :last  do |b|
+      .form-check
+        label.form-check-label
+          = b.radio_button(class: 'form-check-input')
+          = b.text
+    h5.mt-4 = t('pair_programming_exercise_feedback.working_time')
+    = f.collection_radio_buttons :user_estimated_worktime, @times, :first, :last  do |b|
+      .form-check
+        label.form-check-label
+          = b.radio_button(class: 'form-check-input')
+          = b.text
+    = f.hidden_field(:exercise_id, :value => @exercise.id)
+  .actions = render('shared/submit_button', f: f, object: @uef)

--- a/app/views/pair_programming_exercise_feedbacks/new.html.slim
+++ b/app/views/pair_programming_exercise_feedbacks/new.html.slim
@@ -1,0 +1,1 @@
+= render('form')

--- a/app/views/programming_groups/_form.html.slim
+++ b/app/views/programming_groups/_form.html.slim
@@ -1,7 +1,7 @@
 = form_for(@programming_group, url: exercise_programming_groups_path) do |f|
   = render('shared/form_errors', object: @programming_group)
   .mb-3
-    = f.label(:programming_partner_ids, class: 'form-label')
+    = f.label(:programming_partner_id, class: 'form-label')
     = f.text_field(:programming_partner_ids, class: 'form-control', required: true, value: (@programming_group.programming_partner_ids - [current_user.id_with_type]).join(', '))
-    .help-block.form-text = t('.hints.programming_partner_ids')
+    /.help-block.form-text = t('.hints.programming_partner_ids')
   .actions.mb-0 = render('shared/submit_button', f: f, object: @programming_group)

--- a/app/views/programming_groups/new.html.slim
+++ b/app/views/programming_groups/new.html.slim
@@ -1,4 +1,4 @@
-h1 = t('shared.new_model', model: ProgrammingGroup.model_name.human)
+h1 = t('programming_groups.new.create_programming_pair')
 .row
   .col-md-6
     p

--- a/app/views/programming_groups/new.html.slim
+++ b/app/views/programming_groups/new.html.slim
@@ -1,14 +1,22 @@
 h1 = t('shared.new_model', model: ProgrammingGroup.model_name.human)
-p
-  => t('programming_groups.new.own_user_id')
-  b
-    = current_user.id_with_type
-p
-  = t('programming_groups.new.enter_partner_id', exercise_title: @exercise.title)
-= render('form')
+.row
+  .col-md-6
+    p
+      => t('programming_groups.new.own_user_id')
+      b
+        = current_user.id_with_type
+    p
+      = t('programming_groups.new.enter_partner_id', exercise_title: @exercise.title)
+    = render('form')
 
-div.mt-4
-  a.btn.btn-success href=new_exercise_programming_group_path(@exercise) == t('programming_groups.new.check_invitation')
+    div.mt-4
+      a.btn.btn-success href=new_exercise_programming_group_path(@exercise) == t('programming_groups.new.check_invitation')
 
-  p.mt-4
-    == t('programming_groups.new.work_alone', path: implement_exercise_path(@exercise))
+      p.mt-4
+        == t('programming_groups.new.work_alone', path: implement_exercise_path(@exercise))
+
+  .col-md-6
+    h5 = t('programming_groups.new.find_partner_title')
+    p
+      = t('programming_groups.new.find_partner_description')
+    iframe name="embed_readwrite" src="https://etherpad.xopic.de/p/find_programming_group_for_exercise_#{@exercise.id}?showControls=true&showChat=true&showLineNumbers=true&useMonospaceFont=false" width="100%" height="300" style='border: 1px solid black;'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -229,6 +229,9 @@ de:
       internal_user:
         one: Interner Nutzer
         other: Interne Nutzer
+      pair_programming_exercise_feedback:
+        one: Feedback
+        other: Feedbacks
       programming_group:
         one: Programmiergruppe
         other: Programmiergruppen
@@ -975,6 +978,21 @@ de:
     previous_label: '&#8592; Vorherige Seite'
   file_template:
     no_template_label: "Leere Datei"
+  pair_programming_exercise_feedback:
+    difficulty_easy: "Die Aufgabe war viel zu einfach."
+    difficulty_some_what_easy: "Die Aufgabe war etwas zu einfach."
+    difficulty_ok: "Die Aufgabenschwierigkeit war genau richtig."
+    difficulty_some_what_difficult: "Die Aufgabe war etwas zu schwierig."
+    difficult_too_difficult: "Die Aufgabe war viel zu schwierig."
+    difficulty: "Schwierigkeit der Aufgabe:"
+    description: "Vielen Dank für Deine Abgabe! Bevor du die Aufgabe beendest, würden wir uns freuen, wenn Du uns hier Feedback zur Aufgabe gibst."
+    estimated_time_less_5: "weniger als 5 Minuten"
+    estimated_time_5_to_10: "zwischen 5 und 10 Minuten"
+    estimated_time_10_to_20: "zwischen 10 und 20 Minuten"
+    estimated_time_20_to_30: "zwischen 20 und 30 Minuten"
+    estimated_time_more_30: "mehr als 30 Minuten"
+    working_time: "Geschätze Bearbeitungszeit für diese Aufgabe:"
+    no_feedback: "Es wurde noch kein Feedback zu dieser Aufgabe gegeben."
   user_exercise_feedback:
     difficulty_easy: "Die Aufgabe war zu einfach"
     difficulty_some_what_easy: "Die Aufgabe war etwas zu einfach"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -398,6 +398,7 @@ de:
       send: Senden
       start_over: Diese Aufgabe zurücksetzen
       start_over_active_file: Diese Datei zurücksetzen
+      start_video: Videochat starten
       stop: Stoppen
       submit: Code zur Bewertung abgeben
       deadline: Deadline
@@ -467,6 +468,7 @@ de:
       default_linter_feedback: Sehr gut. Der Linter hat nichts mehr zu beanstanden.
       error_messages: Fehlermeldungen
       existing_programming_group: Sie arbeiten gerade an der Übung mit dem Titel '%{exercise}' als Teil einer Programmiergruppe. Bitte schließen Sie Ihre Arbeit dort ab, indem Sie Ihren Code bewerten und abgeben, bevor Sie mit der Bearbeitung dieser Übung beginnen.
+      external_privacy_policy: Durch Nutzung des Videochats stimmen Sie der <a href=%{url}>externen Datenschutzerklärung</a> zu.
       messages: Meldungen
       feedback: Feedback
       test_file: 'Test-Datei <span class="number">%{number}</span> (<span class="filename">%{filename}</span>)'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -57,7 +57,7 @@ de:
         uuid: UUID
         unpublished: Deaktiviert
       programming_group:
-        programming_partner_ids: Nutzer-IDs der Programmierpartner
+        programming_partner_id: Nutzer-ID der Programmierpartnerin / des Programmierpartners
       programming_group/programming_group_memberships:
         base: Programmiergruppenmitgliedschaft
       proxy_exercise:
@@ -270,7 +270,8 @@ de:
             password:
               weak: ist zu schwach. Versuchen Sie es mit einem  langen Passwort, welches Groß-, Kleinbuchstaben, Zahlen und Sonderzeichen enthält.
         programming_group:
-          size_too_small: Die Größe dieser Programmiergruppe ist zu klein. Geben Sie mindestens eine andere Nutzer-ID an.
+          size_too_large: Die Größe dieser Programmiergruppe ist zu groß. Geben Sie nur eine andere Nutzer-ID an.
+          size_too_small: Die Größe dieser Programmiergruppe ist zu klein. Geben Sie eine andere Nutzer-ID an.
           invalid_partner_id: Die Nutzer-ID '%{partner_id}' ist ungültig und wurde entfernt. Bitte überprüfen Sie die Nutzer-IDs der Programmierpartner.
         programming_group_membership:
           already_exists: 'existiert bereits für diese Aufgabe für den Nutzer mit der ID %{id_with_type}.'
@@ -589,12 +590,13 @@ de:
       hints:
         programming_partner_ids: "Sie können mehrere Nutzer-IDs mit Kommata getrennt eingeben, wie z.B.: 'e123, e234'."
     new:
+      create_programming_pair: Programmierpaar erstellen
       check_invitation: "Einladung prüfen"
-      enter_partner_id: "Bitte geben Sie hier die Nutzer-IDs der Personen ein, mit denen Sie zusammen die Aufgabe '%{exercise_title}' lösen möchten. Beachten Sie jedoch, dass anschließend keiner aus der Gruppe austreten kann. Alle Teammitglieder können also sehen, was Sie in dieser Aufgabe schreiben und umgekehrt. Für die nächste Aufgabe können Sie sich erneuert entscheiden, ob und mit wem Sie zusammen arbeiten möchten."
-      find_partner_title: "Finde einen Programmierpartner für die Aufgabe"
-      find_partner_description: "Kopiere eine andere Nutzer-ID aus der Liste unten und lösche sie anschließend. Wenn noch keine Nutzer-IDs in der Liste vorhanden sind, fügen Sie Ihre Nutzer-ID hinzu und warten Sie, bis ein anderer Nutzer eine Programmiergruppe mit Ihnen erstellt. Dies können Sie mit dem Knopf 'Einladung prüfen' testen. Wenn Sie allein arbeiten möchten, löschen Sie bitte Ihre Nutzer-ID aus der Liste."
-      own_user_id: "Ihre Nutzer-ID:"
-      work_alone: "Sie können sich einmalig dafür entscheiden, die Aufgabe alleine zu bearbeiten. Anschließend können Sie jedoch nicht mehr in die Gruppenarbeit für diese Aufgabe wechseln. Klicken Sie <a href=%{path})>hier</a>, um die Aufgabe im Einzelmodus zu starten."
+      enter_partner_id: "Bitte gib hier die Nutzer-ID der Person ein, mit der du zusammen die Aufgabe '%{exercise_title}' lösen möchtest. Beachte jedoch, dass anschließend keiner die Zusammenarbeit beenden kann. Dein:e Teampartner:in kann sehen, was du in dieser Aufgabe schreibst und umgekehrt. Für die nächste Aufgabe kannst du dich erneuert entscheiden, ob und mit wem du zusammen arbeiten möchtest."
+      find_partner_title: "Finde eine:n Programmierpartner:in für die Aufgabe"
+      find_partner_description: "Kopiere eine andere Nutzer-ID aus der Liste unten und lösche sie anschließend. Wenn noch keine Nutzer-IDs in der Liste vorhanden sind, füge deine Nutzer-ID hinzu und warte, bis ein andere:r Nutzer:in ein Programmierpaar mit dir erstellt. Dies kannst du mit dem Knopf 'Einladung prüfen' testen. Wenn du allein arbeiten möchtest, lösche bitte deine Nutzer-ID aus der Liste, falls du sie hinzugefügt hast."
+      own_user_id: "Deine Nutzer-ID:"
+      work_alone: "Du kannst dich einmalig dafür entscheiden, die Aufgabe alleine zu bearbeiten. Anschließend kannst du jedoch nicht mehr in die Partnerarbeit für diese Aufgabe wechseln. <a href=%{path})>Klicke hier, um die Aufgabe im Einzelmodus zu starten.</a>"
   external_users:
     statistics:
       title: Statistiken für Externe Benutzer

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -385,6 +385,8 @@ de:
       expand_action_sidebar: Aktions-Leiste Ausklappen
       expand_output_sidebar: Ausgabe-Leiste Ausklappen
       input: Ihre Eingabe
+      is_offline: "%{name} ist offline"
+      is_online: "%{name} ist online"
       lastsaved: 'Zuletzt gespeichert: '
       network: 'Während Ihr Code läuft, ist Port %{port} unter folgender Adresse erreichbar: <a href="%{address}" target="_blank" rel="noopener">%{address}</a>.'
       pair_programming_session: Pair Programming Session

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -487,6 +487,7 @@ de:
       exit_failure: Die letzte Code-Ausführung wurde mit einem Fehler beendet (Statuscode %{exit_code}).
       no_output_yet: Bisher existiert noch keine Ausgabe.
       output: Programm-Ausgabe
+      pair_programming_feedback: Falls dir Probleme bei der Zusammenarbeit auffallen, kannst du diese gerne <a target='_blank', href=%{url}>hier aufschreiben</a>. Vielen Dank!"
       passed_tests: Erfolgreiche Tests
       code_rating: Code-Stil
       progress: Fortschritt

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -386,6 +386,7 @@ de:
       input: Ihre Eingabe
       lastsaved: 'Zuletzt gespeichert: '
       network: 'Während Ihr Code läuft, ist Port %{port} unter folgender Adresse erreichbar: <a href="%{address}" target="_blank" rel="noopener">%{address}</a>.'
+      pair_programming_session: Pair Programming Session
       render: Anzeigen
       run: Ausführen
       run_failure: Ihr Code konnte nicht auf der Plattform ausgeführt werden.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -591,6 +591,8 @@ de:
     new:
       check_invitation: "Einladung prüfen"
       enter_partner_id: "Bitte geben Sie hier die Nutzer-IDs der Personen ein, mit denen Sie zusammen die Aufgabe '%{exercise_title}' lösen möchten. Beachten Sie jedoch, dass anschließend keiner aus der Gruppe austreten kann. Alle Teammitglieder können also sehen, was Sie in dieser Aufgabe schreiben und umgekehrt. Für die nächste Aufgabe können Sie sich erneuert entscheiden, ob und mit wem Sie zusammen arbeiten möchten."
+      find_partner_title: "Finde einen Programmierpartner für die Aufgabe"
+      find_partner_description: "Kopiere eine andere Nutzer-ID aus der Liste unten und lösche sie anschließend. Wenn noch keine Nutzer-IDs in der Liste vorhanden sind, fügen Sie Ihre Nutzer-ID hinzu und warten Sie, bis ein anderer Nutzer eine Programmiergruppe mit Ihnen erstellt. Dies können Sie mit dem Knopf 'Einladung prüfen' testen. Wenn Sie allein arbeiten möchten, löschen Sie bitte Ihre Nutzer-ID aus der Liste."
       own_user_id: "Ihre Nutzer-ID:"
       work_alone: "Sie können sich einmalig dafür entscheiden, die Aufgabe alleine zu bearbeiten. Anschließend können Sie jedoch nicht mehr in die Gruppenarbeit für diese Aufgabe wechseln. Klicken Sie <a href=%{path})>hier</a>, um die Aufgabe im Einzelmodus zu starten."
   external_users:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -591,6 +591,8 @@ en:
     new:
       check_invitation: "Check invitation"
       enter_partner_id: "Please enter the user IDs from the practice partners with whom you want to solve the exercise '%{exercise_title}'. However, note that no one can leave the group afterward. Hence, all team members can see what you write in this exercise and vice versa. For the next exercise, you can decide again whether and with whom you want to work together."
+      find_partner_title: "Find a programming partner for the exercise"
+      find_partner_description: "Copy another user ID from the list below and delete it afterward. If there are no user IDs on the list yet, add your user ID and wait for another user to create a programming group with you. You can test this with the 'Check invitation' button. If you decide to work alone, please delete your user ID from the list."
       own_user_id: "Your user ID:"
       work_alone: "You can choose once to work on the exercise alone. Afterward, however, you will not be able to switch to group work for this exercise. Click <a href=%{path}>here</a> to get to the exercise in single mode."
   external_users:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -229,6 +229,9 @@ en:
       internal_user:
         one: Internal User
         other: Internal Users
+      pair_programming_exercise_feedback:
+        one: Feedback
+        other: Feedbacks
       programming_group:
         one: Programming Group
         other: Programming Groups
@@ -975,6 +978,21 @@ en:
     previous_label: '&#8592; Previous Page'
   file_template:
     no_template_label: "Empty File"
+  pair_programming_exercise_feedback:
+    difficulty_easy: "The exercise was far too easy."
+    difficulty_some_what_easy: "The exercise was a bit too easy."
+    difficulty_ok: "The exercise difficulty was just right."
+    difficulty_some_what_difficult: "The exercise was a bit too difficult."
+    difficult_too_difficult: "The exercise was far too difficult."
+    difficulty: "Difficulty of the exercise:"
+    description: "Thank you for your submission! Before you finish the task, we kindly ask you for feedback for this exercise."
+    estimated_time_less_5: "less than 5 minutes"
+    estimated_time_5_to_10: "between 5 and 10 minutes"
+    estimated_time_10_to_20: "between 10 and 20 minutes"
+    estimated_time_20_to_30: "between 20 and 30 minutes"
+    estimated_time_more_30: "more than 30 minutes"
+    working_time: "Estimated time working on this exercise:"
+    no_feedback: "There is no feedback for this exercise yet."
   user_exercise_feedback:
     difficulty_easy: "the exercise was too easy"
     difficulty_some_what_easy: "the exercise was somewhat easy"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,6 +398,7 @@ en:
       send: Send
       start_over: Reset this exercise
       start_over_active_file: Reset this file
+      start_video: Start video chat
       stop: Stop
       submit: Submit Code For Assessment
       deadline: Deadline
@@ -467,6 +468,7 @@ en:
       default_linter_feedback: Well done. The linter is completly satisfied.
       error_messages: Error Messages
       existing_programming_group: You are currently working on the exercise entitled '%{exercise}' as part of a programming group. Please finish your work there by scoring and submitting your code before you start implementing this exercise.
+      external_privacy_policy: By using the video chat, you agree to the <a href=%{url}> external privacy policy</a>.
       messages: Messages
       feedback: Feedback
       test_file: 'Test File <span class="number">%{number}</span> (<span class="filename">%{filename}</span>)'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -386,6 +386,7 @@ en:
       input: Your input
       lastsaved: 'Last saved: '
       network: 'While your code is running, port %{port} is accessible using the following address: <a href="%{address}" target="_blank" rel="noopener">%{address}</a>.'
+      pair_programming_session: Pair Programming Session
       render: Render
       run: Run
       run_failure: Your code could not be run.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -487,6 +487,7 @@ en:
       exit_failure: The last code run exited with a failure (status code %{exit_code}).
       no_output_yet: There is no output yet.
       output: Program Output
+      pair_programming_feedback: If you notice any errors with the pair programming feature, feel free to <a target='_blank', href=%{url}>write them down here</a>. Thanks a lot!
       passed_tests: Passed Tests
       code_rating: Code Rating
       progress: Progress

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -385,6 +385,8 @@ en:
       expand_action_sidebar: Expand Action Sidebar
       expand_output_sidebar: Expand Output Sidebar
       input: Your input
+      is_offline: "%{name} is offline"
+      is_online: "%{name} is online"
       lastsaved: 'Last saved: '
       network: 'While your code is running, port %{port} is accessible using the following address: <a href="%{address}" target="_blank" rel="noopener">%{address}</a>.'
       pair_programming_session: Pair Programming Session

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,7 +57,7 @@ en:
         uuid: UUID
         unpublished: Unpublished
       programming_group:
-        programming_partner_ids: Programming Partner IDs
+        programming_partner_id: Programming Partner ID
       programming_group/programming_group_memberships:
         base: Programming Group Membership
       proxy_exercise:
@@ -270,6 +270,7 @@ en:
             password:
               weak: is too weak. Try to use a long password with upper and lower case letters, numbers and special characters.
         programming_group:
+          size_too_large: The size of this programming group is too large. Enter at most one other user ID to work with.
           size_too_small: The size of this programming group is too small. Enter at least one other user ID to work with.
           invalid_partner_id: The user ID '%{partner_id}' is invalid and was removed. Please check the user IDs of your programming partners.
         programming_group_membership:
@@ -589,12 +590,13 @@ en:
       hints:
         programming_partner_ids: "You can enter several user IDs separated by commas such as 'e123, e234'."
     new:
+      create_programming_pair: Create Programming Pair
       check_invitation: "Check invitation"
-      enter_partner_id: "Please enter the user IDs from the practice partners with whom you want to solve the exercise '%{exercise_title}'. However, note that no one can leave the group afterward. Hence, all team members can see what you write in this exercise and vice versa. For the next exercise, you can decide again whether and with whom you want to work together."
+      enter_partner_id: "Please enter the user ID from the practice partner with whom you want to solve the exercise '%{exercise_title}'. However, note that no one can leave the pair afterward. Hence, your team partner can see what you write in this exercise and vice versa. For the next exercise, you can decide again whether and with whom you want to work together."
       find_partner_title: "Find a programming partner for the exercise"
-      find_partner_description: "Copy another user ID from the list below and delete it afterward. If there are no user IDs on the list yet, add your user ID and wait for another user to create a programming group with you. You can test this with the 'Check invitation' button. If you decide to work alone, please delete your user ID from the list."
+      find_partner_description: "Copy another user ID from the list below and delete it afterward. If there are no user IDs on the list yet, add your user ID and wait for another user to create a programming group with you. You can test this with the 'Check invitation' button. If you decide to work alone, please delete your user ID from the list if you added it before."
       own_user_id: "Your user ID:"
-      work_alone: "You can choose once to work on the exercise alone. Afterward, however, you will not be able to switch to group work for this exercise. Click <a href=%{path}>here</a> to get to the exercise in single mode."
+      work_alone: "You can choose once to work on the exercise alone. Afterward, however, you will not be able to switch to work in a pair for this exercise. <a href=%{path}>Click here to get to the exercise in single mode.</a>"
   external_users:
     statistics:
       title: External User Statistics

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,8 @@ Rails.application.routes.draw do
 
   resources :user_exercise_feedbacks, except: %i[show index]
 
+  resources :pair_programming_exercise_feedbacks, only: %i[new create]
+
   resources :external_users, only: %i[index show], concerns: :statistics do
     resources :exercises do
       get :statistics, to: 'exercises#external_user_statistics', on: :member

--- a/db/migrate/20230904174803_add_contributor_and_study_group_to_events.rb
+++ b/db/migrate/20230904174803_add_contributor_and_study_group_to_events.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddContributorAndStudyGroupToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :events, :programming_group, index: true, null: true, foreign_key: true
+    add_reference :events, :study_group, index: true, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20230904180123_create_events_synchronized_editor.rb
+++ b/db/migrate/20230904180123_create_events_synchronized_editor.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CreateEventsSynchronizedEditor < ActiveRecord::Migration[7.0]
+  def change
+    create_table :events_synchronized_editor, id: :uuid do |t|
+      t.references :programming_group, index: true, null: false, foreign_key: true
+      t.references :study_group, index: true, null: false, foreign_key: true
+      t.references :user, index: true, null: false, polymorphic: true
+      t.integer :command, limit: 1, null: false, default: 0, comment: 'Used as enum in Rails'
+      t.integer :status, limit: 1, null: true, comment: 'Used as enum in Rails'
+
+      # The following attributes are only stored for delta objects
+      t.references :file, index: true, null: true, foreign_key: true
+      t.integer :action, limit: 1, null: true, comment: 'Used as enum in Rails'
+      t.integer :range_start_row, null: true
+      t.integer :range_start_column, null: true
+      t.integer :range_end_row, null: true
+      t.integer :range_end_column, null: true
+      t.text :text, null: true
+      t.text :lines, null: true, array: true
+      t.string :nl, limit: 2, null: true, comment: 'Identifies the line break type (i.e., \r\n or \n)'
+      t.jsonb :data, null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230905190519_add_pair_programming_exercise_feedbacks.rb
+++ b/db/migrate/20230905190519_add_pair_programming_exercise_feedbacks.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddPairProgrammingExerciseFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :pair_programming_exercise_feedbacks do |t|
+      t.references :exercise, null: false, index: true, foreign_key: true
+      t.references :submission, null: false, index: true, foreign_key: true
+      t.references :user, polymorphic: true, null: false, index: true
+      t.references :programming_group, null: true, index: {name: 'pp_feedback_programming_group'}, foreign_key: true
+      t.references :study_group, null: false, index: true, foreign_key: true
+      t.integer :difficulty
+      t.integer :user_estimated_worktime
+      t.integer :reason_work_alone
+      t.float :normalized_score
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_04_180123) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_05_190519) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -382,6 +382,26 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_04_180123) do
     t.index ["study_group_id"], name: "index_lti_parameters_on_study_group_id"
   end
 
+  create_table "pair_programming_exercise_feedbacks", force: :cascade do |t|
+    t.bigint "exercise_id", null: false
+    t.bigint "submission_id", null: false
+    t.string "user_type", null: false
+    t.bigint "user_id", null: false
+    t.bigint "programming_group_id"
+    t.bigint "study_group_id", null: false
+    t.integer "difficulty"
+    t.integer "user_estimated_worktime"
+    t.integer "reason_work_alone"
+    t.float "normalized_score"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["exercise_id"], name: "index_pair_programming_exercise_feedbacks_on_exercise_id"
+    t.index ["programming_group_id"], name: "pp_feedback_programming_group"
+    t.index ["study_group_id"], name: "index_pair_programming_exercise_feedbacks_on_study_group_id"
+    t.index ["submission_id"], name: "index_pair_programming_exercise_feedbacks_on_submission_id"
+    t.index ["user_type", "user_id"], name: "index_pair_programming_exercise_feedbacks_on_user"
+  end
+
   create_table "programming_group_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "programming_group_id", null: false
     t.string "user_type", null: false
@@ -643,6 +663,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_04_180123) do
   add_foreign_key "lti_parameters", "exercises"
   add_foreign_key "lti_parameters", "external_users"
   add_foreign_key "lti_parameters", "study_groups"
+  add_foreign_key "pair_programming_exercise_feedbacks", "exercises"
+  add_foreign_key "pair_programming_exercise_feedbacks", "programming_groups"
+  add_foreign_key "pair_programming_exercise_feedbacks", "study_groups"
+  add_foreign_key "pair_programming_exercise_feedbacks", "submissions"
   add_foreign_key "programming_group_memberships", "programming_groups"
   add_foreign_key "programming_groups", "exercises"
   add_foreign_key "remote_evaluation_mappings", "study_groups"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_21_063101) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_04_180123) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -143,6 +143,35 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_063101) do
     t.integer "file_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "programming_group_id"
+    t.bigint "study_group_id"
+    t.index ["programming_group_id"], name: "index_events_on_programming_group_id"
+    t.index ["study_group_id"], name: "index_events_on_study_group_id"
+  end
+
+  create_table "events_synchronized_editor", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "programming_group_id", null: false
+    t.bigint "study_group_id", null: false
+    t.string "user_type", null: false
+    t.bigint "user_id", null: false
+    t.integer "command", limit: 2, default: 0, null: false, comment: "Used as enum in Rails"
+    t.integer "status", limit: 2, comment: "Used as enum in Rails"
+    t.bigint "file_id"
+    t.integer "action", limit: 2, comment: "Used as enum in Rails"
+    t.integer "range_start_row"
+    t.integer "range_start_column"
+    t.integer "range_end_row"
+    t.integer "range_end_column"
+    t.text "text"
+    t.text "lines", array: true
+    t.string "nl", limit: 2, comment: "Identifies the line break type (i.e., \\r\\n or \\n)"
+    t.jsonb "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["file_id"], name: "index_events_synchronized_editor_on_file_id"
+    t.index ["programming_group_id"], name: "index_events_synchronized_editor_on_programming_group_id"
+    t.index ["study_group_id"], name: "index_events_synchronized_editor_on_study_group_id"
+    t.index ["user_type", "user_id"], name: "index_events_synchronized_editor_on_user"
   end
 
   create_table "execution_environments", id: :serial, force: :cascade do |t|
@@ -603,6 +632,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_063101) do
   add_foreign_key "community_solution_contributions", "study_groups"
   add_foreign_key "community_solution_locks", "community_solutions"
   add_foreign_key "community_solutions", "exercises"
+  add_foreign_key "events", "programming_groups"
+  add_foreign_key "events", "study_groups"
+  add_foreign_key "events_synchronized_editor", "files"
+  add_foreign_key "events_synchronized_editor", "programming_groups"
+  add_foreign_key "events_synchronized_editor", "study_groups"
   add_foreign_key "exercise_tips", "exercise_tips", column: "parent_exercise_tip_id"
   add_foreign_key "exercise_tips", "exercises"
   add_foreign_key "exercise_tips", "tips"

--- a/lib/pair_programming23_study.rb
+++ b/lib/pair_programming23_study.rb
@@ -2,9 +2,27 @@
 
 class PairProgramming23Study
   ENABLE = ENV.fetch('PAIR_PROGRAMMING_23_STUDY', nil) == 'true'
+  STUDY_GROUP_IDS = [368, 450].freeze
 
-  def self.participate?
-    # TODO: Decide which users are in the study
-    ENABLE
+  def self.participate?(user, exercise)
+    ENABLE || participate_in_pp?(user, exercise)
+  end
+
+  def self.participate_in_pp?(user, exercise)
+    # All easy tasks of the first week to be solved by the participants on their own
+    if experiment_course?(user.current_study_group_id) && [636, 647, 648, 649, 637, 638, 623, 639, 650, 625, 624, 651, 653, 654, 655, 664, 656].exclude?(exercise.id)
+      user_group = user.id % 3 # => 0, 1, 2
+      case user_group
+        when 0, 1
+          return true
+        else # 2
+          return false
+      end
+    end
+    false
+  end
+
+  def self.experiment_course?(study_group_id)
+    STUDY_GROUP_IDS.include? study_group_id
   end
 end

--- a/spec/policies/request_for_comment_policy_spec.rb
+++ b/spec/policies/request_for_comment_policy_spec.rb
@@ -62,7 +62,6 @@ describe RequestForCommentPolicy do
 
       it 'grant access to other authors of the programming group' do
         rfc.submission.update(contributor: programming_group)
-        expect(policy).to permit(author_other_group_member, rfc)
         expect(policy).to permit(viewer_other_group_member, rfc)
       end
     end
@@ -78,7 +77,6 @@ describe RequestForCommentPolicy do
 
       it 'grant access to other authors of the programming group' do
         rfc.submission.update(contributor: programming_group)
-        expect(policy).to permit(author_other_group_member, rfc)
         expect(policy).to permit(viewer_other_group_member, rfc)
       end
 
@@ -93,9 +91,8 @@ describe RequestForCommentPolicy do
     let(:author_study_groups) { create_list(:study_group, 1, consumer: author_consumer) }
     let(:rfc) { create(:rfc, user: rfc_author) }
 
-    let(:author_other_group_member) { create(:external_user, consumer: author_consumer) }
     let(:viewer_other_group_member) { create(:external_user, consumer: viewer_consumer) }
-    let(:programming_group) { create(:programming_group, exercise: rfc.submission.exercise, users: [rfc.author, author_other_group_member, viewer_other_group_member]) }
+    let(:programming_group) { create(:programming_group, exercise: rfc.submission.exercise, users: [rfc.author, viewer_other_group_member]) }
 
     context "when the author's rfc_visibility is set to all" do
       let(:author_consumer) { create(:consumer, rfc_visibility: 'all') }


### PR DESCRIPTION
* Assign users to A/B groups
* Show in implement route in statusbar if it is a pair programming session and connection status of team partner
* Add button to start (video) chat with programming group
* Add etherpad to exchange user IDs
* Fixed synchronized editor for multiple files (solves #1868)
* Unsubscribe from channel when redirecting
* Limit programming groups to two people
* Etherpad link for pair programming feedback
* Add events for pair programming study