### PR TITLE
Fix sentry issues for pair programming

### DIFF
--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -1011,7 +1011,10 @@ var CodeOceanEditor = {
     },
 
     applyChanges: function (delta, active_file) {
-        const editor = this.editor_for_file.get(active_file.id)
+        const editor = this.editor_for_file.get(active_file.id);
+        if (editor === undefined) {
+            return;
+        }
         editor.session.doc.applyDeltas([delta]);
     },
 

--- a/app/models/event/synchronized_editor.rb
+++ b/app/models/event/synchronized_editor.rb
@@ -34,7 +34,8 @@ class Event::SynchronizedEditor < ApplicationRecord
   validates :range_start_column, numericality: {only_integer: true, greater_than_or_equal_to: 0}, if: -> { action_editor_change? }
   validates :range_end_row, numericality: {only_integer: true, greater_than_or_equal_to: 0}, if: -> { action_editor_change? }
   validates :range_end_column, numericality: {only_integer: true, greater_than_or_equal_to: 0}, if: -> { action_editor_change? }
-  validates :lines, presence: true, if: -> { action_editor_change? || action_current_content? }
+  validates :lines, presence: true, if: -> { action_editor_change? }
+  validate :lines_not_nil, if: -> { action_current_content? }
 
   def self.create_for_editor_change(event, user, programming_group)
     event_copy = event.deep_dup
@@ -90,4 +91,12 @@ class Event::SynchronizedEditor < ApplicationRecord
     event.presence if event.present? # TODO: As of now, we are storing the `session_id` most of the times. Intended?
   end
   private_class_method :data_attribute
+end
+
+private
+
+def lines_not_nil
+  if lines.nil?
+    errors.add(:lines, 'cannot be nil')
+  end
 end


### PR DESCRIPTION
* Allow empty lines for current_content event: fixes CODEOCEAN-VR
* Return if editor is null: fixes CODEOCEAN-FRONTEND-3A