### PR TITLE
Exclusively lock Runners during code executions

### DIFF
--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -773,6 +773,8 @@ var CodeOceanEditor = {
             this.showContainerDepletedMessage();
         } else if (output.status === 'out_of_memory') {
             this.showOutOfMemoryMessage();
+        } else if (output.status === 'runner_in_use') {
+            this.showRunnerInUseMessage();
         }
     },
 
@@ -829,6 +831,13 @@ var CodeOceanEditor = {
         $.flash.info({
             icon: ['fa-regular', 'fa-clock'],
             text: $('#editor').data('message-out-of-memory')
+        });
+    },
+
+    showRunnerInUseMessage: function () {
+        $.flash.warning({
+            icon: ['fa-solid', 'fa-triangle-exclamation'],
+            text: I18n.t('exercises.editor.runner_in_use')
         });
     },
 

--- a/app/assets/javascripts/editor/evaluation.js
+++ b/app/assets/javascripts/editor/evaluation.js
@@ -110,6 +110,11 @@ CodeOceanEditorEvaluation = {
             this.showOutOfMemoryMessage();
         }
         if (_.some(response, function (result) {
+            return result.status === 'runner_in_use';
+        })) {
+            this.showRunnerInUseMessage();
+        }
+        if (_.some(response, function (result) {
             return result.status === 'container_depleted';
         })) {
             this.showContainerDepletedMessage();

--- a/app/assets/javascripts/shell.js
+++ b/app/assets/javascripts/shell.js
@@ -148,13 +148,22 @@ $(document).on('turbolinks:load', function () {
         }
 
         // We build the path to the file by concatenating the paths of all parent nodes.
-        let file_path = node.parents.reverse().map(function (id) {
+        let file_path = getParents(jstree, node.parent).map(function (id) {
             return jstree.get_text(id);
         }).filter(function (text) {
             return text !== false;
         }).join('/');
 
         return `${node.parent !== '#' ? '/' : ''}${file_path}${node.original.path}`;
+    }
+
+    const getParents = function (jstree, node_id) {
+        debugger;
+        if (node_id === '#') {
+            return ['#'];
+        }
+
+        return getParents(jstree, jstree.get_parent(node_id)).concat([node_id]);
     }
 
     const shell = $('#shell');

--- a/app/controllers/live_streams_controller.rb
+++ b/app/controllers/live_streams_controller.rb
@@ -26,15 +26,15 @@ class LiveStreamsController < ApplicationController
     runner = Runner.for(current_user, @execution_environment)
     fallback_location = shell_execution_environment_path(@execution_environment)
     privileged = params[:sudo] || @execution_environment.privileged_execution?
-    send_runner_file(runner, desired_file, fallback_location, privileged:)
+    send_runner_file(runner, desired_file, fallback_location, privileged:, exclusive: false)
   end
 
   private
 
-  def send_runner_file(runner, desired_file, redirect_fallback = root_path, privileged: false)
+  def send_runner_file(runner, desired_file, redirect_fallback = root_path, privileged: false, exclusive: true)
     filename = File.basename(desired_file)
     send_stream(filename:, type: 'application/octet-stream', disposition: 'attachment') do |stream|
-      runner.download_file(desired_file, privileged_execution: privileged) do |chunk, overall_size, _content_type|
+      runner.download_file(desired_file, privileged_execution: privileged, exclusive:) do |chunk, overall_size, _content_type|
         unless response.committed?
           # Disable Rack::ETag, which would otherwise cause the response to be cached
           # See https://github.com/rack/rack/issues/1619#issuecomment-848460528

--- a/app/controllers/remote_evaluation_controller.rb
+++ b/app/controllers/remote_evaluation_controller.rb
@@ -72,6 +72,9 @@ class RemoteEvaluationController < ApplicationController
       # TODO: check token expired?
       {message: 'No exercise found for this validation_token! Please keep out!', status: 401}
     end
+  rescue Runner::Error::RunnerInUse => e
+    Rails.logger.debug { "Scoring a submission failed because the runner was already in use: #{e.message}" }
+    {message: I18n.t('exercises.editor.runner_in_use'), status: 409}
   rescue Runner::Error => e
     Rails.logger.debug { "Runner error while scoring submission #{@submission.id}: #{e.message}" }
     {message: I18n.t('exercises.editor.depleted'), status: 503}

--- a/app/errors/runner/error.rb
+++ b/app/errors/runner/error.rb
@@ -16,6 +16,8 @@ class Runner
 
     class Unauthorized < Error; end
 
+    class RunnerInUse < Error; end
+
     class RunnerNotFound < Error; end
 
     class FaradayError < Error; end

--- a/app/models/execution_environment.rb
+++ b/app/models/execution_environment.rb
@@ -92,7 +92,7 @@ class ExecutionEnvironment < ApplicationRecord
     retries = 0
     begin
       runner = Runner.for(author, self)
-      output = runner.execute_command(VALIDATION_COMMAND)
+      output = runner.execute_command(VALIDATION_COMMAND, exclusive: false)
       errors.add(:docker_image, "error: #{output[:stderr]}") if output[:stderr].present?
     rescue Runner::Error => e
       # In case of an Runner::Error, we retry multiple times before giving up.

--- a/app/models/programming_group.rb
+++ b/app/models/programming_group.rb
@@ -28,6 +28,18 @@ class ProgrammingGroup < ApplicationRecord
     false
   end
 
+  def learner?
+    true
+  end
+
+  def teacher?
+    false
+  end
+
+  def admin?
+    false
+  end
+
   def self.parent_resource
     Exercise
   end

--- a/app/models/testrun.rb
+++ b/app/models/testrun.rb
@@ -14,6 +14,7 @@ class Testrun < ApplicationRecord
     timeout: 3,
     out_of_memory: 4,
     terminated_by_client: 5,
+    runner_in_use: 6,
   }, _default: :ok, _prefix: true
 
   validates :exit_code, numericality: {only_integer: true, min: 0, max: 255}, allow_nil: true

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -398,6 +398,7 @@ de:
       network: 'Während Ihr Code läuft, ist Port %{port} unter folgender Adresse erreichbar: <a href="%{address}" target="_blank" rel="noopener">%{address}</a>.'
       render: Anzeigen
       run: Ausführen
+      runner_in_use: Sie führen momentan Code aus. Bitte stoppen Sie die vorherige Ausführung oder warten Sie einen Moment, bevor Sie fortfahren.
       run_failure: Ihr Code konnte nicht auf der Plattform ausgeführt werden.
       run_success: Ihr Code wurde auf der Plattform ausgeführt.
       requestComments: Kommentare erbitten

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,6 +398,7 @@ en:
       network: 'While your code is running, port %{port} is accessible using the following address: <a href="%{address}" target="_blank" rel="noopener">%{address}</a>.'
       render: Render
       run: Run
+      runner_in_use: You are currently running code. Please stop the previous execution, or wait a moment before proceeding.
       run_failure: Your code could not be run.
       run_success: Your code was run on our servers.
       requestComments: Request Comments

--- a/db/migrate/20231029172331_add_reserved_until_to_runners.rb
+++ b/db/migrate/20231029172331_add_reserved_until_to_runners.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReservedUntilToRunners < ActiveRecord::Migration[7.1]
+  def change
+    add_column :runners, :reserved_until, :datetime, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_13_194635) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_29_172331) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -483,6 +483,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_13_194635) do
     t.bigint "contributor_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "reserved_until"
     t.index ["contributor_type", "contributor_id"], name: "index_runners_on_user"
     t.index ["execution_environment_id"], name: "index_runners_on_execution_environment_id"
   end

