### PR TITLE
Allow teachers most reading actions on CodeOcean

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -19,7 +19,7 @@ class CommentsController < ApplicationController
         comment.username = comment.user.displayname
         comment.date = comment.created_at.strftime('%d.%m.%Y %k:%M')
         comment.updated = (comment.created_at != comment.updated_at)
-        comment.editable = comment.user == current_user
+        comment.editable = policy(comment).edit?
       end
     else
       @comments = []

--- a/app/controllers/external_users_controller.rb
+++ b/app/controllers/external_users_controller.rb
@@ -11,8 +11,8 @@ class ExternalUsersController < ApplicationController
   private :authorize!
 
   def index
-    @search = ExternalUser.ransack(params[:q], {auth_object: current_user})
-    @users = @search.result.in_study_group_of(current_user).includes(:consumer).paginate(page: params[:page], per_page: per_page_param)
+    @search = policy_scope(ExternalUser).ransack(params[:q], {auth_object: current_user})
+    @users = @search.result.includes(:consumer).paginate(page: params[:page], per_page: per_page_param)
     authorize!
   end
 

--- a/app/controllers/internal_users_controller.rb
+++ b/app/controllers/internal_users_controller.rb
@@ -33,8 +33,8 @@ class InternalUsersController < ApplicationController
   private :change_password
 
   def index
-    @search = InternalUser.ransack(params[:q], {auth_object: current_user})
-    @users = @search.result.in_study_group_of(current_user).includes(:consumer).order(:name).paginate(page: params[:page], per_page: per_page_param)
+    @search = policy_scope(InternalUser).ransack(params[:q], {auth_object: current_user})
+    @users = @search.result.includes(:consumer).order(:name).paginate(page: params[:page], per_page: per_page_param)
     authorize!
   end
 

--- a/app/controllers/programming_groups_controller.rb
+++ b/app/controllers/programming_groups_controller.rb
@@ -9,7 +9,7 @@ class ProgrammingGroupsController < ApplicationController
 
   def index
     set_exercise_and_authorize if params[:exercise_id].present?
-    @search = ProgrammingGroup.ransack(params[:q], {auth_object: current_user})
+    @search = policy_scope(ProgrammingGroup).ransack(params[:q], {auth_object: current_user})
     @programming_groups = @search.result.includes(:exercise, :programming_group_memberships, :internal_users, :external_users).order(:id).paginate(page: params[:page], per_page: per_page_param)
     authorize!
   end

--- a/app/controllers/proxy_exercises_controller.rb
+++ b/app/controllers/proxy_exercises_controller.rb
@@ -3,7 +3,7 @@
 class ProxyExercisesController < ApplicationController
   include CommonBehavior
 
-  before_action :set_exercise_and_authorize, only: MEMBER_ACTIONS + %i[clone reload]
+  before_action :set_exercise_and_authorize, only: MEMBER_ACTIONS + %i[clone]
 
   def authorize!
     authorize(@proxy_exercise || @proxy_exercises)

--- a/app/controllers/study_groups_controller.rb
+++ b/app/controllers/study_groups_controller.rb
@@ -7,10 +7,10 @@ class StudyGroupsController < ApplicationController
 
   def index
     @search = policy_scope(StudyGroup).ransack(params[:q])
-    @study_groups_paginate = @search.result.includes(:consumer).order(:name).paginate(page: params[:page], per_page: per_page_param)
-    @study_groups = @study_groups_paginate.joins(:study_group_memberships)
-      .group(:id, :name, :external_id, :consumer_id, :created_at, :updated_at)
-      .select(:id, :name, :external_id, :consumer_id, :created_at, :updated_at, 'count(study_group_memberships.id) as user_count')
+    @study_groups = StudyGroup.where(id: @search.result.ids)
+      .includes(:consumer, :study_group_memberships)
+      .order(:name)
+      .paginate(page: params[:page], per_page: per_page_param)
     authorize!
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -23,7 +23,7 @@ class SubmissionsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: %i[render_file download_file]
 
   def index
-    @search = Submission.ransack(params[:q])
+    @search = policy_scope(Submission).ransack(params[:q])
     @submissions = @search.result.includes(:exercise, :contributor).paginate(page: params[:page], per_page: per_page_param)
     authorize!
   end

