### PR TITLE
Prevent error during RfC create when navigating

### DIFF
--- a/app/assets/javascripts/editor/participantsupport.js.erb
+++ b/app/assets/javascripts/editor/participantsupport.js.erb
@@ -108,11 +108,15 @@ CodeOceanEditorFlowr = {
 CodeOceanEditorRequestForComments = {
   requestComments: function () {
     const cause = $('#requestComments');
-    const editor = $('#editor')
-    const questionElement = $('#question')
     this.newSentryTransaction(cause, async () => {
+      const editor = $('#editor')
+      const questionElement = $('#question')
+      const closeAskForCommentsButton = $('#closeAskForCommentsButton');
+      const askForCommentsButton = $('#askForCommentsButton');
+      const commentModal = $('#comment-modal');
+
       questionElement.prop("disabled", true);
-      $('#closeAskForCommentsButton').addClass('d-none');
+      closeAskForCommentsButton.addClass('d-none');
 
       const exercise_id = editor.data('exercise-id');
       const file_id = $('.editor').data('id');
@@ -121,7 +125,7 @@ CodeOceanEditorRequestForComments = {
       const submission = await this.createSubmission(cause, null).catch(this.ajaxError.bind(this));
       if (!submission) return;
 
-      this.showSpinner($('#askForCommentsButton'));
+      this.showSpinner(askForCommentsButton);
 
       const response = await $.ajax({
         method: 'POST',
@@ -136,11 +140,11 @@ CodeOceanEditorRequestForComments = {
         }
       }).catch(this.ajaxError.bind(this));
 
-      bootstrap.Modal.getInstance($('#comment-modal')).hide();
+      bootstrap.Modal.getInstance(commentModal).hide();
       this.hideSpinner();
-      $('#question').prop("disabled", false).val('');
-      $('#closeAskForCommentsButton').removeClass('d-none');
-      $('#askForCommentsButton').one('click', this.requestComments.bind(this));
+      questionElement.prop("disabled", false).val('');
+      closeAskForCommentsButton.removeClass('d-none');
+      askForCommentsButton.one('click', this.requestComments.bind(this));
 
       // we disabled the button to prevent that the user spams RFCs, but decided against this now.
       //var button = $('#requestComments');
@@ -148,7 +152,7 @@ CodeOceanEditorRequestForComments = {
 
       if (response) {
         await this.runSubmission(submission);
-        $.flash.success({text: $('#askForCommentsButton').data('message-success')});
+        $.flash.success({text: askForCommentsButton.data('message-success')});
       }
     });
   }


### PR DESCRIPTION
Previously, an error could occur when creating an RfC. The erroneous behavior was triggered with the following steps:

1. A learner is on the implement page
2. They click on another link to leave the current page
3. Before the new page opens (through Turbolinks), the "request comments" button was hit
4. Still before the new page was visible, a question was entered and the RfC was submitted.
5. The new page opens
6. Creating the RfC was successful, and a code run should be triggered (as well as hiding the question modal etc.)

With this commit, we still allow creating an RfC without error even if the page was left before everything finished.

Fixes [CODEOCEAN-FRONTEND-9C](https://codeocean.sentry.io/issues/5410402406/)