### PR TITLE
Fix Sentry span for outgoing WebSocket connections

### DIFF
--- a/app/assets/javascripts/editor/execution.js
+++ b/app/assets/javascripts/editor/execution.js
@@ -12,10 +12,12 @@ CodeOceanEditorWebsocket = {
       sockURL.hash = '';
 
       if (span) {
-        sockURL.searchParams.set('HTTP_SENTRY_TRACE', span.toTraceparent());
         const dynamicContext = this.sentryTransaction.getDynamicSamplingContext();
         const baggage = SentryUtils.dynamicSamplingContextToSentryBaggageHeader(dynamicContext);
-        sockURL.searchParams.set('HTTP_BAGGAGE', baggage);
+        if (baggage) {
+          sockURL.searchParams.set('HTTP_SENTRY_TRACE', span.toTraceparent());
+          sockURL.searchParams.set('HTTP_BAGGAGE', baggage);
+        }
       }
 
       return sockURL.toString();


### PR DESCRIPTION
Recently, we noticed that Poseidon's WebSocket spans shown in Sentry are not correctly aligned with the outgoing WebSocket request in CodeOcean. This PR aims to fix that problem.

[Here's a sample trace with the code of this branch](https://codeocean.sentry.io/performance/codeocean:087ae8ca52084d06a5e25021bf7cc144/). 

Related to https://github.com/openHPI/poseidon/issues/438