### PR TITLE
Fix race condition on JavaScript initializer

### DIFF
--- a/app/assets/javascripts/channels/synchronized_editor_channel.js
+++ b/app/assets/javascripts/channels/synchronized_editor_channel.js
@@ -4,7 +4,7 @@ $(document).on('turbolinks:load', function () {
     var editor = $('#editor');
     var exercise_id = editor.data('exercise-id');
 
-    if ($.isController('exercises') && ProgrammingGroups.is_other_user(current_contributor)) {
+    if ($.isController('exercises') && typeof ProgrammingGroups !== 'undefined' && ProgrammingGroups.is_other_user(current_contributor)) {
 
       App.synchronized_editor = App.cable.subscriptions.create({
         channel: "SynchronizedEditorChannel", exercise_id: exercise_id


### PR DESCRIPTION
Previously, ProgrammingGroups could have been undefined in rare cases. Therefore, we check whether the variable is properly defined before calling the method.

Fixes [CODEOCEAN-FRONTEND-7D](https://codeocean.sentry.io/issues/5237549093/)