### PR TITLE
Connection::Buffer: Ignore linter indicator accidentally wrapped in quotes

### DIFF
--- a/lib/runner/connection/buffer.rb
+++ b/lib/runner/connection/buffer.rb
@@ -6,7 +6,7 @@ class Runner::Connection::Buffer
   # substring either in single or double quotes (e.g., within a JSON). Originally, each line break consists of `\r\n`.
   # We keep the `\r` at the end of the line (keeping "empty" lines) and replace it after buffering.
   # Inspired by https://stackoverflow.com/questions/13040585/split-string-by-spaces-properly-accounting-for-quotes-and-backslashes-ruby
-  SPLIT_INDIVIDUAL_LINES = /(?:"""(?:\\"|[^"])*"""|"(?!"")(?:\\"|[^"])*"|''(?:\\'|[^'])*'''|'(?!'')(?:\\'|[^'])*'|[#\\][^\r\n]*|(?:[^\r\n]|\r(?=\n)))+/
+  SPLIT_INDIVIDUAL_LINES = /(?:"""(?:\\"|(?!\r\n +\^\r\n)[^"])*"""|"(?!"")(?:\\"|(?!\r\n +\^\r\n)[^"])*"|''(?:\\'|(?!\r\n +\^\r\n)[^'])*'''|'(?!'')(?:\\'|(?!\r\n +\^\r\n)[^'])*'|[#\\][^\r\n]*|(?:[^\r\n]|\r(?=\n)))+/
 
   def initialize
     @global_buffer = +''


### PR DESCRIPTION
The PyLint output is marking the erroneous location visually by using ^ in the next line. This indicator is always prefixed by multiple spaces and the line does not contain any further text. Now, it might happen that the indicator is between two source lines that use the same quote type. Since we detect quotes through our regex, this occurrence would qualify, effectively enquoting the linter indicator ^. As a consequence of our quote handling, we normally prevented quoted text from being split. However, in the described scenario, this is not desired, since we are not dealing with a regular quote (but an accidental mismatch).

Therefore, with this commit, we disable our quote handling for those multi-line quotes where one line fully represents a typical PyLint indicator line. This should restore the desired line-matching behavior.

Fixes [CODEOCEAN-12N](https://codeocean.sentry.io/issues/5161130664/)