--- a/app/models/consumer.rb
+++ b/app/models/consumer.rb
@@ -10,10 +10,6 @@ class Consumer < ApplicationRecord
   has_many :users
   has_many :study_groups, dependent: :destroy
 
-  scope :with_internal_users, -> { where('id IN (SELECT DISTINCT consumer_id FROM internal_users)') }
-  scope :with_external_users, -> { where('id IN (SELECT DISTINCT consumer_id FROM external_users)') }
-  scope :with_study_groups, -> { where('id IN (SELECT DISTINCT consumer_id FROM study_groups)') }
-
   validates :name, presence: true
   validates :oauth_key, presence: true, uniqueness: true
   validates :oauth_secret, presence: true

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -35,9 +35,6 @@ class Exercise < ApplicationRecord
   has_many :pair_programming_waiting_users
   has_many :request_for_comments
 
-  scope :with_submissions, -> { where('id IN (SELECT exercise_id FROM submissions)') }
-  scope :with_programming_groups, -> { where('id IN (SELECT exercise_id FROM programming_groups)') }
-
   validate :valid_main_file?
   validate :valid_submission_deadlines?
   validates :description, presence: true

--- a/app/models/study_group.rb
+++ b/app/models/study_group.rb
@@ -18,10 +18,6 @@ class StudyGroup < ApplicationRecord
     external_users + internal_users
   end
 
-  def user_count
-    attributes['user_count'] || study_group_memberships.size
-  end
-
   def to_s
     name.presence || "StudyGroup #{id}"
   end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -46,8 +46,6 @@ class Submission < ApplicationRecord
 
   scope :latest, -> { order(updated_at: :desc).first }
 
-  scope :in_study_group_of, ->(user) { where(study_group_id: user.study_groups) unless user.admin? }
-
   validates :cause, inclusion: {in: CAUSES}
 
   attr_reader :used_execution_environment

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,7 +71,7 @@ class User < Contributor
     if auth_object.present? && auth_object.admin?
       %w[name email external_id consumer_id platform_admin id]
     else
-      %w[name external_id id]
+      %w[name external_id consumer_id id]
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,17 +27,6 @@ class User < Contributor
   has_one :codeharbor_link, dependent: :destroy
   accepts_nested_attributes_for :user_proxy_exercise_exercises
 
-  scope :in_study_group_of, lambda {|user|
-                              unless user.admin?
-                                joins(:study_group_memberships)
-                                  .where(study_group_memberships: {
-                                    study_group_id: user.study_group_memberships
-                                                        .where(study_group_memberships: {role: StudyGroupMembership.roles[:teacher]})
-                                                        .select(:study_group_id),
-                                  })
-                              end
-                            }
-
   validates :platform_admin, inclusion: [true, false]
 
   def learner?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -35,6 +35,8 @@ class ApplicationPolicy
       study_groups = @record.submission.study_group
     elsif @record.respond_to? :user # e.g. exercise
       study_groups = @record.author.study_groups.where(study_group_memberships: {role: :teacher})
+    elsif @record.is_a?(ProgrammingGroup) && @record.respond_to?(:submissions) # e.g. programming group
+      study_groups = @record.submissions.select(:study_group_id)
     elsif @record.respond_to? :users # e.g. study_group
       study_groups = @record
     elsif @record.respond_to? :study_groups # e.g. user

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -31,7 +31,7 @@ class ApplicationPolicy
     # !! Order is important !!
     if @record.respond_to? :study_group # e.g. submission
       study_groups = @record.study_group
-    elsif @record.respond_to? :submission # e.g. request_for_comment
+    elsif @record.respond_to? :submission # e.g. request_for_comment, comment
       study_groups = @record.submission.study_group
     elsif @record.respond_to? :user # e.g. exercise
       study_groups = @record.author.study_groups.where(study_group_memberships: {role: :teacher})

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -10,7 +10,7 @@ class CommentPolicy < ApplicationPolicy
   end
 
   %i[new? destroy? update? edit?].each do |action|
-    define_method(action) { admin? || author? }
+    define_method(action) { admin? || author? || teacher_in_study_group? }
   end
 
   def index?

