### PR TITLE
Fix memorization for false values

### DIFF
--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -19,13 +19,13 @@ class Runner < ApplicationRecord
   end
 
   def self.management_active?
-    @management_active ||= begin
-      runner_management = CodeOcean::Config.new(:code_ocean).read[:runner_management]
-      if runner_management
-        runner_management[:enabled]
-      else
-        false
-      end
+    return @management_active if defined? @management_active
+
+    runner_management = CodeOcean::Config.new(:code_ocean).read[:runner_management]
+    if runner_management
+      @management_active = runner_management[:enabled]
+    else
+      @management_active = false
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,16 +31,21 @@ class User < Contributor
 
   def learner?
     return true if current_study_group_id.nil?
+    return @learner if defined? @learner
 
-    @learner ||= current_study_group_membership.exists?(role: :learner) && !platform_admin?
+    @learner = current_study_group_membership.exists?(role: :learner) && !platform_admin?
   end
 
   def teacher?
-    @teacher ||= current_study_group_membership.exists?(role: :teacher) && !platform_admin?
+    return @teacher if defined? @teacher
+
+    @teacher = current_study_group_membership.exists?(role: :teacher) && !platform_admin?
   end
 
   def admin?
-    @admin ||= platform_admin?
+    return @admin if defined? @admin
+
+    @admin = platform_admin?
   end
 
   def id_with_type

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 def reset_runner_strategy
-  Runner.instance_variable_set :@strategy_class, nil
-  Runner.instance_variable_set :@management_active, nil
+  Runner.remove_instance_variable(:@strategy_class) if Runner.instance_variable_defined?(:@strategy_class)
+  Runner.remove_instance_variable(:@management_active) if Runner.instance_variable_defined?(:@management_active)
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Previously, a boolean value of `false` would not have been memorized correctly. Instead, the mechanism commonly used with `||=` would always reevalute the original, rendering the memorization useless. `true` values were not affected of this bug.