### PR TITLE
Allow updates to StudyGroups with internal users

### DIFF
--- a/app/controllers/study_groups_controller.rb
+++ b/app/controllers/study_groups_controller.rb
@@ -23,7 +23,7 @@ class StudyGroupsController < ApplicationController
   def update
     myparams = study_group_params
     @members = @study_group.study_group_memberships.includes(:user)
-    myparams[:external_users] = @members.where(id: myparams[:study_group_membership_ids].compact_blank).map(&:user)
+    myparams[:study_group_memberships] = @members.where(id: myparams[:study_group_membership_ids].compact_blank)
     update_and_respond(object: @study_group, params: myparams)
   end
 


### PR DESCRIPTION
Previously, the wrong parameter prevented correct updates to the group when an internal user was present. Now, we can handle validation errors of the StudyGroup as intended and remove both, internal and external users.

Fixes [CODEOCEAN-13X](https://codeocean.sentry.io/issues/5698367654/)