--- a/app/policies/consumer_policy.rb
+++ b/app/policies/consumer_policy.rb
@@ -1,4 +1,39 @@
 # frozen_string_literal: true
 
 class ConsumerPolicy < AdminOnlyPolicy
+  class WithInternalUsersScope < Scope
+    def resolve
+      if @user.admin?
+        @scope.where(id: InternalUser.select(:consumer_id))
+      elsif @user.teacher?
+        @scope.where(id: InternalUserPolicy::Scope.new(@user, InternalUser).resolve.select(:consumer_id))
+      else
+        @scope.none
+      end
+    end
+  end
+
+  class WithExternalUsersScope < Scope
+    def resolve
+      if @user.admin?
+        @scope.where(id: ExternalUser.select(:consumer_id))
+      elsif @user.teacher?
+        @scope.where(id: ExternalUserPolicy::Scope.new(@user, ExternalUser).resolve.select(:consumer_id))
+      else
+        @scope.none
+      end
+    end
+  end
+
+  class WithStudyGroupsScope < Scope
+    def resolve
+      if @user.admin?
+        @scope.where(id: StudyGroup.select(:consumer_id))
+      elsif @user.teacher?
+        @scope.where(id: StudyGroupPolicy::Scope.new(@user, StudyGroup).resolve.select(:consumer_id))
+      else
+        @scope.none
+      end
+    end
+  end
 end

--- a/app/policies/error_template_attribute_policy.rb
+++ b/app/policies/error_template_attribute_policy.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class ErrorTemplateAttributePolicy < AdminOnlyPolicy
+  %i[index? show?].each do |action|
+    define_method(action) { admin? || teacher? }
+  end
 end

--- a/app/policies/error_template_policy.rb
+++ b/app/policies/error_template_policy.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class ErrorTemplatePolicy < AdminOnlyPolicy
+  %i[index? show?].each do |action|
+    define_method(action) { admin? || teacher? }
+  end
+
   def add_attribute?
     admin?
   end

--- a/app/policies/execution_environment_policy.rb
+++ b/app/policies/execution_environment_policy.rb
@@ -2,12 +2,12 @@
 
 class ExecutionEnvironmentPolicy < AdminOnlyPolicy
   # download_arbitrary_file? is used in the live_streams_controller.rb
-  %i[execute_command? shell? list_files? statistics? show? sync_to_runner_management? download_arbitrary_file?].each do |action|
-    define_method(action) { admin? || author? }
+  %i[index? execute_command? shell? list_files? show? download_arbitrary_file?].each do |action|
+    define_method(action) { admin? || teacher? }
   end
 
-  [:index?].each do |action|
-    define_method(action) { admin? || teacher? }
+  %i[statistics? sync_to_runner_management?].each do |action|
+    define_method(action) { admin? || author? }
   end
 
   def sync_all_to_runner_management?

--- a/app/policies/exercise_policy.rb
+++ b/app/policies/exercise_policy.rb
@@ -13,10 +13,6 @@ class ExercisePolicy < AdminOrAuthorPolicy
     admin? || teacher_in_study_group?
   end
 
-  def submission_statistics?
-    admin? || teacher_in_study_group?
-  end
-
   def detailed_statistics?
     admin?
   end

--- a/app/policies/exercise_policy.rb
+++ b/app/policies/exercise_policy.rb
@@ -55,4 +55,28 @@ class ExercisePolicy < AdminOrAuthorPolicy
       end
     end
   end
+
+  class WithProgrammingGroupsScope < Scope
+    def resolve
+      if @user.admin?
+        @scope.where(id: ProgrammingGroup.select(:exercise_id))
+      elsif @user.teacher?
+        @scope.where(id: ProgrammingGroupPolicy::Scope.new(@user, ProgrammingGroup).resolve.select(:exercise_id))
+      else
+        @scope.none
+      end
+    end
+  end
+
+  class WithSubmissionsScope < Scope
+    def resolve
+      if @user.admin?
+        @scope.where(id: Submission.select(:exercise_id))
+      elsif @user.teacher?
+        @scope.where(id: SubmissionPolicy::Scope.new(@user, Submission).resolve.select(:exercise_id))
+      else
+        @scope.none
+      end
+    end
+  end
 end

