### PR TITLE
Disable footnote backlinks in Markdown

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,7 +50,13 @@ module ApplicationHelper
   end
 
   def render_markdown(markdown)
-    ActionController::Base.helpers.sanitize Kramdown::Document.new(markdown, input: 'GFM', hard_wrap: false, smart_quotes: 'apos,apos,quot,quot').to_html.strip
+    ActionController::Base.helpers.sanitize Kramdown::Document.new(
+      markdown,
+      input: 'GFM',
+      hard_wrap: false,
+      smart_quotes: 'apos,apos,quot,quot',
+      footnote_backlink: nil
+    ).to_html.strip
   end
 
   def row(options = {}, &block)


### PR DESCRIPTION
These backlinks don't work reliably and are thus more harmful than useful.