### PR TITLE
Enable contenthash in CSS filenames for webpack assets

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -66,7 +66,9 @@ const envConfig = module.exports = {
     },
     plugins: [
         new CompressionPlugin(),
-        new MiniCssExtractPlugin(),
+        new MiniCssExtractPlugin({
+            filename: '[name]-[contenthash].css',
+        }),
         new SubresourceIntegrityPlugin(),
         new WebpackAssetsManifest({
             entrypoints: true,


### PR DESCRIPTION
Previously, CSS files lacked a content hash in their filename (i.e., `application.css` rather than `application-3e40df0e5fb0538b2a29.css`). Without a content hash, some browsers might use an outdated CSS file and compare it to the newest SRI hash sent by the server, resulting in an invalid SRI hash (thus preventing any CSS from being applied). 

While I think this worked before, it could have been introduced by a recent dependency upgrade. Thus, this PR explicitly configures the content hash for CSS files. JS files were not affected by this problem.