--- a/app/policies/external_user_policy.rb
+++ b/app/policies/external_user_policy.rb
@@ -16,4 +16,21 @@ class ExternalUserPolicy < AdminOnlyPolicy
   def tag_statistics?
     admin?
   end
+
+  class Scope < Scope
+    def resolve
+      if @user.admin?
+        @scope.all
+      elsif @user.teacher?
+        @scope.joins(:study_group_memberships)
+          .where(study_group_memberships: {
+            study_group_id: @user.study_group_memberships
+                                 .where(study_group_memberships: {role: StudyGroupMembership.roles[:teacher]})
+                                 .select(:study_group_id),
+          })
+      else
+        @scope.none
+      end
+    end
+  end
 end

--- a/app/policies/file_template_policy.rb
+++ b/app/policies/file_template_policy.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class FileTemplatePolicy < AdminOnlyPolicy
+  %i[index? show?].each do |action|
+    define_method(action) { admin? || teacher? }
+  end
+
   def by_file_type?
     everyone
   end

--- a/app/policies/file_type_policy.rb
+++ b/app/policies/file_type_policy.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class FileTypePolicy < AdminOnlyPolicy
+  %i[index? show?].each do |action|
+    define_method(action) { admin? || teacher? }
+  end
 end

--- a/app/policies/internal_user_policy.rb
+++ b/app/policies/internal_user_policy.rb
@@ -12,4 +12,21 @@ class InternalUserPolicy < AdminOnlyPolicy
   def show?
     admin? || @record == @user || teacher_in_study_group?
   end
+
+  class Scope < Scope
+    def resolve
+      if @user.admin?
+        @scope.all
+      elsif @user.teacher?
+        @scope.joins(:study_group_memberships)
+          .where(study_group_memberships: {
+            study_group_id: @user.study_group_memberships
+                                .where(study_group_memberships: {role: StudyGroupMembership.roles[:teacher]})
+                                .select(:study_group_id),
+          })
+      else
+        @scope.none
+      end
+    end
+  end
 end

--- a/app/policies/proxy_exercise_policy.rb
+++ b/app/policies/proxy_exercise_policy.rb
@@ -10,7 +10,7 @@ class ProxyExercisePolicy < AdminOrAuthorPolicy
   end
 
   %i[clone? destroy? edit? update?].each do |action|
-    define_method(action) { admin? || author? }
+    define_method(action) { admin? || author? || teacher_in_study_group? }
   end
 
   class Scope < Scope

--- a/app/policies/study_group_policy.rb
+++ b/app/policies/study_group_policy.rb
@@ -13,7 +13,7 @@ class StudyGroupPolicy < AdminOnlyPolicy
     # A default study group should not get deleted without the consumer
     return no_one if @record.external_id.blank?
 
-    admin? || teacher_in_study_group?
+    admin?
   end
 
   class Scope < Scope

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class TagPolicy < AdminOnlyPolicy
+  %i[index? show?].each do |action|
+    define_method(action) { admin? || teacher? }
+  end
+
   class Scope < Scope
     def resolve
       if @user.admin? || @user.teacher?

--- a/app/policies/tip_policy.rb
+++ b/app/policies/tip_policy.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class TipPolicy < AdminOnlyPolicy
+  %i[index? show?].each do |action|
+    define_method(action) { admin? || teacher? }
+  end
+
   class Scope < Scope
     def resolve
       if @user.admin? || @user.teacher?

--- a/app/views/exercises/statistics.html.slim
+++ b/app/views/exercises/statistics.html.slim
@@ -45,9 +45,7 @@ h1 = @exercise
     p = @exercise.average_working_time
 
 - {internal_users: t('.internal_users'), external_users: t('.external_users'), programming_groups: t('.programming_groups')}.each_pair do |symbol, label|
-  - submissions = Submission.where(contributor: @exercise.send(symbol), exercise: @exercise).in_study_group_of(current_user)
-  - unless policy(@exercise).detailed_statistics?
-    - submissions = submissions.final
+  - submissions = policy_scope(Submission).where(contributor: @exercise.send(symbol), exercise: @exercise)
   - if submissions.any?
     strong = label
     - if symbol == :external_users

