### PR TITLE
Capture non-JSON error in newSentryTransaction

### DIFF
--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -215,8 +215,8 @@ var CodeOceanEditor = {
                     // WebSocket errors are handled in `showWebsocketError` already.
                     if (error.target instanceof WebSocket) return;
 
-                    console.error(JSON.stringify(error));
-                    Sentry.captureException(JSON.stringify(error), {mechanism: {handled: false}});
+                    console.error(error);
+                    Sentry.captureException(error, {mechanism: {handled: false, data: {error_json: JSON.stringify(error)}}});
                 }
             });
         });


### PR DESCRIPTION
Using the JSON representation of the error only works for some errors, whereas others are simply marked with a {}. Still, we attach the JSON representation to the Sentry event captured.