### PR TITLE
Use memorized study groups for Pundit Scopes

### DIFF
--- a/.rubocop/rails.yml
+++ b/.rubocop/rails.yml
@@ -25,3 +25,9 @@ Rails/DynamicFindBy:
   Whitelist:
     - find_by_sql # Default value for this cop
     - find_by_id_with_type # custom method defined in the `User` model
+
+Rails/PluckInWhere:
+  Exclude:
+    # Within scopes, we often use pluck to get the IDs of sub-records.
+    # This massively improves the performance by avoiding a rerun of the subquery for each row.
+    - "app/policies/**/*"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,6 +57,14 @@ class User < Contributor
     study_group_memberships.where(study_group: current_study_group_id).limit(1)
   end
 
+  def study_group_ids_as_teacher
+    @study_group_ids_as_teacher ||= study_group_memberships.where(role: :teacher).pluck(:study_group_id)
+  end
+
+  def study_group_ids_as_learner
+    @study_group_ids_as_learner ||= study_group_memberships.where(role: :learner).pluck(:study_group_id)
+  end
+
   def self.find_by_id_with_type(id_with_type)
     if id_with_type[0].casecmp('e').zero?
       ExternalUser.find(id_with_type[1..])

--- a/app/policies/consumer_policy.rb
+++ b/app/policies/consumer_policy.rb
@@ -6,7 +6,7 @@ class ConsumerPolicy < AdminOnlyPolicy
       if @user.admin?
         @scope.where(id: InternalUser.select(:consumer_id))
       elsif @user.teacher?
-        @scope.where(id: InternalUserPolicy::Scope.new(@user, InternalUser).resolve.select(:consumer_id))
+        @scope.where(id: InternalUserPolicy::Scope.new(@user, InternalUser).resolve.distinct.pluck(:consumer_id))
       else
         @scope.none
       end
@@ -18,7 +18,7 @@ class ConsumerPolicy < AdminOnlyPolicy
       if @user.admin?
         @scope.where(id: ExternalUser.select(:consumer_id))
       elsif @user.teacher?
-        @scope.where(id: ExternalUserPolicy::Scope.new(@user, ExternalUser).resolve.select(:consumer_id))
+        @scope.where(id: ExternalUserPolicy::Scope.new(@user, ExternalUser).resolve.distinct.pluck(:consumer_id))
       else
         @scope.none
       end
@@ -30,7 +30,7 @@ class ConsumerPolicy < AdminOnlyPolicy
       if @user.admin?
         @scope.where(id: StudyGroup.select(:consumer_id))
       elsif @user.teacher?
-        @scope.where(id: StudyGroupPolicy::Scope.new(@user, StudyGroup).resolve.select(:consumer_id))
+        @scope.where(id: StudyGroupPolicy::Scope.new(@user, StudyGroup).resolve.distinct.pluck(:consumer_id))
       else
         @scope.none
       end

--- a/app/policies/exercise_policy.rb
+++ b/app/policies/exercise_policy.rb
@@ -47,7 +47,7 @@ class ExercisePolicy < AdminOrAuthorPolicy
           # The exercise's author is a teacher in the study group
           .where(study_group_memberships: {role: StudyGroupMembership.roles[:teacher]})
           # The current user is a teacher in the *same* study group
-          .where(study_group_memberships: {study_group_id: @user.study_group_memberships.where(role: :teacher).select(:study_group_id)})
+          .where(study_group_memberships: {study_group_id: @user.study_group_ids_as_teacher})
           .or(@scope.distinct.where(user: @user))
           .or(@scope.distinct.where(public: true))
       else

--- a/app/policies/exercise_policy.rb
+++ b/app/policies/exercise_policy.rb
@@ -61,7 +61,7 @@ class ExercisePolicy < AdminOrAuthorPolicy
       if @user.admin?
         @scope.where(id: ProgrammingGroup.select(:exercise_id))
       elsif @user.teacher?
-        @scope.where(id: ProgrammingGroupPolicy::Scope.new(@user, ProgrammingGroup).resolve.select(:exercise_id))
+        @scope.where(id: ProgrammingGroupPolicy::Scope.new(@user, ProgrammingGroup).resolve.distinct.pluck(:exercise_id))
       else
         @scope.none
       end
@@ -73,7 +73,7 @@ class ExercisePolicy < AdminOrAuthorPolicy
       if @user.admin?
         @scope.where(id: Submission.select(:exercise_id))
       elsif @user.teacher?
-        @scope.where(id: SubmissionPolicy::Scope.new(@user, Submission).resolve.select(:exercise_id))
+        @scope.where(id: SubmissionPolicy::Scope.new(@user, Submission).resolve.distinct.pluck(:exercise_id))
       else
         @scope.none
       end

