### PR TITLE
Add noreferrer policy for external links

### DIFF
--- a/app/views/application/help.html.slim
+++ b/app/views/application/help.html.slim
@@ -11,4 +11,4 @@
       - ApplicationController::LEGAL_SETTINGS.each do |name, link|
         li
           / i18n-tasks-use t('shared.help.privacy_policy') t('shared.help.imprint')
-          = link_to(t("shared.help.#{name.delete_suffix('_url')}"), link, target: '_blank', rel: 'noopener')
+          = link_to(t("shared.help.#{name.delete_suffix('_url')}"), link, target: '_blank', rel: 'noopener noreferrer')

--- a/app/views/exercises/implement.html.slim
+++ b/app/views/exercises/implement.html.slim
@@ -20,7 +20,7 @@
                 = t('exercises.editor.start_video')
 
               .small.text-body-tertiary.text-nowrap.mt-1
-                a href='https://www.tu-ilmenau.de/datenschutz' target='_blank' rel='noopener'
+                a href='https://www.tu-ilmenau.de/datenschutz' target='_blank' rel='noopener noreferrer'
                   = t('exercises.implement.external_privacy_policy')
 
             span.me-3.mt-1

--- a/config/locales/de/execution_environment.yml
+++ b/config/locales/de/execution_environment.yml
@@ -29,7 +29,7 @@ de:
       hints:
         command: "<em>filename</em> wird automatisch durch den richtigen Dateinamen ersetzt. Das folgende Zeichen ist verboten: ' (einfaches Anführungszeichen)"
         cpu_limit: Geben Sie die Mindestmenge an CPU-Anteilen an, die für jeden Runner reserviert werden soll, gemessen in MHz.
-        docker_image: Wählen Sie ein Docker-Image aus der Liste oder fügen Sie ein neues hinzu, welches über <a href="https://hub.docker.com/" target="_blank" rel="noopener">DockerHub</a> verfügbar ist.
+        docker_image: Wählen Sie ein Docker-Image aus der Liste oder fügen Sie ein neues hinzu, welches über <a href="https://hub.docker.com/" target="_blank" rel="noopener noreferrer">DockerHub</a> verfügbar ist.
         exposed_ports_list: Während der Ausführung sind diese Ports für Lernende zugänglich. Die Portnummern müssen nummerisch und mit Komma voneinander getrennt sein.
     index:
       shell: Shell

--- a/config/locales/de/exercise.yml
+++ b/config/locales/de/exercise.yml
@@ -63,7 +63,7 @@ de:
       is_offline: "%{name} ist offline"
       is_online: "%{name} ist online"
       lastsaved: 'Zuletzt gespeichert: '
-      network: 'Während Ihr Code läuft, ist Port %{port} unter folgender Adresse erreichbar: <a href="%{address}" target="_blank" rel="noopener">%{address}</a>.'
+      network: 'Während Ihr Code läuft, ist Port %{port} unter folgender Adresse erreichbar: <a href="%{address}" target="_blank" rel="noopener noreferrer">%{address}</a>.'
       out_of_memory: Ausführung gestoppt. Ihr Code hat den erlaubten Arbeitsspeicher von %{memory_limit} MB überschritten.
       render: Anzeigen
       requestComments: Kommentare erbitten
@@ -168,7 +168,7 @@ de:
         go_to_question: Lösung ansehen
         heading: Weitere Hinweise | Unterstützt von StackOverflow
       intervention:
-        explanation: 'Diese Meldung erscheint, weil Sie %{duration} Minuten an dieser Aufgabe gearbeitet haben. 25% Ihrer Mitlernenden arbeiten länger daran, insofern ist das kein Problem, aber dies hat sich als <a href=''https://hpi.de/forschung/publikationen/dissertationen/dissertation-ralf-teusner.html'' style=''display: contents;'' target=''_blank'' rel=''noopener''>effektiven Zeitpunkt für diese Meldung</a> erwiesen.'
+        explanation: 'Diese Meldung erscheint, weil Sie %{duration} Minuten an dieser Aufgabe gearbeitet haben. 25% Ihrer Mitlernenden arbeiten länger daran, insofern ist das kein Problem, aber dies hat sich als <a href=''https://hpi.de/forschung/publikationen/dissertationen/dissertation-ralf-teusner.html'' style=''display: contents;'' target=''_blank'' rel=''noopener noreferrer''>effektiven Zeitpunkt für diese Meldung</a> erwiesen.'
       linter_file: Linter-Feedback <span class="number d-none">%{number}</span>(<span class="filename">%{filename}</span>)
       messages: Meldungen
       no_execution_environment: Für die Aufgabe wurde noch keine Ausführungsumgebung gewählt.

