### PR TITLE
Correctly set `hidden_feedback` for inherited files

### DIFF
--- a/app/models/code_ocean/file.rb
+++ b/app/models/code_ocean/file.rb
@@ -136,7 +136,7 @@ module CodeOcean
     end
 
     def set_ancestor_values
-      %i[feedback_message file_type hidden name path read_only role weight].each do |attribute|
+      %i[feedback_message file_type hidden name path read_only role weight hidden_feedback].each do |attribute|
         send(:"#{attribute}=", ancestor.send(attribute))
       end
     end


### PR DESCRIPTION
Without this fix, `hidden_feedback` was only effective when `read_only` was set, too.

/cc @brry: This fixes the erroneous behavior we just observed together.
