### PR TITLE
Reorder includes for `spec_helper` and `rails_helper`

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,11 +5,14 @@ ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
 require 'support/prometheus_client_stub'
 require File.expand_path('../config/environment', __dir__)
+
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
+
+# Add additional requires below this line. Rails is not loaded until this point!
 require 'rspec/rails'
 require 'pundit/rspec'
-# Add additional requires below this line. Rails is not loaded until this point!
+require 'webmock/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,10 @@ unless RUBY_PLATFORM == 'java' || ENV.fetch('RUBYMINE_SIMPLECOV_COVERAGE_PATH', 
   SimpleCov.start('rails')
 end
 
-require 'webmock/rspec'
+RSpec::Matchers.define_negated_matcher :avoid_change, :change
+RSpec::Matchers.define_negated_matcher :not_include, :include
+RSpec::Matchers.define_negated_matcher :not_have_attributes, :have_attributes
+RSpec::Matchers.define_negated_matcher :not_eql, :eql
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
While working on https://github.com/openHPI/codeharbor/pull/1463, I noticed some differences between CodeOcean and CodeHarbor. This PR aligns both code bases again with each other.