### PR TITLE
Fix NameError on block forward

### DIFF
--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -56,7 +56,7 @@ class Runner < ApplicationRecord
 
   def download_file(desired_file, privileged_execution:, exclusive: true, &)
     reserve! if exclusive
-    @strategy.download_file(desired_file, privileged_execution:, &block)
+    @strategy.download_file(desired_file, privileged_execution:, &)
     release! if exclusive
   end
 


### PR DESCRIPTION
This is a regression from 27f128ad.

Fixes [CODEOCEAN-12R](https://codeocean.sentry.io/issues/5248673115/)