### PR TITLE
Flush content for modal footer

### DIFF
--- a/app/views/application/help.html.slim
+++ b/app/views/application/help.html.slim
@@ -5,7 +5,7 @@
   h2 = t('shared.help.execution_environment_specific_help', execution_environment:)
   = render_markdown(execution_environment.help)
 
-- content_for :modal_footer do
+- content_for :modal_footer, flush: true do
   - if ApplicationController::LEGAL_SETTINGS.present?
     ul.horizontal.dash.pull-start
       - ApplicationController::LEGAL_SETTINGS.each do |name, link|

--- a/app/views/programming_groups/_info_pair_programming.html.slim
+++ b/app/views/programming_groups/_info_pair_programming.html.slim
@@ -1,6 +1,6 @@
 = render_markdown(t('programming_groups.new.info_pair_programming'))
 
-- content_for :modal_footer do
+- content_for :modal_footer, flush: true do
   button.btn.btn-secondary#dont_show_info_pp_modal_again data-bs-dismiss='modal'
     = t('programming_groups.new.dont_show_modal_again')
   button.btn.btn-primary data-bs-dismiss='modal'


### PR DESCRIPTION
Previously, the content for a modal footer was concatenated (which was unintended). Now, each modal as its own footer, if configured.

| Before | After |
|--------|--------|
| ![Bildschirmfoto 2024-08-02 um 14 36 08](https://github.com/user-attachments/assets/0c5a09ff-c95a-445c-86f3-9c21485a678d) ![Bildschirmfoto 2024-08-02 um 14 36 34](https://github.com/user-attachments/assets/94634afa-9824-4a9b-acdc-d40b33fff502) | ![Bildschirmfoto 2024-08-02 um 14 36 27](https://github.com/user-attachments/assets/33c1f544-c5d1-4c13-bc6f-44588d69ae22) ![Bildschirmfoto 2024-08-02 um 14 36 34](https://github.com/user-attachments/assets/94634afa-9824-4a9b-acdc-d40b33fff502)  | 