--- a/app/views/external_users/index.html.slim
+++ b/app/views/external_users/index.html.slim
@@ -1,6 +1,7 @@
 h1 = ExternalUser.model_name.human(count: :other)
 
 = render(layout: 'shared/form_filters') do |f|
+  - consumers_with_external_users = ConsumerPolicy::WithExternalUsersScope.new(current_user, Consumer).resolve
   - if current_user.admin?
     .col-md-9.col
       .row.align-items-center
@@ -18,7 +19,7 @@ h1 = ExternalUser.model_name.human(count: :other)
           = f.select :platform_admin_true, [[t('shared.admin_filter.only'), 1], [t('shared.admin_filter.none'), 0]], {include_blank: t('shared.admin_filter.all'), selected: params[:q] ? params[:q][:platform_admin_true] : ''}
         .col-auto.mt-3.mt-lg-0
           = f.label(:consumer_id_eq, ExternalUser.human_attribute_name('consumer'), class: 'visually-hidden form-label')
-          = f.collection_select(:consumer_id_eq, Consumer.with_external_users, :id, :name, class: 'form-control', include_blank: true, prompt: ExternalUser.human_attribute_name('consumer'))
+          = f.collection_select(:consumer_id_eq, consumers_with_external_users, :id, :name, class: 'form-control', include_blank: true, prompt: ExternalUser.human_attribute_name('consumer'))
   - else
     .col-auto
       = f.label(:name_cont, ExternalUser.human_attribute_name('name'), class: 'visually-hidden form-label')
@@ -26,6 +27,9 @@ h1 = ExternalUser.model_name.human(count: :other)
     .col-auto
       = f.label(:external_id_cont, ExternalUser.human_attribute_name('external_id'), class: 'visually-hidden form-label')
       = f.search_field(:external_id_cont, class: 'form-control', placeholder: ExternalUser.human_attribute_name('external_id'))
+    .col-auto
+      = f.label(:consumer_id_eq, ExternalUser.human_attribute_name('consumer'), class: 'visually-hidden form-label')
+      = f.collection_select(:consumer_id_eq, consumers_with_external_users, :id, :name, class: 'form-control', include_blank: true, prompt: ExternalUser.human_attribute_name('consumer'))
 .table-responsive
   table.table
     thead

--- a/app/views/external_users/index.html.slim
+++ b/app/views/external_users/index.html.slim
@@ -36,7 +36,8 @@ h1 = ExternalUser.model_name.human(count: :other)
       tr
         th = ExternalUser.human_attribute_name('name')
         th = ExternalUser.human_attribute_name('consumer')
-        th = ExternalUser.human_attribute_name('platform_admin')
+        - if current_user.admin?
+          th = ExternalUser.human_attribute_name('platform_admin')
         th = t('shared.actions')
     tbody
       - @users.each do |user|

--- a/app/views/external_users/statistics.html.slim
+++ b/app/views/external_users/statistics.html.slim
@@ -1,9 +1,7 @@
 h1 = t('.title', user: @user.displayname)
 
-- submissions = Submission.where(contributor: @user).in_study_group_of(current_user)
+- submissions = policy_scope(Submission).where(contributor: @user)
 - exercises = Exercise.where(id: submissions.joins(:exercise).group(:exercise_id).select(:exercise_id).distinct).compact
-- if submissions.any? && !policy(exercises.first).detailed_statistics?
-  - submissions = submissions.final
 
 - if submissions.any?
   .table-responsive

--- a/app/views/internal_users/index.html.slim
+++ b/app/views/internal_users/index.html.slim
@@ -1,10 +1,11 @@
 h1 = InternalUser.model_name.human(count: :other)
 
-- if current_user.admin?
-  = render(layout: 'shared/form_filters') do |f|
-    .col-auto
-      = f.label(:consumer_id_eq, InternalUser.human_attribute_name('consumer'), class: 'visually-hidden form-label')
-      = f.collection_select(:consumer_id_eq, Consumer.with_internal_users, :id, :name, class: 'form-control', include_blank: true, prompt: InternalUser.human_attribute_name('consumer'))
+= render(layout: 'shared/form_filters') do |f|
+  .col-auto
+    = f.label(:consumer_id_eq, InternalUser.human_attribute_name('consumer'), class: 'visually-hidden form-label')
+    - consumers_with_internal_users = ConsumerPolicy::WithInternalUsersScope.new(current_user, Consumer).resolve
+    = f.collection_select(:consumer_id_eq, consumers_with_internal_users, :id, :name, class: 'form-control', include_blank: true, prompt: InternalUser.human_attribute_name('consumer'))
+  - if current_user.admin?
     .col-sm
       = f.label(:email_cont, InternalUser.human_attribute_name('email'), class: 'visually-hidden form-label')
       = f.search_field(:email_cont, class: 'form-control', placeholder: InternalUser.human_attribute_name('email'))

