### PR TITLE
Convert errors captured with Sentry to JSON

### DIFF
--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -215,8 +215,8 @@ var CodeOceanEditor = {
                     try {
                         return await callback();
                     } catch (error) {
-                        console.error(error);
-                        Sentry.captureException(error, {mechanism: {handled: false}});
+                        console.error(JSON.stringify(error));
+                        Sentry.captureException(JSON.stringify(error), {mechanism: {handled: false}});
                     }
                 });
             });


### PR DESCRIPTION
Otherwise, the events might be captured as:

```js
{
  currentTarget: [object WebSocket],
  isTrusted: true,
  target: [object WebSocket],
  type: error
}
```