### PR TITLE
RSpec: Raise on potential false positives

### DIFF
--- a/spec/support/expectations.rb
+++ b/spec/support/expectations.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec::Expectations.configuration.tap do |config|
+  config.on_potential_false_positives = :raise
+end


### PR DESCRIPTION
We want to ensure that RSpec expectations are used correctly. Hence, we want to raise on potential false positives, allowing developers to double-check their expectations.