### PR TITLE
Fix margin for "Administration" menu on small screens

### DIFF
--- a/app/views/application/_navigation.html.slim
+++ b/app/views/application/_navigation.html.slim
@@ -1,7 +1,7 @@
 - if current_user.try(:admin?) || current_user.try(:teacher?)
   ul.nav.navbar-nav
     li.nav-item.dropdown
-      a.nav-link.dropdown-toggle.mx-3 data-bs-toggle='dropdown' href='#'
+      a.nav-link.dropdown-toggle.mx-lg-3 data-bs-toggle='dropdown' href='#'
         = t('shared.administration')
         span.caret
       ul.dropdown-menu.p-0.mt-1 role='menu'


### PR DESCRIPTION
This PR fixes a visual issue with the "Administration" menu alignment on smaller screens.

| Before | After |
|--------|--------|
| <img width="376" alt="Bildschirmfoto 2024-05-08 um 10 59 38" src="https://github.com/openHPI/codeocean/assets/7300329/d5aef2a9-79b4-4ee0-97a4-a0d6ff6c1fb1"> | <img width="376" alt="Bildschirmfoto 2024-05-08 um 10 59 55" src="https://github.com/openHPI/codeocean/assets/7300329/44d17217-b929-4cfb-8240-1fe298b0d2b2"> | 