### PR TITLE
Change order of Sprocket assets and introduce dependency

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,4 +19,19 @@
 //= require color_mode_picker
 //
 // app/assets
+// --> Include some assets first, as they are used by other assets.
+// --> Hence, the order specified here is important.
+//
+// 1. Some common base functions and monkey patches
+//= require base
+// 2. Programming groups are required by "channels/synchronized_editor_channel.js"
+//= require programming_groups
+// 3. The turtle library is required by "editor/turtle.js"
+//= require turtle
+// 4. Some channels are required by "editor/editor.js.erb"
+//= require_tree ./channels
+// 5. Require the editor components, as needed by "./editor.js" and "./community_solution.js"
+//= require_tree ./editor
+//
+// All remaining assets are loaded in alphabetical order
 //= require_tree .

--- a/app/assets/javascripts/channels/synchronized_editor_channel.js
+++ b/app/assets/javascripts/channels/synchronized_editor_channel.js
@@ -4,7 +4,7 @@ $(document).on('turbolinks:load', function () {
     var editor = $('#editor');
     var exercise_id = editor.data('exercise-id');
 
-    if ($.isController('exercises') && typeof ProgrammingGroups !== 'undefined' && ProgrammingGroups.is_other_user(current_contributor)) {
+    if ($.isController('exercises') && ProgrammingGroups.is_other_user(current_contributor)) {
 
       App.synchronized_editor = App.cable.subscriptions.create({
         channel: "SynchronizedEditorChannel", exercise_id: exercise_id

--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -27,15 +27,14 @@ var CodeOceanEditor = {
 
     lastCopyText: null,
 
-    <% self.class.include Rails.application.routes.url_helpers %>
     <% @config ||= CodeOcean::Config.new(:code_ocean).read(erb: false) %>
     // Important notice: Changing the config values requires any content-wise
     // modification for this file in the development environment. Lacking to do so
     // will result in the old, server-side cached serving of this file even across
     // server restarts!
     sendEvents: <%= @config['codeocean_events'] ? @config['codeocean_events']['enabled'] : false %>,
-    eventURL: "<%= @config['codeocean_events'] ? events_path : '' %>",
-    fileTypeURL: "<%= file_types_path %>",
+    eventURL: Routes.events_path(),
+    fileTypeURL: Routes.file_types_path(),
 
     confirmDestroy: function (event) {
         event.preventDefault();

--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -27,7 +27,7 @@ var CodeOceanEditor = {
 
     lastCopyText: null,
 
-    <% @config ||= CodeOcean::Config.new(:code_ocean).read(erb: false) %>
+    <% @config ||= CodeOcean::Config.new(:code_ocean, erb: false).read %>
     // Important notice: Changing the config values requires any content-wise
     // modification for this file in the development environment. Lacking to do so
     // will result in the old, server-side cached serving of this file even across

--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -1,3 +1,9 @@
+// Note: Directives are only processed if they come before any application code.
+// Once you have a line that does not include a comment or whitespace then Sprockets will stop looking for directives.
+// If you use a directive outside of the "header" of the document it will not do anything, and won't raise any errors.
+// <% config_file = CodeOcean::Config.new(:code_ocean, erb: false) %>
+//= depend_on <%= config_file.path.basename %>
+
 var CodeOceanEditor = {
     THEME: window.getCurrentTheme() === 'dark' ? 'ace/theme/tomorrow_night' : 'ace/theme/tomorrow',
 
@@ -27,12 +33,7 @@ var CodeOceanEditor = {
 
     lastCopyText: null,
 
-    <% @config ||= CodeOcean::Config.new(:code_ocean, erb: false).read %>
-    // Important notice: Changing the config values requires any content-wise
-    // modification for this file in the development environment. Lacking to do so
-    // will result in the old, server-side cached serving of this file even across
-    // server restarts!
-    sendEvents: <%= @config['codeocean_events'] ? @config['codeocean_events']['enabled'] : false %>,
+    sendEvents: <%= config_file.read['codeocean_events'] ? config_file.read['codeocean_events']['enabled'] : false %>,
     eventURL: Routes.events_path(),
     fileTypeURL: Routes.file_types_path(),
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,7 +6,8 @@
 Rails.application.config.assets.version = '1.1'
 
 # Add additional assets to the asset load path.
-# Rails.application.config.assets.paths << Emoji.images_path
+# We require the config directory to enable asset dependencies on CodeOcean::Config values (stored as YML files in `config`).
+Rails.application.config.assets.paths << Rails.root.join('config')
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/lib/code_ocean/config.rb
+++ b/lib/code_ocean/config.rb
@@ -2,12 +2,16 @@
 
 module CodeOcean
   class Config
-    def initialize(filename)
-      @filename = filename
+    attr_reader :path, :read
+
+    def initialize(filename, options = {})
+      @path = Rails.root.join('config', "#{filename}.yml#{options[:erb] ? '.erb' : ''}")
+      @read = parse(options)
     end
 
-    def read(options = {})
-      path = Rails.root.join('config', "#{@filename}.yml#{options[:erb] ? '.erb' : ''}")
+    private
+
+    def parse(options)
       if ::File.exist?(path)
         yaml_content = ::File.new(path, 'r').read || ''
         yaml_content = ERB.new(yaml_content).result if options[:erb]

--- a/lib/runner/strategy/docker_container_pool.rb
+++ b/lib/runner/strategy/docker_container_pool.rb
@@ -146,7 +146,7 @@ class Runner::Strategy::DockerContainerPool < Runner::Strategy
   def self.config
     @config ||= begin
       # Since the docker configuration file contains code that must be executed, we use ERB templating.
-      docker_config = CodeOcean::Config.new(:docker).read(erb: true)
+      docker_config = CodeOcean::Config.new(:docker, erb: true).read
       codeocean_config = CodeOcean::Config.new(:code_ocean).read[:runner_management] || {}
       # All keys in `docker_config` take precedence over those in `codeocean_config`
       docker_config.merge codeocean_config

--- a/spec/lib/code_ocean/config_spec.rb
+++ b/spec/lib/code_ocean/config_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CodeOcean::Config do
 
     context 'with a .yml.erb file' do
       let(:path) { Rails.root.join('config', "#{filename}.yml.erb") }
-      let(:read) { described_class.new(filename).read(erb: true) }
+      let(:read) { described_class.new(filename, erb: true).read }
 
       context 'when the file is present' do
         before { File.write(path, {Rails.env.to_s => content}.to_yaml) }


### PR DESCRIPTION
This PR aims to fix another JavaScript error shown in Sentry: [CODEOCEAN-FRONTEND-7W](https://codeocean.sentry.io/issues/5276691444/).

The error indicates that `CodeOceanEditorEvaluation is not defined` in the following location:

https://github.com/openHPI/codeocean/blob/7d5883acc4f8a7af8a105fabdbd99410b7673e2a/app/assets/javascripts/editor.js#L1-L14

I was surprised by this error and have never seen it before. Still, it is similar to [CODEOCEAN-FRONTEND-7D](https://codeocean.sentry.io/issues/5237549093/) fixed in #2270. Thus, I started to reflect on why that happens and what could be the issue. 

One idea I got is linked to the recent changes we made with JavaScript assets: We changed how the ACE editor and the Markdown editor were included, removing them from Sprockets (and its general `application.js` bundle), and moved them over to Webpack. Effectively, this reduced the file size of the Sprockets-generated JavaScript file, and potentially modified the order of elements. Potentially, this could result in a race condition, as previously identified with #2270 already. Now, however, I think that the way we generate the Sprockets-based  `application.js` bundle is the issue: By just using `require_tree`, we effectively included all our JavaScript files in an alphabetical order [[1]](https://github.com/rails/sprockets?tab=readme-ov-file#file-order-processing). This hasn't changed, and removing items should not affect the remaining alphabetical order. However, we also use Turbolinks with the `turbolinks:load` event.

The `turbolinks:load` event "fires once after the initial page load, and again after every Turbolinks visit" [[2]](https://github.com/turbolinks/turbolinks?tab=readme-ov-file#full-list-of-events). Further a contributor states that "`turbolinks:load` is always fired when Turbolinks loads a page via AJAX, but it does not wait for scripts to load" [[3]](https://github.com/turbolinks/turbolinks/issues/534#issuecomment-613064059). Investigating on our bundled `application.js`, I identified that the problematic `CodeOceanEditorEvaluation` (as well as other `CodeOceanEditor` elements) were only declared after being used in one of the `turbolinks:load` handlers. A good example for that is `CodeOceanEditorAJAX`, as shown in the table.

Thus, my conclusion is that the alphabetical order chosen by Sprockets is not ideal for our case, and maybe the smaller bundle size makes it more likely that we are now seeing the respective issues. As a consequence, I manually checked the dependencies and extracted a few components that I think should be loaded first. Once these are included in the bundle, I still use the `require_tree`, since Sprockets will automatically de-duplicate entries [[4]](https://github.com/rails/sprockets?tab=readme-ov-file#require) to ensure each asset is only included once in the bundle.

| Before | After |
|--------|--------|
| <img width="533" alt="Bildschirmfoto 2024-05-08 um 23 43 29" src="https://github.com/openHPI/codeocean/assets/7300329/66a2fc2c-f7a0-420e-beb1-8993899c4137"> | <img width="514" alt="Bildschirmfoto 2024-05-08 um 23 44 08" src="https://github.com/openHPI/codeocean/assets/7300329/de821855-3795-4566-85a3-c2394608362b"> | 
| `CodeOceanEditorAJAX ` is first used before declared | `CodeOceanEditorAJAX ` is first declared, later used (search: `3 of 3`) |

Please take a moment to think through the solution chosen and whether you'd assume it fixes the underlying issue. Further, reviewing commit-by-commit is recommended.