--- a/app/policies/external_user_policy.rb
+++ b/app/policies/external_user_policy.rb
@@ -24,9 +24,7 @@ class ExternalUserPolicy < AdminOnlyPolicy
       elsif @user.teacher?
         @scope.joins(:study_group_memberships)
           .where(study_group_memberships: {
-            study_group_id: @user.study_group_memberships
-                                 .where(study_group_memberships: {role: StudyGroupMembership.roles[:teacher]})
-                                 .select(:study_group_id),
+            study_group_id: @user.study_group_ids_as_teacher,
           })
       else
         @scope.none

--- a/app/policies/internal_user_policy.rb
+++ b/app/policies/internal_user_policy.rb
@@ -20,9 +20,7 @@ class InternalUserPolicy < AdminOnlyPolicy
       elsif @user.teacher?
         @scope.joins(:study_group_memberships)
           .where(study_group_memberships: {
-            study_group_id: @user.study_group_memberships
-                                .where(study_group_memberships: {role: StudyGroupMembership.roles[:teacher]})
-                                .select(:study_group_id),
+            study_group_id: @user.study_group_ids_as_teacher,
           })
       else
         @scope.none

--- a/app/policies/programming_group_policy.rb
+++ b/app/policies/programming_group_policy.rb
@@ -31,9 +31,7 @@ class ProgrammingGroupPolicy < AdminOnlyPolicy
       elsif @user.teacher?
         @scope.joins(:submissions)
           .where(submissions: {
-            study_group_id: @user.study_group_memberships
-                                 .where(study_group_memberships: {role: StudyGroupMembership.roles[:teacher]})
-                                 .select(:study_group_id),
+            study_group_id: @user.study_group_ids_as_teacher,
           }).distinct
       else
         @scope.none

--- a/app/policies/proxy_exercise_policy.rb
+++ b/app/policies/proxy_exercise_policy.rb
@@ -23,7 +23,7 @@ class ProxyExercisePolicy < AdminOrAuthorPolicy
           # The proxy_exercise's author is a teacher in the study group
           .where(study_group_memberships: {role: StudyGroupMembership.roles[:teacher]})
           # The current user is a teacher in the *same* study group
-          .where(study_group_memberships: {study_group_id: @user.study_group_memberships.where(role: :teacher).select(:study_group_id)})
+          .where(study_group_memberships: {study_group_id: @user.study_group_ids_as_teacher})
           .or(@scope.distinct.where(user: @user))
           .or(@scope.distinct.where(public: true))
       else

--- a/app/policies/submission_policy.rb
+++ b/app/policies/submission_policy.rb
@@ -35,7 +35,7 @@ class SubmissionPolicy < ApplicationPolicy
       if @user.admin?
         @scope.all
       elsif @user.teacher?
-        @scope.where(study_group_id: @user.study_groups, cause: CausesScope.new(@user, Submission).resolve)
+        @scope.where(study_group_id: @user.study_group_ids_as_teacher, cause: CausesScope.new(@user, Submission).resolve)
       else
         @scope.none
       end


### PR DESCRIPTION
Previously, the subquery (for the study group IDs) was performed for each row during the join operation. Especially joining the submission table was too expensive for that operation, causing a massive slowdown. The metric below is already showing a subsequent query (with a fully loaded cache pipeline), the first request even took longer.

I feel there would be more potential to improve the page rendering even further, but this is out of scope for now. Affected are only teachers, since admins don't have the respective study group filter.

| Before | After |
|--------|--------|
| <img width="1475" alt="Bildschirmfoto 2024-08-05 um 21 15 31" src="https://github.com/user-attachments/assets/f239af40-3913-451a-8e12-d715b6923a59"> | <img width="1474" alt="Bildschirmfoto 2024-08-05 um 21 30 42" src="https://github.com/user-attachments/assets/3f0a509e-f836-45bd-a1ac-4588fa73e398"> | 
| [Trace](https://codeocean.sentry.io/performance/trace/09f6ef1455014182ab9c18e06d739d50/?node=trace-root&project=5667283&query=http.method%3AGET&referrer=performance-transaction-summary&source=performance_transaction_summary&statsPeriod=14d&timestamp=1722883400&transaction=ProgrammingGroupsController%23index&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29) | [Trace](https://codeocean.sentry.io/performance/trace/4526e8ccd2694963a5f5763c33bfddf6/?node=trace-root&project=5667283&query=http.method%3AGET&referrer=performance-transaction-summary&showTransactions=recent&source=performance_transaction_summary&statsPeriod=14d&timestamp=1722885534&transaction=ProgrammingGroupsController%23index&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29) |