### PR TITLE
Add custom redirect to LimeSurvey through LTI

### DIFF
--- a/app/controllers/user_exercise_feedbacks_controller.rb
+++ b/app/controllers/user_exercise_feedbacks_controller.rb
@@ -41,9 +41,9 @@ class UserExerciseFeedbacksController < ApplicationController
     Sentry.set_extras(params: uef_params)
 
     @exercise = Exercise.find(uef_params[:exercise_id])
-    rfc = RequestForComment.unsolved.where(exercise_id: @exercise.id, user: current_user).first
+    rfc = RequestForComment.unsolved.where(exercise: @exercise, user: current_user).first
     submission = begin
-      current_contributor.submissions.where(exercise_id: @exercise.id).order('created_at DESC').first
+      current_contributor.submissions.where(exercise: @exercise).order(created_at: :desc).first
     rescue StandardError
       nil
     end

--- a/app/helpers/action_cable_helper.rb
+++ b/app/helpers/action_cable_helper.rb
@@ -22,7 +22,7 @@ module ActionCableHelper
 
   def trigger_rfc_action_cable_from_comment
     # Context: Comment
-    RequestForComment.find_by(submission: file.context).trigger_rfc_action_cable
+    request_for_comment.trigger_rfc_action_cable
   end
 
   def trigger_working_times_action_cable

--- a/app/models/code_ocean/file.rb
+++ b/app/models/code_ocean/file.rb
@@ -32,6 +32,7 @@ module CodeOcean
     has_many :files, class_name: 'CodeOcean::File'
     has_many :testruns
     has_many :comments
+    has_one :request_for_comment
     has_many :events_synchronized_editor, class_name: 'Event::SynchronizedEditor'
     alias descendants files
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -8,11 +8,9 @@ class Comment < ApplicationRecord
   attr_accessor :username, :date, :updated, :editable
 
   belongs_to :file, class_name: 'CodeOcean::File'
+  has_one :submission, through: :file, source: :context, source_type: 'Submission'
+  has_one :request_for_comment, through: :submission
   # after_save :trigger_rfc_action_cable_from_comment
-
-  def request_for_comment
-    RequestForComment.find_by(submission_id: file.context.id)
-  end
 
   def only_comment_for_rfc?
     request_for_comment.comments.one?

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -33,6 +33,7 @@ class Exercise < ApplicationRecord
   has_many :internal_users, source: :contributor, source_type: 'InternalUser', through: :submissions
   has_many :programming_groups
   has_many :pair_programming_waiting_users
+  has_many :request_for_comments
 
   scope :with_submissions, -> { where('id IN (SELECT exercise_id FROM submissions)') }
 

--- a/app/models/request_for_comment.rb
+++ b/app/models/request_for_comment.rb
@@ -22,10 +22,6 @@ class RequestForComment < ApplicationRecord
 
   # after_save :trigger_rfc_action_cable
 
-  def comments_count
-    submission.files.sum {|file| file.comments.size }
-  end
-
   def commenters
     comments.map(&:user).uniq
   end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -17,6 +17,7 @@ class Submission < ApplicationRecord
   has_many :testruns
   has_many :structured_errors, dependent: :destroy
   has_many :comments, through: :files
+  has_one :request_for_comment
   has_one :user_exercise_feedback
   has_one :pair_programming_exercise_feedback
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   belongs_to :consumer
   has_many :anomaly_notifications, as: :contributor, dependent: :destroy
   has_many :authentication_token, dependent: :destroy
+  has_many :comments, as: :user
   has_many :study_group_memberships, as: :user
   has_many :study_groups, through: :study_group_memberships, as: :user
   has_many :programming_group_memberships, as: :user
@@ -21,6 +22,7 @@ class User < ApplicationRecord
   has_many :testruns, as: :user
   has_many :interventions, through: :user_exercise_interventions
   has_many :remote_evaluation_mappings, as: :user
+  has_many :request_for_comments, as: :user
   has_many :runners, as: :contributor
   has_many :events
   has_many :events_synchronized_editor, class_name: 'Event::SynchronizedEditor'

--- a/app/views/request_for_comments/_list_entry.html.slim
+++ b/app/views/request_for_comments/_list_entry.html.slim
@@ -6,7 +6,7 @@ tr.table-row-clickable data-id=request_for_comment.id data-href=request_for_comm
       span.fa-solid.fa-check.fa-2x style="color: var(--bs-secondary-text-emphasis);" aria-hidden="true"
     - else
       = ''
-  td.text-center = request_for_comment.comments_count
+  td.text-center = request_for_comment.comments.size
   - if request_for_comment.has_attribute?(:question) && request_for_comment.question.present?
     td.text-primary = truncate(request_for_comment.question, length: 200)
   - else

--- a/app/views/request_for_comments/index.html.slim
+++ b/app/views/request_for_comments/index.html.slim
@@ -45,7 +45,7 @@ h1 = RequestForComment.model_name.human(count: 2)
             td = truncate(request_for_comment.question, length: 200)
           - else
             td = '-'
-          td = request_for_comment.comments_count
+          td = request_for_comment.comments.size
           td = link_to_if(request_for_comment.user && policy(request_for_comment.user).show?, request_for_comment.user.displayname, request_for_comment.user)
           td = t('shared.time.before', time: distance_of_time_in_words_to_now(request_for_comment.created_at))
           td = t('shared.time.before', time: distance_of_time_in_words_to_now(request_for_comment.last_comment.nil? ? request_for_comment.updated_at : request_for_comment.last_comment))


### PR DESCRIPTION
This PR adds the possibility to redirect learners to LimeSurvey (coming from LTI).

Further, this PR adds some general associations in the first commit (unrelated to the survey redirect, but required for the parameters added).

⚠️ I have tested the implementation only roughly, so please do that as part of the review.