### PR TITLE
Fix layout for exercise description on implement route

### DIFF
--- a/app/views/exercises/implement.html.slim
+++ b/app/views/exercises/implement.html.slim
@@ -6,7 +6,7 @@
 #editor-column
   - unless @embed_options[:hide_exercise_description]
     .exercise.clearfix
-      .col-9.d-lg-flex.flex-row.justify-content-between.align-items-baseline
+      .d-lg-flex.flex-row.justify-content-between.align-items-baseline
         .col-lg-7
           h1#exercise-headline
             i#description-symbol class=(@embed_options[:collapse_exercise_description] ? 'fa-solid fa-chevron-right' : 'fa-solid fa-chevron-down')


### PR DESCRIPTION
Regresses 9a9efd5c and a7fa9b5b

| Before | After |
|--------|--------|
| <img width="1728" alt="Bildschirmfoto 2024-04-24 um 16 23 24" src="https://github.com/openHPI/codeocean/assets/7300329/2bc85dfd-a72a-4186-85bb-1590aa81783c"> | <img width="1725" alt="Bildschirmfoto 2024-04-24 um 16 23 43" src="https://github.com/openHPI/codeocean/assets/7300329/3cf64015-0339-4524-a83e-4a69a4411060"> | 