### PR TITLE
fix kramdown using curved quotes 

### DIFF
--- a/app/assets/javascripts/pagedown/markdown.editor.js.erb
+++ b/app/assets/javascripts/pagedown/markdown.editor.js.erb
@@ -835,7 +835,7 @@
 
             var prevTime = new Date().getTime();
 
-            text = converter.makeHtml(text);
+            text = converter.makeHtml(text).replaceAll(/&#8220;|&#8221;/g, '"');
 
             // Calculate the processing time of the HTML creation.
             // It's used as the delay time in the event listener.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,7 +50,7 @@ module ApplicationHelper
   end
 
   def render_markdown(markdown)
-    ActionController::Base.helpers.sanitize Kramdown::Document.new(markdown, input: 'GFM', hard_wrap: false).to_html.strip
+    ActionController::Base.helpers.sanitize Kramdown::Document.new(markdown, input: 'GFM', hard_wrap: false, smart_quotes: 'apos,apos,quot,quot').to_html.strip
   end
 
   def row(options = {}, &block)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -314,7 +314,7 @@ class Submission < ApplicationRecord
     else
       # The render_markdown method from application_helper.rb is not available in model classes.
       ActionController::Base.helpers.sanitize(
-        Kramdown::Document.new(file.feedback_message).to_html,
+        Kramdown::Document.new(file.feedback_message, smart_quotes: 'apos,apos,quot,quot').to_html,
         tags: %w[strong],
         attributes: []
       )


### PR DESCRIPTION
Kramdown uses curved quotation marks by default, when rendering markdown to html

This changes them to be straight quotes, so they can be easily copied in code or the like.
