### PR TITLE
Improve locales for external user statistics

### DIFF
--- a/app/views/exercises/external_users/statistics.html.slim
+++ b/app/views/exercises/external_users/statistics.html.slim
@@ -1,8 +1,8 @@
 h1
-  => @exercise
-  ' (external user
-  = link_to_if(policy(@external_user).show?, @external_user.displayname, @external_user)
-  ' )
+  = t('.title_html',
+        exercise: @exercise,
+        user_class: @external_user.class.model_name.human,
+        user: link_to_if(policy(@external_user).show?, @external_user.displayname, @external_user))
 - submissions = @all_events.filter {|event| event.is_a? Submission }
 - current_submission = submissions.first
 - if current_submission

--- a/app/views/external_users/statistics.html.slim
+++ b/app/views/external_users/statistics.html.slim
@@ -1,4 +1,4 @@
-h1 = t('.title')
+h1 = t('.title', user: @user.displayname)
 
 - submissions = Submission.where(contributor: @user).in_study_group_of(current_user)
 - exercises = Exercise.where(id: submissions.joins(:exercise).group(:exercise_id).select(:exercise_id).distinct).compact

--- a/config/locales/de/exercise.yml
+++ b/config/locales/de/exercise.yml
@@ -118,6 +118,7 @@ de:
         tests: Unit Tests
         time: Zeit (UTC)
         time_difference: Arbeitszeit bis hier*
+        title_html: "%{exercise} (%{user_class} %{user})"
         toggle_autosave_off: Zwischenspeicherungen ausblenden
         toggle_autosave_on: Zwischenspeicherungen anzeigen
         toggle_status_off: Zwischenspeicherungen sind ausgeblendet

--- a/config/locales/de/external_user.yml
+++ b/config/locales/de/external_user.yml
@@ -23,5 +23,5 @@ de:
       exercise: Übung
       runs: Abgaben
       score: Maximale Punktzahl
-      title: Statistiken für Externe Personen
+      title: Aufgabenstatistik für %{user}
       worktime: Arbeitszeit

--- a/config/locales/en/exercise.yml
+++ b/config/locales/en/exercise.yml
@@ -118,6 +118,7 @@ en:
         tests: Unit Test Results
         time: Time (UTC)
         time_difference: Working Time until here*
+        title_html: "%{exercise} (%{user_class} %{user})"
         toggle_autosave_off: Hide Autosaves
         toggle_autosave_on: Show Autosaves
         toggle_status_off: Autosaves are currently hidden

--- a/config/locales/en/external_user.yml
+++ b/config/locales/en/external_user.yml
@@ -23,5 +23,5 @@ en:
       exercise: Exercise
       runs: Submissions
       score: Maximum Score
-      title: External User Statistics
+      title: Exercise Statistics for %{user}
       worktime: Working Time

--- a/spec/views/exercises/external_users/statistics.html.slim_spec.rb
+++ b/spec/views/exercises/external_users/statistics.html.slim_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'exercises/external_users/statistics.html.slim' do
+  let(:user) { create(:admin) }
+  let(:exercise) { create(:fibonacci, user:) }
+  let(:external_user) { create(:external_user) }
+
+  before do
+    create_list(:submission, 2, cause: 'autosave', contributor: external_user, exercise:)
+    create_list(:submission, 2, cause: 'run', contributor: external_user, exercise:)
+    create(:submission, cause: 'assess', contributor: external_user, exercise:)
+
+    without_partial_double_verification do
+      allow(view).to receive_messages(current_user: user, current_contributor: user)
+    end
+    assign(:exercise, exercise)
+    assign(:show_autosaves, false)
+    assign(:external_user, external_user)
+    assign(:all_events, external_user.submissions.where(exercise:))
+
+    # The following two variables normally contain the time between two submissions (delta)
+    # if lower than StatisticsHelper::WORKING_TIME_DELTA_IN_SECONDS, and the sum of all deltas.
+    # For the spec, we simply assume no working time and therefore fill both arrays with zeros.
+    assign(:deltas, [0] * external_user.submissions.where(exercise:).count)
+    assign(:working_times_until, [0] * external_user.submissions.where(exercise:).count)
+
+    # Manipulate the controller instance to include necessary path options
+    controller.request.path_parameters[:id] = exercise.id
+    controller.request.path_parameters[:external_user_id] = external_user.id
+
+    render
+  end
+
+  it 'displays the correct title' do
+    parsed_content = Nokogiri::HTML(rendered)
+    text_content = parsed_content.text.strip
+    expect(text_content).to include("#{exercise} (#{ExternalUser.model_name.human} #{external_user.displayname})")
+  end
+
+  it 'contains a link to the user' do
+    expect(rendered).to have_link(external_user.displayname, href: external_user_path(external_user))
+  end
+end


### PR DESCRIPTION
While working on my research, I noticed an imprecise localization for statistics, giving too few context.

//cc @Melhaya for the boy scouting rule

_PS: The tests are failing until #2398 has been merged._