### PR TITLE
Policy: Use no_one rather than false

### DIFF
--- a/app/policies/code_ocean/file_policy.rb
+++ b/app/policies/code_ocean/file_policy.rb
@@ -7,7 +7,7 @@ module CodeOcean
     end
 
     def show?
-      return false if @record.native_file? && !@record.native_file_location_valid?
+      return no_one if @record.native_file? && !@record.native_file_location_valid?
 
       if @record.context.is_a?(Exercise)
         admin? || author? || !@record.hidden
@@ -17,7 +17,7 @@ module CodeOcean
     end
 
     def show_protected_upload?
-      return false if @record.native_file? && !@record.native_file_location_valid?
+      return no_one if @record.native_file? && !@record.native_file_location_valid?
 
       if @record.context.is_a?(Exercise)
         admin? || author? || (!@record.context.unpublished && !@record.hidden)

--- a/app/policies/codeharbor_link_policy.rb
+++ b/app/policies/codeharbor_link_policy.rb
@@ -4,11 +4,11 @@ class CodeharborLinkPolicy < ApplicationPolicy
   CODEHARBOR_CONFIG = CodeOcean::Config.new(:code_ocean).read[:codeharbor]
 
   def index?
-    false
+    no_one
   end
 
   def show?
-    false
+    no_one
   end
 
   def new?

--- a/app/policies/programming_group_policy.rb
+++ b/app/policies/programming_group_policy.rb
@@ -11,7 +11,7 @@ class ProgrammingGroupPolicy < AdminOnlyPolicy
 
   def stream_sync_editor?
     # A programming group needs to exist for the user to be able to stream the synchronized editor.
-    return false if @record.blank?
+    return no_one if @record.blank?
 
     admin? || author_in_programming_group?
   end


### PR DESCRIPTION
Despite having a dedicated `no_one` method, it wasn't consequently used in all places. Thus, this PR re-aligns the usage across all policies.

//cc @Melhaya for the boy scouting rule

_PS: The tests are failing until #2398 has been merged._