### PR TITLE
RfC: Keep indention when displaying comments

### DIFF
--- a/app/assets/stylesheets/request-for-comments.css.scss
+++ b/app/assets/stylesheets/request-for-comments.css.scss
@@ -198,6 +198,7 @@ html[data-bs-theme="light"] {
   }
 
   .comment-content {
+    white-space: pre-wrap;
     word-wrap: break-word;
     margin-bottom: 10px;
   }


### PR DESCRIPTION
When writing a comment with Python code, the indention was lost (see the [course forum](https://open.hpi.de/courses/pythonjunior-schule2024/question/ad8dcaf7-b515-4783-a066-a442e7c5786a)). This PR fixes that behavior:

| Before | After |
|--------|--------|
| <img width="494" alt="Bildschirmfoto 2024-04-18 um 17 39 51" src="https://github.com/openHPI/codeocean/assets/7300329/df16ca40-7246-4598-a44a-21b01255a583"> | <img width="494" alt="Bildschirmfoto 2024-04-18 um 17 40 04" src="https://github.com/openHPI/codeocean/assets/7300329/2e875894-9217-4e70-8b88-954c09a35966"> | 
