### PR TITLE
Explicitly state permissions for CommunitySolutionPolicy

### DIFF
--- a/app/policies/community_solution_policy.rb
+++ b/app/policies/community_solution_policy.rb
@@ -1,11 +1,31 @@
 # frozen_string_literal: true
 
 class CommunitySolutionPolicy < AdminOnlyPolicy
+  def show?
+    # We don't have a show action, so no one can show a CommunitySolution directly.
+    no_one
+  end
+
+  def new?
+    # We don't have a destroy action, so no one can create a CommunitySolution directly.
+    no_one
+  end
+
+  def create?
+    # We don't have a destroy action, so no one can initialize a CommunitySolution directly.
+    no_one
+  end
+
   def edit?
     everyone
   end
 
   def update?
     everyone
+  end
+
+  def destroy?
+    # We don't have a destroy action, so no one can destroy a CommunitySolution directly.
+    no_one
   end
 end

--- a/spec/policies/community_solution_policy_spec.rb
+++ b/spec/policies/community_solution_policy_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CommunitySolutionPolicy do
+  subject(:policy) { described_class }
+
+  permissions(:index?) do
+    it 'grants access to admins only' do
+      expect(policy).to permit(build(:admin), Consumer.new)
+      %i[external_user teacher].each do |factory_name|
+        expect(policy).not_to permit(create(factory_name), Consumer.new)
+      end
+    end
+  end
+
+  %i[edit? update?].each do |action|
+    permissions(action) do
+      it 'grants access to anyone' do
+        %i[admin external_user teacher].each do |factory_name|
+          expect(policy).to permit(create(factory_name), CommunitySolution.new)
+        end
+      end
+    end
+  end
+
+  %i[create? destroy? new? show?].each do |action|
+    permissions(action) do
+      it 'does not grant access to anyone' do
+        %i[admin external_user teacher].each do |factory_name|
+          expect(policy).not_to permit(create(factory_name), CommunitySolution.new)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Viewing the index page for community solutions was broken, since the breadcrumbs tried to access the `show?` policy.