### PR TITLE
Improve error handling for LTI sessions

### DIFF
--- a/app/controllers/concerns/lti.rb
+++ b/app/controllers/concerns/lti.rb
@@ -56,7 +56,7 @@ module Lti
   end
 
   def refuse_lti_launch(options = {})
-    return_to_consumer(lti_errorlog: options[:message], lti_errormsg: t('sessions.oauth.failure'))
+    return_to_consumer(lti_errormsg: t('sessions.oauth.failure', error: options[:message]))
   end
 
   def require_oauth_parameters

--- a/app/controllers/concerns/lti.rb
+++ b/app/controllers/concerns/lti.rb
@@ -20,9 +20,8 @@ module Lti
   end
 
   def consumer_return_url(provider, options = {})
-    consumer_return_url = provider.try(:launch_presentation_return_url) || params[:launch_presentation_return_url]
-    consumer_return_url += "?#{options.to_query}" if consumer_return_url && options.present?
-    consumer_return_url
+    url = provider.try(:launch_presentation_return_url) || params[:launch_presentation_return_url]
+    AuthenticatedUrlHelper.add_query_parameters(url, options)
   end
 
   def external_user_email(provider)
@@ -97,10 +96,9 @@ module Lti
   end
 
   def return_to_consumer(options = {})
-    consumer_return_url = @provider.try(:launch_presentation_return_url)
-    if consumer_return_url
-      consumer_return_url += "?#{options.to_query}" if options.present?
-      redirect_to(consumer_return_url, allow_other_host: true)
+    return_url = consumer_return_url(@provider, options)
+    if return_url
+      redirect_to(return_url, allow_other_host: true)
     else
       flash[:danger] = options[:lti_errormsg]
       flash[:info] = options[:lti_msg]

--- a/app/controllers/concerns/lti.rb
+++ b/app/controllers/concerns/lti.rb
@@ -96,6 +96,10 @@ module Lti
   end
 
   def return_to_consumer(options = {})
+    # The `lti_errorlog` is only *logged* at the consumer and not necessarily displayed to the user.
+    # The `lti_errormsg` is displayed to the user as an error.
+    # The `lti_log` is only *logged* at the consumer and not necessarily displayed to the user.
+    # The `lti_msg` is displayed to the user as an information.
     return_url = consumer_return_url(@provider, options)
     if return_url
       redirect_to(return_url, allow_other_host: true)

--- a/app/controllers/concerns/lti.rb
+++ b/app/controllers/concerns/lti.rb
@@ -72,6 +72,14 @@ module Lti
     refuse_lti_launch(message: t('sessions.oauth.invalid_consumer')) unless @consumer
   end
 
+  def require_valid_launch_presentation_return_url
+    # We want to check that any URL given is absolute, but none URL is fine, too.
+    return unless params[:launch_presentation_return_url]
+
+    url = URI.parse(params[:launch_presentation_return_url])
+    refuse_lti_launch(message: t('sessions.oauth.invalid_launch_presentation_return_url')) unless url.absolute?
+  end
+
   def require_valid_lis_outcome_service_url
     # We want to check that any URL given is absolute, but none URL is fine, too.
     return unless params[:lis_outcome_service_url]

--- a/app/controllers/concerns/lti.rb
+++ b/app/controllers/concerns/lti.rb
@@ -109,7 +109,7 @@ module Lti
     # The `lti_log` is only *logged* at the consumer and not necessarily displayed to the user.
     # The `lti_msg` is displayed to the user as an information.
     return_url = consumer_return_url(@provider, options)
-    if return_url
+    if return_url && URI.parse(return_url).absolute?
       redirect_to(return_url, allow_other_host: true)
     else
       flash[:danger] = options[:lti_errormsg]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,8 +4,8 @@ class SessionsController < ApplicationController
   include Lti
 
   %i[require_oauth_parameters require_valid_consumer_key require_valid_oauth_signature require_unique_oauth_nonce
-     require_valid_lis_outcome_service_url set_current_user require_valid_exercise_token set_study_group_membership
-     set_embedding_options].each do |method_name|
+     require_valid_launch_presentation_return_url require_valid_lis_outcome_service_url set_current_user require_valid_exercise_token
+     set_study_group_membership set_embedding_options].each do |method_name|
     before_action(method_name, only: :create_through_lti)
   end
 