--- a/app/views/programming_groups/index.html.slim
+++ b/app/views/programming_groups/index.html.slim
@@ -3,7 +3,8 @@
   = render(layout: 'shared/form_filters') do |f|
     .col-auto
       = f.label(:exercise_id_eq, ProgrammingGroup.human_attribute_name('exercise'), class: 'visually-hidden form-label')
-      = f.collection_select(:exercise_id_eq, Exercise.with_programming_groups, :id, :title, class: 'form-control', prompt: ProgrammingGroup.human_attribute_name('exercise'))
+      - exercises_with_programming_groups = ExercisePolicy::WithProgrammingGroupsScope.new(current_user, Exercise).resolve
+      = f.collection_select(:exercise_id_eq, exercises_with_programming_groups, :id, :title, class: 'form-control', prompt: ProgrammingGroup.human_attribute_name('exercise'))
     .col-auto
       = f.label(:programming_group_memberships_user_of_ExternalUser_type_id_eq, ProgrammingGroup.human_attribute_name('external_user_id'), class: 'visually-hidden form-label')
       = f.search_field(:programming_group_memberships_user_of_ExternalUser_type_id_eq, class: 'form-control', placeholder: ProgrammingGroup.human_attribute_name('external_user_id'))

--- a/app/views/study_groups/_table.html.slim
+++ b/app/views/study_groups/_table.html.slim
@@ -14,7 +14,7 @@
           td
             code = group.external_id
           td = link_to_if(policy(group.consumer).show?, group.consumer, group.consumer)
-          td = group.user_count
+          td = group.study_group_memberships.size
           td = link_to(t('shared.show'), group) if policy(group).show?
           td = link_to(t('shared.edit'), edit_study_group_path(group)) if policy(group).edit?
           td = link_to(t('shared.destroy'), group, data: {confirm: t('shared.confirm_destroy')}, method: :delete) if policy(group).destroy?

--- a/app/views/study_groups/index.html.slim
+++ b/app/views/study_groups/index.html.slim
@@ -3,7 +3,8 @@ h1 = StudyGroup.model_name.human(count: :other)
 = render(layout: 'shared/form_filters') do |f|
   .col-auto
     = f.label(:consumer_id_eq, InternalUser.human_attribute_name('consumer'), class: 'visually-hidden form-label')
-    = f.collection_select(:consumer_id_eq, Consumer.with_study_groups, :id, :name, class: 'form-control', prompt: InternalUser.human_attribute_name('consumer'))
+    - consumers_with_study_groups = ConsumerPolicy::WithStudyGroupsScope.new(current_user, Consumer).resolve
+    = f.collection_select(:consumer_id_eq, consumers_with_study_groups, :id, :name, class: 'form-control', prompt: InternalUser.human_attribute_name('consumer'))
   .col-auto
     = f.label(:name_cont, StudyGroup.human_attribute_name('name'), class: 'visually-hidden form-label')
     = f.search_field(:name_cont, class: 'form-control', placeholder: StudyGroup.human_attribute_name('name'))

--- a/app/views/study_groups/show.html.slim
+++ b/app/views/study_groups/show.html.slim
@@ -7,7 +7,7 @@ h1
 = row(label: 'study_group.external_id') do
   code = @study_group.external_id
 = row(label: 'study_group.consumer', value: link_to_if(policy(@study_group).show?, @study_group.consumer, @study_group.consumer))
-= row(label: 'study_group.member_count', value: @study_group.user_count)
+= row(label: 'study_group.member_count', value: @study_group.study_group_memberships.size)
 
 h2.mt-4 = StudyGroup.human_attribute_name('members')
 .table-responsive

