### PR TITLE
Fix incorrect translation on exercise edit

### DIFF
--- a/app/views/exercises/_file_form.html.slim
+++ b/app/views/exercises/_file_form.html.slim
@@ -42,10 +42,10 @@ li.card.mt-2
               = f.label(:hidden_feedback, class: 'form-label mb-0')
               .help-block.form-text.mb-0 = t('.hints.hidden_feedback')
         .mb-3
-          = f.label(:name, class: 'form-label')
+          = f.label(:feedback_message, class: 'form-label')
           = f.text_area(:feedback_message, class: 'form-control', maxlength: 255)
           .help-block.form-text = t('.hints.feedback_message')
         .mb-3
-          = f.label(:role, class: 'form-label')
+          = f.label(:weight, class: 'form-label')
           = f.number_field(:weight, class: 'form-control', min: 0, step: 'any')
       = render('code_field', attribute: :content, form: f)


### PR DESCRIPTION
It seems like we mixed up two translations while working on #2248. With this PR, we fix the erroneous labels.