### PR TITLE
Prevent duplicate error handling for WebSocket events

### DIFF
--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -215,6 +215,9 @@ var CodeOceanEditor = {
                     try {
                         return await callback();
                     } catch (error) {
+                        // WebSocket errors are handled in `showWebsocketError` already.
+                        if (error.target instanceof WebSocket) return;
+
                         console.error(JSON.stringify(error));
                         Sentry.captureException(JSON.stringify(error), {mechanism: {handled: false}});
                     }


### PR DESCRIPTION
With the current implementation, some errors were captured twice (or only a single time, even if not desired at all).

The special WebSocket errors are not nicely captured here:

<img width="478" alt="Bildschirmfoto 2024-05-25 um 20 15 00" src="https://github.com/openHPI/codeocean/assets/7300329/ebcfd792-40d7-45e7-a94a-f1cf8f47b5f7">

Further, they lacked a complete stack trace:

<img width="925" alt="Bildschirmfoto 2024-05-25 um 20 16 21" src="https://github.com/openHPI/codeocean/assets/7300329/61b30dff-b660-4098-962c-850c08f0c113">

Therefore, we delegate this to a dedicated method `showWebsocketError` already capturing Sentry events:

https://github.com/openHPI/codeocean/blob/c5518bb592aa47650db29ed2cc5b8e1862853dab/app/assets/javascripts/editor/editor.js.erb#L895-L905

Regularly, we disable this error tracing, i.e., when closing the connection.

https://github.com/openHPI/codeocean/blob/c5518bb592aa47650db29ed2cc5b8e1862853dab/app/assets/javascripts/editor/evaluation.js#L144

Still, with the current implementation, a (misleading) error would still be captured a single time in Sentry.