### PR TITLE
Extract Contributor concern as abstract class

### DIFF
--- a/app/models/concerns/contributor.rb
+++ b/app/models/concerns/contributor.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module Contributor
-  extend ActiveSupport::Concern
-
-  included do
-    has_many :submissions, as: :contributor
-  end
-end

--- a/app/models/concerns/contributor_creation.rb
+++ b/app/models/concerns/contributor_creation.rb
@@ -2,7 +2,6 @@
 
 module ContributorCreation
   extend ActiveSupport::Concern
-  include Contributor
 
   ALLOWED_CONTRIBUTOR_TYPES = [InternalUser, ExternalUser, ProgrammingGroup].map(&:to_s).freeze
 

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class Contributor < ApplicationRecord
+  self.abstract_class = true
+
+  has_many :anomaly_notifications, as: :contributor, dependent: :destroy
+  has_many :user_exercise_interventions, as: :contributor
+  has_many :runners, as: :contributor, dependent: :destroy
+
+  has_many :submissions, as: :contributor
+
+  def learner?
+    raise NotImplementedError
+  end
+
+  def teacher?
+    raise NotImplementedError
+  end
+
+  def admin?
+    raise NotImplementedError
+  end
+
+  def internal_user?
+    is_a?(InternalUser)
+  end
+
+  def external_user?
+    is_a?(ExternalUser)
+  end
+
+  def programming_group?
+    is_a?(ProgrammingGroup)
+  end
+
+  def to_s
+    displayname
+  end
+
+  def to_page_context
+    {
+      id:,
+      type: self.class.name,
+      consumer: try(:consumer)&.name, # Only a user is associated with a consumer.
+      displayname:,
+    }
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,7 @@ end
 
 # delete all present records
 Rails.application.eager_load!
-(ApplicationRecord.descendants - [ActiveRecord::SchemaMigration, User]).each(&:delete_all)
+(ApplicationRecord.descendants - [ActiveRecord::SchemaMigration, Contributor, User]).each(&:delete_all)
 
 # delete file uploads
 FileUtils.rm_rf(Rails.public_path.join('uploads'))


### PR DESCRIPTION
During documentation of the pair programming feature, we noticed that the Contributor should be an abstract class, which is parent for the User and the ProgrammingGroup. With this commit, we perform these changes.