### PR TITLE
Fix working time statistics when viewed without autosaves

### DIFF
--- a/app/views/exercises/external_users/statistics.html.slim
+++ b/app/views/exercises/external_users/statistics.html.slim
@@ -79,13 +79,13 @@ h1
                       .unit-test-result.positive-result title=[run.file&.filepath, run.log].join("\n").strip
                     - else
                       .unit-test-result.unknown-result title=[run.file&.filepath, run.log].join("\n").strip
-                td = @working_times_until[event_index] if event_index.positive? && policy(@exercise).detailed_statistics?
+                td = @working_times_until[event_index] if policy(@exercise).detailed_statistics?
               - elsif this.is_a? UserExerciseIntervention
                 td = this.created_at.strftime('%F %T')
                 td = this.intervention.name
                 td
                 td
-                td = @working_times_until[event_index] if event_index.positive? && policy(@exercise).detailed_statistics?
+                td = @working_times_until[event_index] if policy(@exercise).detailed_statistics?
     small
       b
         = t('.legend')


### PR DESCRIPTION
Previously, hiding autosaves also mixed up with the calculation of working times. This was caused by the missing submissions not being reflected in the deltas. The solution implemented here is not nice, but fulfills its requirements. Refactoring of the whole view is recommended.

| With Autosaves | Before | After |
|--------|--------|--------|
| <img width="714" alt="Bildschirmfoto 2024-08-09 um 13 26 14" src="https://github.com/user-attachments/assets/c0abc7c0-40ea-4db8-94bb-f8d02310531c"> | <img width="709" alt="Bildschirmfoto 2024-08-09 um 13 26 27" src="https://github.com/user-attachments/assets/44f01a2d-ec31-4cff-9864-f53a34f36d8f"> | <img width="712" alt="Bildschirmfoto 2024-08-09 um 13 26 36" src="https://github.com/user-attachments/assets/185cfbd5-1952-4065-bdf3-fae32cd7e3be"> | 