--- a/app/views/submissions/index.html.slim
+++ b/app/views/submissions/index.html.slim
@@ -3,10 +3,12 @@ h1 = Submission.model_name.human(count: :other)
 = render(layout: 'shared/form_filters') do |f|
   .col-auto
     = f.label(:exercise_id_eq, Submission.human_attribute_name('exercise'), class: 'visually-hidden form-label')
-    = f.collection_select(:exercise_id_eq, Exercise.with_submissions, :id, :title, class: 'form-control', prompt: Submission.human_attribute_name('exercise'))
+    - exercises_with_submissions = ExercisePolicy::WithSubmissionsScope.new(current_user, Exercise).resolve
+    = f.collection_select(:exercise_id_eq, exercises_with_submissions, :id, :title, class: 'form-control', prompt: Submission.human_attribute_name('exercise'))
   .col-auto
     = f.label(:cause_eq, Submission.human_attribute_name('cause'), class: 'visually-hidden form-label')
-    = f.select(:cause_eq, Submission.distinct.pluck(:cause).sort, class: 'form-control', prompt: Submission.human_attribute_name('cause'))
+    - submission_causes = SubmissionPolicy::CausesScope.new(current_user, Submission).resolve.map {|cause, _id| [t("submissions.causes.#{cause}"), cause] }
+    = f.collection_select(:cause_eq, submission_causes.sort_by(&:first), :second, :first, class: 'form-control', prompt: Submission.human_attribute_name('cause'))
 
 .table-responsive
   table.table.mt-4

--- a/spec/policies/execution_environment_policy_spec.rb
+++ b/spec/policies/execution_environment_policy_spec.rb
@@ -7,21 +7,23 @@ RSpec.describe ExecutionEnvironmentPolicy do
 
   let(:execution_environment) { build(:ruby) }
 
-  permissions :index? do
-    it 'grants access to admins' do
-      expect(policy).to permit(build(:admin), execution_environment)
-    end
+  %i[index? execute_command? shell? list_files? show? download_arbitrary_file?].each do |action|
+    permissions(action) do
+      it 'grants access to admins' do
+        expect(policy).to permit(build(:admin), execution_environment)
+      end
 
-    it 'grants access to teachers' do
-      expect(policy).to permit(create(:teacher), execution_environment)
-    end
+      it 'grants access to teachers' do
+        expect(policy).to permit(create(:teacher), execution_environment)
+      end
 
-    it 'does not grant access to external users' do
-      expect(policy).not_to permit(build(:external_user), execution_environment)
+      it 'does not grant access to external users' do
+        expect(policy).not_to permit(build(:external_user), execution_environment)
+      end
     end
   end
 
-  %i[execute_command? shell? statistics? show?].each do |action|
+  %i[statistics? sync_to_runner_management?].each do |action|
     permissions(action) do
       it 'grants access to admins' do
         expect(policy).to permit(build(:admin), execution_environment)

--- a/spec/policies/file_type_policy_spec.rb
+++ b/spec/policies/file_type_policy_spec.rb
@@ -7,7 +7,27 @@ RSpec.describe FileTypePolicy do
 
   let(:file_type) { build(:dot_rb) }
 
-  %i[destroy? edit? update? new? create? index? show?].each do |action|
+  %i[index? show?].each do |action|
+    permissions(action) do
+      it 'grants access to admins' do
+        expect(policy).to permit(build(:admin), file_type)
+      end
+
+      it 'grants access to authors' do
+        expect(policy).to permit(file_type.author, file_type)
+      end
+
+      it 'grants access to teachers' do
+        expect(policy).to permit(create(:teacher), file_type)
+      end
+
+      it 'does not grant access to external users' do
+        expect(policy).not_to permit(create(:external_user), file_type)
+      end
+    end
+  end
+
+  %i[destroy? edit? update? new? create?].each do |action|
     permissions(action) do
       it 'grants access to admins' do
         expect(policy).to permit(build(:admin), file_type)

--- a/spec/policies/programming_group_policy_spec.rb
+++ b/spec/policies/programming_group_policy_spec.rb
@@ -5,15 +5,62 @@ require 'rails_helper'
 RSpec.describe ProgrammingGroupPolicy do
   subject(:policy) { described_class }
 
