### PR TITLE
Adjust CSP and fix ACE integration

### DIFF
--- a/app/assets/javascripts/base.js
+++ b/app/assets/javascripts/base.js
@@ -24,10 +24,6 @@ $.fn.scrollTo = function(selector) {
   }, ANIMATION_DURATION);
 };
 
-// Disable the use of web workers for JStree due to JS error
-// See https://github.com/vakata/jstree/issues/1717 for details
-$.jstree.defaults.core.worker = false;
-
 $(document).on('turbolinks:load', function() {
     // Update all CSRF tokens on the page to reduce InvalidAuthenticityToken errors
     // See https://github.com/rails/jquery-ujs/issues/456 for details

--- a/app/assets/javascripts/request_for_comments.js
+++ b/app/assets/javascripts/request_for_comments.js
@@ -64,7 +64,6 @@ $(document).on('turbolinks:load', function () {
         currentEditor.setReadOnly(true);
         // set editor mode (used for syntax highlighting
         currentEditor.getSession().setMode($(editor).data('mode'));
-        currentEditor.getSession().setOption("useWorker", false);
         currentEditor.setTheme(CodeOceanEditor.THEME);
 
         currentEditor.commentVisualsByLine = {};

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -81,7 +81,8 @@ window.Routes = Routes;
 
 // ACE editor
 import ace from 'ace-builds';
-import "ace-builds/esm-resolver";
-import "ace-builds/src-noconflict/ext-language_tools";
-import "ace-builds/src-noconflict/ext-modelist";
+import "ace-builds/webpack-resolver"; // Enable webpack resolver, requires `file-loader` to be installed
+// Enable ACE editor extensions. See https://github.com/ajaxorg/ace/wiki/Extensions
+import "ace-builds/src-noconflict/ext-language_tools"; // Enable autocompletion
+import "ace-builds/src-noconflict/ext-modelist"; // Enable language mode detection
 window.ace = ace; // Publish ace in global namespace

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -85,4 +85,5 @@ import "ace-builds/webpack-resolver"; // Enable webpack resolver, requires `file
 // Enable ACE editor extensions. See https://github.com/ajaxorg/ace/wiki/Extensions
 import "ace-builds/src-noconflict/ext-language_tools"; // Enable autocompletion
 import "ace-builds/src-noconflict/ext-modelist"; // Enable language mode detection
+ace.config.set("useStrictCSP", true); // Enable strict CSP mode
 window.ace = ace; // Publish ace in global namespace

--- a/app/javascript/stylesheets.scss
+++ b/app/javascript/stylesheets.scss
@@ -12,6 +12,12 @@ $web-font-path: '//';
 @import '~bootstrap/scss/bootstrap';
 @import '~bootswatch/dist/yeti/bootswatch';
 
+// Import the Ace editor styles
+@import url('~ace-builds/css/ace.css');
+@import url('~ace-builds/css/theme/tomorrow.css');
+@import url('~ace-builds/css/theme/tomorrow_night.css');
+
+
 // We define our own button style here, since `btn-outline-dark` and `btn-outline-light` do not switch colors.
 html[data-bs-theme="dark"] {
   .btn-outline-contrast {

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -60,6 +60,7 @@ Rails.application.configure do
     # Currently, these include turbolinks, and vis.js.
     policy.style_src_elem       :self, :unsafe_inline, :report_sample
     # We still use some inline styles within the application, and indirectly through d3.js.
+    # Further, the ToastUi markdown editor currently requires inline styles, too.
     policy.style_src_attr       :unsafe_inline, :report_sample
     # The `style_src` directive is only a fallback for browsers not supporting `style_src_elem` and `style_src_attr`.
     policy.style_src            :self, :unsafe_inline, :report_sample

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -15,11 +15,15 @@ Rails.application.config.permissions_policy do |policy|
   policy.fullscreen           :none
   policy.geolocation          :none
   policy.gyroscope            :none
+  policy.hid                  :none
+  policy.idle_detection       :none
   policy.magnetometer         :none
   policy.microphone           :none
   policy.midi                 :none
   policy.payment              :none
   policy.picture_in_picture   :none
-  # The `speaker` directive is used for selection of non-default audio output devices
+  policy.screen_wake_lock     :none
+  policy.serial               :none
   policy.usb                  :none
+  policy.web_share            :none
 end

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -35,6 +35,16 @@ const envConfig = module.exports = {
                     filename: 'icons/[hash].svg'
                 },
             },
+            // Extract ToastUi's inline PNGs to actual resources, similar to Bootstrap's SVGs.
+            // This removes the requirement for `data:` URLs in our CSP
+            {
+                mimetype: 'image/png',
+                scheme: 'data',
+                type: 'asset/resource',
+                generator: {
+                    filename: 'icons/[hash].png'
+                },
+            },
             erb
         ]
     },

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -24,6 +24,17 @@ const envConfig = module.exports = {
     },
     module: {
         rules: [
+            // Extract Bootstrap's inline SVGs to actual resources.
+            // This removes the requirement for `data:` URLs in our CSP
+            // See https://getbootstrap.com/docs/5.3/getting-started/webpack/#extracting-svg-files
+            {
+                mimetype: 'image/svg+xml',
+                scheme: 'data',
+                type: 'asset/resource',
+                generator: {
+                    filename: 'icons/[hash].svg'
+                },
+            },
             erb
         ]
     },


### PR DESCRIPTION
This PR changes the way we integrate ACE, aiming to allow the web workers spawned by the editor.
Further, it adjusts the CSP and Feature Policy to current values.

This PR is already compatible with #2242.