--- a/app/helpers/authenticated_url_helper.rb
+++ b/app/helpers/authenticated_url_helper.rb
@@ -90,7 +90,7 @@ module AuthenticatedUrlHelper
       query_params.merge!(parameters)
 
       # Add the query string back to the URL
-      parsed_url.query = URI.encode_www_form(query_params)
+      parsed_url.query = URI.encode_www_form(query_params) if query_params.present?
 
       # Return the full URL
       parsed_url.to_s

--- a/app/views/sessions/destroy_through_lti.html.slim
+++ b/app/views/sessions/destroy_through_lti.html.slim
@@ -4,7 +4,7 @@ p
   / i18n-tasks-use t('.success_with_outcome') t('.success_without_outcome')
   = t(".success_#{@lti_parameter ? 'with' : 'without'}_outcome", consumer: current_user.consumer)
   / i18n-tasks-use t('.finished_with_consumer') t('.finished_without_consumer')
-  ==< t(".finished_#{@lti_parameter ? 'with' : 'without'}_consumer", consumer: h(current_user.consumer.name), url: @url)
+  ==< t(".finished_#{@url ? 'with' : 'without'}_consumer", consumer: h(current_user.consumer.name), url: @url)
   =< t('.do_not_use_backbutton')
 
 h2 = t('shared.statistics')

--- a/config/locales/de/session.yml
+++ b/config/locales/de/session.yml
@@ -32,6 +32,7 @@ de:
       failure: Leider ist ein Fehler aufgetreten.
       invalid_consumer: Ungültiger OAuth-Key.
       invalid_exercise_token: Ungültiges Aufgaben-Token.
+      invalid_launch_presentation_return_url: Ungültige URL für die LTI-Rückgabe
       invalid_lis_outcome_service_url: Ungültige URL für den LTI-Ergebnisdienst.
       invalid_signature: Ungültige OAuth-Signatur.
       missing_parameters: OAuth-Parameter fehlen.

--- a/config/locales/de/session.yml
+++ b/config/locales/de/session.yml
@@ -29,11 +29,11 @@ de:
       link: Anmelden
       remember_me: Angemeldet bleiben
     oauth:
-      failure: Leider ist ein Fehler aufgetreten.
-      invalid_consumer: Ungültiger OAuth-Key.
-      invalid_exercise_token: Ungültiges Aufgaben-Token.
+      failure: 'Leider ist ein Fehler aufgetreten: %{error}. Bitte wenden Sie sich an einen Administrator der E-Learning-Plattform, um die Konfiguration überprüfen zu lassen.'
+      invalid_consumer: Ungültiger OAuth-Key
+      invalid_exercise_token: Ungültiges Aufgaben-Token
       invalid_launch_presentation_return_url: Ungültige URL für die LTI-Rückgabe
-      invalid_lis_outcome_service_url: Ungültige URL für den LTI-Ergebnisdienst.
-      invalid_signature: Ungültige OAuth-Signatur.
-      missing_parameters: OAuth-Parameter fehlen.
-      used_nonce: Die Nonce wurde bereits verwendet.
+      invalid_lis_outcome_service_url: Ungültige URL für den LTI-Ergebnisdienst
+      invalid_signature: Ungültige OAuth-Signatur
+      missing_parameters: OAuth-Parameter fehlen
+      used_nonce: Die Nonce wurde bereits verwendet

--- a/config/locales/en/session.yml
+++ b/config/locales/en/session.yml
@@ -29,11 +29,11 @@ en:
       link: Sign In
       remember_me: Remember me
     oauth:
-      failure: Sorry, something went wrong.
-      invalid_consumer: Invalid OAuth key.
-      invalid_exercise_token: Invalid exercise token.
+      failure: 'Sorry, something went wrong: %{error}. Please ask an administrator of the e-learning platform to check the configuration.'
+      invalid_consumer: Invalid OAuth key
+      invalid_exercise_token: Invalid exercise token
       invalid_launch_presentation_return_url: Invalid LTI return URL