-  let(:programming_group) { build(:programming_group) }
+  let(:study_group) { create(:study_group) }
+  let(:programming_group_members) { create_list(:external_user, 2, study_groups: [study_group]) }
+  let(:programming_group) { create(:programming_group, users: programming_group_members) }
 
-  %i[index? destroy? show? edit? update?].each do |action|
+  before do
+    create(:submission, contributor: programming_group, study_group:)
+  end
+
+  permissions :index? do
+    it 'grants access to admins' do
+      expect(policy).to permit(create(:admin), programming_group)
+    end
+
+    it 'grants access to teachers' do
+      expect(policy).to permit(create(:teacher), programming_group)
+    end
+
+    it 'does not grant access to external users' do
+      expect(policy).not_to permit(create(:external_user), programming_group)
+    end
+  end
+
+  permissions :show? do
+    it 'grants access to admins' do
+      expect(policy).to permit(create(:admin), programming_group)
+    end
+
+    it 'grants access to teachers of the same study group' do
+      expect(policy).to permit(create(:teacher, study_groups: [study_group]), programming_group)
+    end
+
+    it 'does not grant access to other teachers' do
+      expect(policy).not_to permit(create(:teacher), programming_group)
+    end
+
+    it 'does not grant access to external users' do
+      expect(policy).not_to permit(create(:external_user), programming_group)
+    end
+  end
+
+  %i[edit? update?].each do |action|
     permissions(action) do
-      it 'grants access to admins only' do
+      it 'grants access to admins' do
         expect(policy).to permit(create(:admin), programming_group)
-        %i[external_user teacher].each do |factory_name|
-          expect(policy).not_to permit(create(factory_name), programming_group)
-        end
+      end
+
+      it 'does not grant access to teachers of the same study group' do
+        expect(policy).not_to permit(create(:teacher, study_groups: [study_group]), programming_group)
+      end
+
+      it 'does not grant access to other teachers' do
+        expect(policy).not_to permit(create(:teacher), programming_group)
+      end
+
+      it 'does not grant access to external users' do
+        expect(policy).not_to permit(create(:external_user), programming_group)
       end
     end
   end
@@ -41,6 +88,24 @@ RSpec.describe ProgrammingGroupPolicy do
       it 'does not grant access to someone who is not a member of the programming group' do
         expect(policy).not_to permit(create(:external_user), programming_group)
       end
+    end
+  end
+
+  permissions :destroy? do
+    it 'grants access to admins' do
+      expect(policy).to permit(create(:admin), programming_group)
+    end
+
+    it 'does not grant access to teachers of the same study group' do
+      expect(policy).not_to permit(create(:teacher, study_groups: [study_group]), programming_group)
+    end
+
+    it 'does not grant access to other teachers' do
+      expect(policy).not_to permit(create(:teacher), programming_group)
+    end
+
+    it 'does not grant access to external users' do
+      expect(policy).not_to permit(create(:external_user), programming_group)
     end
   end
 end

--- a/spec/policies/submission_policy_spec.rb
+++ b/spec/policies/submission_policy_spec.rb
@@ -37,11 +37,16 @@ RSpec.describe SubmissionPolicy do
   end
 
   permissions :index? do
-    it 'grants access to admins only' do
+    it 'grants access to admins' do
       expect(policy).to permit(build(:admin), Submission.new)
-      %i[external_user teacher].each do |factory_name|
-        expect(policy).not_to permit(create(factory_name), Submission.new)
-      end
+    end
+
+    it 'grants access to teachers' do
+      expect(policy).to permit(create(:teacher), Submission.new)
+    end
+
+    it 'does not grant access to external users' do
+      expect(policy).not_to permit(create(:external_user), Submission.new)
     end
   end
 end


### PR DESCRIPTION
With these changes, teachers gain more permissions on CodeOcean. Besides reading many objects, they can interact with execution environments more by now. For index pages, teachers only see those objects they are allowed to show. Furthermore, this PR:

- resolves a bug regarding the number of users for a study group when signed in as a teacher
- enables further filter for teachers (especially to find external and internal users better)
- enables teachers (and admin) to edit comments to RfCs, i.e. in case of explicit comments

Reviewing commit-by-commit is recommended