--- a/spec/factories/runner.rb
+++ b/spec/factories/runner.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     runner_id { SecureRandom.uuid }
     execution_environment factory: :ruby
     contributor factory: :external_user
+
+    after(:build) do |runner|
+      runner.strategy = Runner.strategy_class.new(runner.runner_id, runner.execution_environment)
+    end
   end
 end

--- a/spec/models/execution_environment_spec.rb
+++ b/spec/models/execution_environment_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe ExecutionEnvironment do
     it 'executes the validation command' do
       allow(runner).to receive(:execute_command).and_return({})
       working_docker_image?
-      expect(runner).to have_received(:execute_command).with(ExecutionEnvironment::VALIDATION_COMMAND)
+      expect(runner).to have_received(:execute_command).with(ExecutionEnvironment::VALIDATION_COMMAND, exclusive: false)
     end
 
     context 'when the command produces an error' do

--- a/spec/models/runner_spec.rb
+++ b/spec/models/runner_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Runner do
   end
 
   describe '#destroy_at_management' do
-    let(:runner) { described_class.create }
+    let(:runner) { create(:runner) }
 
     before do
       allow(strategy_class).to receive_messages(request_from_management: runner_id, new: strategy)
@@ -66,7 +66,7 @@ RSpec.describe Runner do
   end
 
   describe '#attach to execution' do
-    let(:runner) { described_class.create }
+    let(:runner) { create(:runner) }
     let(:command) { 'ls' }
     let(:event_loop) { instance_double(Runner::EventLoop) }
     let(:connection) { instance_double(Runner::Connection) }
@@ -123,7 +123,7 @@ RSpec.describe Runner do
   end
 
   describe '#copy_files' do
-    let(:runner) { described_class.create }
+    let(:runner) { create(:runner) }
 
     before do
       allow(strategy_class).to receive_messages(request_from_management: runner_id, new: strategy)


### PR DESCRIPTION
Previously, the same runner could be used multiple times with different submissions simultaneously. This, however, yielded errors, for example when one submission time oud (causing the running to be deleted) while another submission was still executed.

Admin actions, such as the shell, can be still executed regardless of any other code execution.

Fixes CODEOCEAN-HG
Fixes openHPI/poseidon#423
