### PR TITLE
Resolve current deprecation warnings

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,7 +32,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join('spec/fixtures')
+  config.fixture_paths = [Rails.root.join('spec/fixtures')]
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
This PR resolves two open deprecation warnings:

- `DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_active_connections! is deprecated. Please call the method directly on the connection handler; for example: `ActiveRecord::Base.connection_handler.clear_active_connections!`. (called from clear_active_connections! at /home/runner/work/codeocean/codeocean/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3/lib/active_record/connection_handling.rb:320)` is resolved in the first commit f50ff1f7489d25ed5d1ab4825c21e1e42661b4be.
- `Rails 7.1 has deprecated the singular fixture_path in favour of an array.You should migrate to plural` is resolved in the second commit 89fd9d193e059476ba333a6f9d9427128578ffa4.