--- a/config/locales/de/meta/shared.yml
+++ b/config/locales/de/meta/shared.yml
@@ -51,4 +51,4 @@ de:
       shortcut: 'Tastaturkürzel: %{shortcut}'
     update: "%{model} aktualisieren"
     upload_file: Datei hochladen
-    websocket_failure: Leider ist ein Verbindungsproblem aufgetreten. <a href="https://websocketstest.com" target="_blank" rel="noopener" class="alert-link">Bitte überprüfen Sie Websocket-Verbindungen mit diesem Tool</a> und versuchen Sie es erneut.
+    websocket_failure: Leider ist ein Verbindungsproblem aufgetreten. <a href="https://websocketstest.com" target="_blank" rel="noopener noreferrer" class="alert-link">Bitte überprüfen Sie Websocket-Verbindungen mit diesem Tool</a> und versuchen Sie es erneut.

--- a/config/locales/en/execution_environment.yml
+++ b/config/locales/en/execution_environment.yml
@@ -29,7 +29,7 @@ en:
       hints:
         command: "<em>filename</em> is automatically replaced with the correct filename. The following character is disallowed: ' (single quote)"
         cpu_limit: Specify the minimum amount of CPU shares to reserve for each runner, measured in MHz.
-        docker_image: Pick a Docker image listed above or add a new one which is available via <a href="https://hub.docker.com/" target="_blank" rel="noopener">DockerHub</a>.
+        docker_image: Pick a Docker image listed above or add a new one which is available via <a href="https://hub.docker.com/" target="_blank" rel="noopener noreferrer">DockerHub</a>.
         exposed_ports_list: During code execution these ports are accessible for the user. Port numbers must be numeric and separated by a comma.
     index:
       shell: Shell

--- a/config/locales/en/exercise.yml
+++ b/config/locales/en/exercise.yml
@@ -63,7 +63,7 @@ en:
       is_offline: "%{name} is offline"
       is_online: "%{name} is online"
       lastsaved: 'Last saved: '
-      network: 'While your code is running, port %{port} is accessible using the following address: <a href="%{address}" target="_blank" rel="noopener">%{address}</a>.'
+      network: 'While your code is running, port %{port} is accessible using the following address: <a href="%{address}" target="_blank" rel="noopener noreferrer">%{address}</a>.'
       out_of_memory: Execution stopped. Your code exceeded the permitted RAM usage of %{memory_limit} MB.
       render: Render
       requestComments: Request Comments
@@ -168,7 +168,7 @@ en:
         go_to_question: Go to answer
         heading: Gain more insights here | Powered by StackOverflow
       intervention:
-        explanation: 'This message appears because you have been working on this exercise for %{duration} minutes. 25% of your fellow learners took more time to solve the exercise, so in that sense it''s not a problem, but this has proven to be an <a href=''https://hpi.de/en/research/publications/dissertations/dissertation-ralf-teusner.html'' style=''display: contents;'' target=''_blank'' rel=''noopener''>effective time for this message</a>.'
+        explanation: 'This message appears because you have been working on this exercise for %{duration} minutes. 25% of your fellow learners took more time to solve the exercise, so in that sense it''s not a problem, but this has proven to be an <a href=''https://hpi.de/en/research/publications/dissertations/dissertation-ralf-teusner.html'' style=''display: contents;'' target=''_blank'' rel=''noopener noreferrer''>effective time for this message</a>.'
       linter_file: Linter Feedback <span class="number d-none">%{number}</span>(<span class="filename">%{filename}</span>)
       messages: Messages
       no_execution_environment: No execution environment has been selected for the exercise yet.

--- a/config/locales/en/meta/shared.yml
+++ b/config/locales/en/meta/shared.yml
@@ -51,4 +51,4 @@ en:
       shortcut: 'Keyboard shortcut: %{shortcut}'
     update: Update %{model}
     upload_file: Upload file
-    websocket_failure: Sorry, a connection issue occurred. <a href="https://websocketstest.com" target="_blank" rel="noopener" class="alert-link">Please check WebSocket connections with this tool</a> and try again.
+    websocket_failure: Sorry, a connection issue occurred. <a href="https://websocketstest.com" target="_blank" rel="noopener noreferrer" class="alert-link">Please check WebSocket connections with this tool</a> and try again.


### PR DESCRIPTION
We recently noticed that our links to external pages only contained the `noopener` directive (instructing browsers to use a dedicated context for the new target) but not the `noreferrer` (which hides the source page's address from the new page). This PR fixes said behavior.

//cc @Melhaya for the boy scouting rule

_PS: The tests are failing until #2398 has been merged._