-      invalid_lis_outcome_service_url: Invalid LTI outcome service URL.
-      invalid_signature: Invalid OAuth signature.
-      missing_parameters: Missing OAuth parameters.
-      used_nonce: Nonce has already been used.
+      invalid_lis_outcome_service_url: Invalid LTI outcome service URL
+      invalid_signature: Invalid OAuth signature
+      missing_parameters: Missing OAuth parameters
+      used_nonce: Nonce has already been used

--- a/config/locales/en/session.yml
+++ b/config/locales/en/session.yml
@@ -32,6 +32,7 @@ en:
       failure: Sorry, something went wrong.
       invalid_consumer: Invalid OAuth key.
       invalid_exercise_token: Invalid exercise token.
+      invalid_launch_presentation_return_url: Invalid LTI return URL
       invalid_lis_outcome_service_url: Invalid LTI outcome service URL.
       invalid_signature: Invalid OAuth signature.
       missing_parameters: Missing OAuth parameters.

--- a/spec/concerns/lti_spec.rb
+++ b/spec/concerns/lti_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Lti do
   describe '#refuse_lti_launch' do
     it 'returns to the tool consumer' do
       message = I18n.t('sessions.oauth.invalid_consumer')
-      expect(controller).to receive(:return_to_consumer).with(lti_errorlog: message, lti_errormsg: I18n.t('sessions.oauth.failure'))
+      expect(controller).to receive(:return_to_consumer).with(lti_errormsg: I18n.t('sessions.oauth.failure', error: message))
       controller.send(:refuse_lti_launch, message:)
     end
   end
@@ -62,7 +62,7 @@ RSpec.describe Lti do
       end
 
       it 'passes messages to the consumer' do
-        message = I18n.t('sessions.oauth.failure')
+        message = I18n.t('sessions.oauth.failure', error: 'dummy error')
         expect(controller).to receive(:redirect_to).with("#{consumer_return_url}?lti_errorlog=#{CGI.escape(message)}", allow_other_host: true)
         controller.send(:return_to_consumer, lti_errorlog: message)
       end
@@ -89,7 +89,7 @@ RSpec.describe Lti do
       end
 
       it 'displays alerts' do
-        message = I18n.t('sessions.oauth.failure')
+        message = I18n.t('sessions.oauth.failure', error: 'dummy error')
         controller.send(:return_to_consumer, lti_errormsg: message)
         expect(controller.instance_variable_get(:@flash)[:danger]).to eq(obtain_message(message))
       end

--- a/spec/concerns/lti_spec.rb
+++ b/spec/concerns/lti_spec.rb
@@ -76,6 +76,36 @@ RSpec.describe Lti do
           controller.send(:return_to_consumer, lti_errorlog: message, lti_msg: message)
         end
       end
+
+      context 'when the return URL is empty' do
+        let(:consumer_return_url) { '' }
+
+        it 'redirects to the root URL' do
+          expect(controller).to receive(:redirect_to).with(:root)
+          controller.send(:return_to_consumer)
+        end
+
+        it 'displays alerts' do
+          message = I18n.t('sessions.oauth.failure', error: 'dummy error')
+          controller.send(:return_to_consumer, lti_errormsg: message)
+          expect(controller.instance_variable_get(:@flash)[:danger]).to eq(obtain_message(message))
+        end
+      end
+
+      context 'when the return URL is relative' do
+        let(:consumer_return_url) { '/path' }
+
+        it 'redirects to the root URL' do
+          expect(controller).to receive(:redirect_to).with(:root)
+          controller.send(:return_to_consumer)
+        end
+
+        it 'displays alerts' do
+          message = I18n.t('sessions.oauth.failure', error: 'dummy error')
+          controller.send(:return_to_consumer, lti_errormsg: message)
+          expect(controller.instance_variable_get(:@flash)[:danger]).to eq(obtain_message(message))
+        end
+      end
     end
 
     context 'without a return URL' do

--- a/spec/concerns/lti_spec.rb
+++ b/spec/concerns/lti_spec.rb
@@ -66,6 +66,16 @@ RSpec.describe Lti do
         expect(controller).to receive(:redirect_to).with("#{consumer_return_url}?lti_errorlog=#{CGI.escape(message)}", allow_other_host: true)
         controller.send(:return_to_consumer, lti_errorlog: message)
       end
