### PR TITLE
Remove any unpermitted parameters and raise if it reoccurs

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,6 +75,9 @@ Rails.application.configure do
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true
 
+  # Raises error for unpermitted parameters (default is `:log`).
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Annotate rendered view with file names.
   config.action_view.annotate_rendered_view_with_filenames = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -61,6 +61,9 @@ Rails.application.configure do
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true
 
+  # Raises error for unpermitted parameters (default is `:log`).
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Annotate rendered view with file names.
   config.action_view.annotate_rendered_view_with_filenames = true
 

--- a/spec/controllers/code_ocean/files_controller_spec.rb
+++ b/spec/controllers/code_ocean/files_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CodeOcean::FilesController do
     let(:submission) { create(:submission, contributor:) }
 
     context 'with a valid file' do
-      let(:perform_request) { proc { post :create, params: {code_ocean_file: build(:file, context: submission).attributes, format: :json} } }
+      let(:perform_request) { proc { post :create, params: {code_ocean_file: build(:file, context: submission).attributes.slice('name', 'file_type_id', 'file_template_id', 'context_id'), format: :json} } }
 
       before do
         submission.exercise.update(allow_file_creation: true)
@@ -53,7 +53,7 @@ RSpec.describe CodeOcean::FilesController do
     context 'with an invalid file' do
       before do
         submission.exercise.update(allow_file_creation: true)
-        post :create, params: {code_ocean_file: {context_id: submission.id, context_type: Submission}, format: :json}
+        post :create, params: {code_ocean_file: {context_id: submission.id}, format: :json}
       end
 
       expect_assigns(file: CodeOcean::File)

--- a/spec/controllers/consumers_controller_spec.rb
+++ b/spec/controllers/consumers_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ConsumersController do
 
   describe 'POST #create' do
     context 'with a valid consumer' do
-      let(:perform_request) { proc { post :create, params: {consumer: build(:consumer, name: 'New Consumer').attributes} } }
+      let(:perform_request) { proc { post :create, params: {consumer: build(:consumer, name: 'New Consumer').attributes.except('id', 'created_at', 'updated_at')} } }
 
       context 'when the request is performed' do
         before { perform_request.call }
@@ -35,7 +35,7 @@ RSpec.describe ConsumersController do
     end
 
     context 'with a duplicated consumer' do
-      let(:perform_request) { proc { post :create, params: {consumer: build(:consumer).attributes} } }
+      let(:perform_request) { proc { post :create, params: {consumer: build(:consumer).attributes.except('id', 'created_at', 'updated_at')} } }
 
       context 'when the request is performed' do
         before { perform_request.call }

--- a/spec/controllers/execution_environments_controller_spec.rb
+++ b/spec/controllers/execution_environments_controller_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe ExecutionEnvironmentsController do
 
   describe 'POST #create' do
     context 'with a valid execution environment' do
-      let(:perform_request) { proc { post :create, params: {execution_environment: build(:ruby, pool_size: 1).attributes} } }
+      let(:execution_environment_params) { build(:ruby, pool_size: 1).attributes.except('id', 'created_at', 'updated_at', 'user_id', 'user_type') }
+      let(:perform_request) { proc { post :create, params: {execution_environment: execution_environment_params} } }
 
       before do
         allow(Rails.env).to receive(:test?).and_return(false, true)
@@ -182,13 +183,15 @@ RSpec.describe ExecutionEnvironmentsController do
 
   describe 'PUT #update' do
     context 'with a valid execution environment' do
+      let(:execution_environment_params) { build(:ruby, pool_size: 1).attributes.except('id', 'created_at', 'updated_at', 'user_id', 'user_type') }
+
       before do
         allow(Rails.env).to receive(:test?).and_return(false, true)
         allow(Runner.strategy_class).to receive(:sync_environment).and_return(true)
         runner = instance_double Runner
         allow(Runner).to receive(:for).and_return(runner)
         allow(runner).to receive(:execute_command).and_return({})
-        put :update, params: {execution_environment: attributes_for(:ruby, pool_size: 1), id: execution_environment.id}
+        put :update, params: {execution_environment: execution_environment_params, id: execution_environment.id}
       end
 
       expect_assigns(docker_images: Array)

--- a/spec/controllers/exercises_controller_spec.rb
+++ b/spec/controllers/exercises_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ExercisesController do
   end
 
   describe 'POST #create' do
-    let(:exercise_attributes) { build(:dummy).attributes }
+    let(:exercise_attributes) { build(:dummy).attributes.except('created_at', 'id', 'token', 'updated_at', 'user_id', 'user_type', 'uuid') }
 
     context 'with a valid exercise' do
       let(:perform_request) { proc { post :create, params: {exercise: exercise_attributes} } }
@@ -82,7 +82,7 @@ RSpec.describe ExercisesController do
       let(:perform_request) { proc { post :create, params: {exercise: exercise_attributes.merge(files_attributes:)} } }
 
       context 'when specifying the file content within the form' do
-        let(:files_attributes) { {'0' => build(:file).attributes} }
+        let(:files_attributes) { {'0' => build(:file).attributes.except('context_id', 'context_type', 'created_at', 'hashed_content', 'updated_at')} }
 
         it 'creates the file' do
           expect { perform_request.call }.to change(CodeOcean::File, :count)
@@ -90,7 +90,7 @@ RSpec.describe ExercisesController do
       end
 
       context 'when uploading a file' do
-        let(:files_attributes) { {'0' => build(:file, file_type:).attributes.merge(content: uploaded_file)} }
+        let(:files_attributes) { {'0' => build(:file, file_type:).attributes.except('context_id', 'context_type', 'created_at', 'hashed_content', 'updated_at').merge(content: uploaded_file)} }
 
         context 'when uploading a binary file' do
           let(:file_path) { Rails.root.join('db/seeds/audio_video/devstories.mp4') }
@@ -291,7 +291,7 @@ RSpec.describe ExercisesController do
 
   describe 'PUT #update' do
     context 'with a valid exercise' do
-      let(:exercise_attributes) { build(:dummy).attributes }
+      let(:exercise_attributes) { build(:dummy).attributes.except('created_at', 'id', 'token', 'updated_at', 'uuid', 'user_id', 'user_type') }
 
       before { put :update, params: {exercise: exercise_attributes, id: exercise.id} }
 


### PR DESCRIPTION
So far, we had a few tests (and production-used code) that would log unpermitted parameters. This PR therefore addresses this issue by ensuring we are not sending unpermitted parameters during regular use. Furthermore, it raises if any unpermitted parameter is detected in development or test to make everyone aware.

As an additional extra, this PR also reorders some methods for the `InternalUsersController`.