### PR TITLE
Specs: Prevent Rake task from being executed twice

### DIFF
--- a/spec/db/seeds_spec.rb
+++ b/spec/db/seeds_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'seeds' do
   subject(:seed) { Rake::Task['db:seed'].invoke }
 
   before do
-    CodeOcean::Application.load_tasks
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
 
     # We need to migrate the test database before seeding
     # Otherwise, Rails 7.1+ will throw an `NoMethodError`: `pending_migrations.any?`


### PR DESCRIPTION
Otherwise, invoking a Rake task could lead to multiple executions, which is unexpected.