+
+      context 'when the return URL already contains a query parameter' do
+        let(:consumer_return_url) { 'https://example.org?foo=bar' }
+
+        it 'correctly appends query parameters' do
+          message = I18n.t('sessions.oauth.failure', error: 'dummy error')
+          expect(controller).to receive(:redirect_to).with("#{consumer_return_url}&lti_errorlog=#{CGI.escape(message)}&lti_msg=#{CGI.escape(message)}", allow_other_host: true)
+          controller.send(:return_to_consumer, lti_errorlog: message, lti_msg: message)
+        end
+      end
     end
 
     context 'without a return URL' do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -88,10 +88,24 @@ RSpec.describe SessionsController do
     end
 
     context 'without a valid absolute LIS Outcome service URL' do
-      it 'refuses the LTI launch' do
-        allow_any_instance_of(IMS::LTI::ToolProvider).to receive(:valid_request?).and_return(true)
-        expect(controller).to receive(:refuse_lti_launch).with(message: I18n.t('sessions.oauth.invalid_lis_outcome_service_url')).and_call_original
-        post :create_through_lti, params: {oauth_consumer_key: consumer.oauth_key, oauth_nonce: nonce, oauth_signature: SecureRandom.hex, lis_outcome_service_url: '/relative/url'}
+      shared_examples 'a handled error' do
+        it 'refuses the LTI launch' do
+          allow_any_instance_of(IMS::LTI::ToolProvider).to receive(:valid_request?).and_return(true)
+          expect(controller).to receive(:refuse_lti_launch).with(message: I18n.t('sessions.oauth.invalid_lis_outcome_service_url')).and_call_original
+          post :create_through_lti, params: {oauth_consumer_key: consumer.oauth_key, oauth_nonce: nonce, oauth_signature: SecureRandom.hex, lis_outcome_service_url:}
+        end
+      end
+
+      context 'with an empty URL' do
+        let(:lis_outcome_service_url) { '' }
+
+        it_behaves_like 'a handled error'
+      end
+
+      context 'with a relative URL' do
+        let(:lis_outcome_service_url) { '/relative/url' }
+
+        it_behaves_like 'a handled error'
       end
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -65,6 +65,28 @@ RSpec.describe SessionsController do
       end
     end
 
+    context 'without a valid absolute launch return presentation URL' do
+      shared_examples 'a handled error' do
+        it 'refuses the LTI launch' do
+          allow_any_instance_of(IMS::LTI::ToolProvider).to receive(:valid_request?).and_return(true)
+          expect(controller).to receive(:refuse_lti_launch).with(message: I18n.t('sessions.oauth.invalid_launch_presentation_return_url')).and_call_original
+          post :create_through_lti, params: {oauth_consumer_key: consumer.oauth_key, oauth_nonce: nonce, oauth_signature: SecureRandom.hex, launch_presentation_return_url:}
+        end
+      end
+
+      context 'with an empty URL' do
+        let(:launch_presentation_return_url) { '' }
+
+        it_behaves_like 'a handled error'
+      end
+
+      context 'with a relative URL' do
+        let(:launch_presentation_return_url) { '/relative/url' }
+
+        it_behaves_like 'a handled error'
+      end
+    end
+
     context 'without a valid absolute LIS Outcome service URL' do
       it 'refuses the LTI launch' do
         allow_any_instance_of(IMS::LTI::ToolProvider).to receive(:valid_request?).and_return(true)
@@ -83,7 +105,7 @@ RSpec.describe SessionsController do
 
     context 'with valid launch parameters' do
       let(:locale) { :de }
-      let(:perform_request) { post :create_through_lti, params: {custom_locale: locale, custom_token: exercise.token, oauth_consumer_key: consumer.oauth_key, oauth_nonce: nonce, oauth_signature: SecureRandom.hex, user_id: user.external_id, lis_outcome_service_url: 'https://example.org/'} }
+      let(:perform_request) { post :create_through_lti, params: {custom_locale: locale, custom_token: exercise.token, oauth_consumer_key: consumer.oauth_key, oauth_nonce: nonce, oauth_signature: SecureRandom.hex, user_id: user.external_id, launch_presentation_return_url: 'https://example.org/', lis_outcome_service_url: 'https://example.org/'} }
       let(:user) { create(:external_user, consumer:) }
 
       before { allow_any_instance_of(IMS::LTI::ToolProvider).to receive(:valid_request?).and_return(true) }

--- a/spec/factories/lti_parameter.rb
+++ b/spec/factories/lti_parameter.rb
@@ -23,5 +23,9 @@ FactoryBot.define do
     trait :without_outcome_service_url do
       lti_parameters { lti_params.except(:lis_outcome_service_url) }
     end
+
+    trait :without_return_url do
+      lti_parameters { lti_params.except(:launch_presentation_return_url) }
+    end
   end
 end

--- a/spec/helpers/authenticated_url_helper_spec.rb
+++ b/spec/helpers/authenticated_url_helper_spec.rb
@@ -11,5 +11,9 @@ RSpec.describe AuthenticatedUrlHelper do
     it 'does not duplicate existing parameters' do
       expect(described_class.add_query_parameters(root_url(foo: 'bar'), {foo: 'baz'})).to eq(root_url(foo: 'baz'))
     end
+
+    it 'does not add a trailing question mark when called without parameters' do
+      expect(described_class.add_query_parameters(root_url, {})).to eq(root_url)
+    end
   end
 end

--- a/spec/views/sessions/destroy_through_lti.html.slim_spec.rb
+++ b/spec/views/sessions/destroy_through_lti.html.slim_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'sessions/destroy_through_lti.html.slim' do
+  let(:consumer) { create(:consumer) }
+  let(:submission) { create(:submission, exercise: create(:dummy)) }
+
+  before do
+    without_partial_double_verification do
+      allow(view).to receive_messages(current_user: submission.contributor)
+    end
+
+    assign(:submission, submission)
+    assign(:lti_parameter, lti_parameter)
+    assign(:url, url)
+
+    render
+  end
+
+  context 'when a launch return presentation URL is provided' do
+    let(:url) { 'https://example.com' }
+
+    context 'when a LIS Outcome service URL is provided' do
+      let(:lti_parameter) { create(:lti_parameter, external_user: submission.contributor) }
+
+      it 'contains the desired success message' do
+        expect(rendered).to include(I18n.t('sessions.destroy_through_lti.success_with_outcome', consumer:))
+      end
+
+      it 'contains the desired finish message' do
+        expect(rendered).to include(I18n.t('sessions.destroy_through_lti.finished_with_consumer', consumer:, url:))
+      end
+    end
+
+    context 'when no LIS Outcome service URL is provided' do
+      let(:lti_parameter) { create(:lti_parameter, :without_outcome_service_url, external_user: submission.contributor) }
+
+      it 'contains the desired success message' do
+        expect(rendered).to include(I18n.t('sessions.destroy_through_lti.success_without_outcome'))
+      end
+
+      it 'contains the desired finish message' do
+        expect(rendered).to include(I18n.t('sessions.destroy_through_lti.finished_with_consumer', consumer:, url:))
+      end
+    end
+  end
+
+  context 'when no launch return presentation URL is provided' do
+    let(:url) { nil }
+
+    context 'when a LIS Outcome service URL is provided' do
+      let(:lti_parameter) { create(:lti_parameter, :without_return_url, external_user: submission.contributor) }
+
+      it 'contains the desired success message' do
+        expect(rendered).to include(I18n.t('sessions.destroy_through_lti.success_with_outcome', consumer:))
+      end
+
+      it 'contains the desired finish message' do
+        expect(rendered).to include(I18n.t('sessions.destroy_through_lti.finished_without_consumer'))
+      end
+    end
+
+    context 'when no LIS Outcome service URL is provided' do
+      let(:lti_parameter) { create(:lti_parameter, :without_return_url, :without_outcome_service_url, external_user: submission.contributor) }
+
+      it 'contains the desired success message' do
+        expect(rendered).to include(I18n.t('sessions.destroy_through_lti.success_without_outcome'))
+      end
+
+      it 'contains the desired finish message' do
+        expect(rendered).to include(I18n.t('sessions.destroy_through_lti.finished_without_consumer'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes multiple smaller issues with LTI launch requests. It mainly improves two aspects:

- It shows more error details in case of a rejected launch request.
- The `launch_presentation_return_url` is also validated (similar to `lis_outcome_service_url` added in #2275) and now considered optional

Besides these aspects, the PR tackles other, minor issues. Therefore, reviewing commit-by-commit is recommended.