### PR TITLE
Unify modal with CodeHarbor

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,6 +7,10 @@ module ApplicationHelper
     APPLICATION_NAME
   end
 
+  def clear_content_for(name)
+    view_flow.content.delete(name)
+  end
+
   def code_tag(code, language = nil)
     if code.present?
       tag.pre do

--- a/app/views/exercise_collections/_form.html.slim
+++ b/app/views/exercise_collections/_form.html.slim
@@ -35,4 +35,7 @@
 
   .actions = render('shared/submit_button', f:, object: @exercise_collection)
 
-= render('shared/modal', id: 'add-exercise-modal', title: t('.add_exercises'), template: 'exercise_collections/_add_exercise_modal')
+= render 'shared/modal',
+        title: t('.add_exercises'),
+        modal_root_attributes: {id: 'add-exercise-modal'},
+        template: 'exercise_collections/_add_exercise_modal'

--- a/app/views/exercises/_editor.html.slim
+++ b/app/views/exercises/_editor.html.slim
@@ -63,6 +63,20 @@
   - unless @embed_options[:disable_run] && @embed_options[:disable_score]
     .output-col-collapsed#output_sidebar = render('exercises/editor_output')
 
-= render('shared/modal', id: 'comment-modal', title: t('exercises.implement.comment.request'), template: 'exercises/_request_comment_dialogcontent') unless @embed_options[:disable_rfc]
-= render('shared/modal', id: 'break-intervention-modal', title: t('exercises.implement.break_intervention.title'), template: 'interventions/_break_intervention_modal') unless @embed_options[:disable_interventions]
-= render('shared/modal', id: 'tips-intervention-modal', title: t('exercises.implement.tips.heading'), template: 'interventions/_tips_intervention_modal') unless @embed_options[:disable_hints] || @tips.blank?
+- unless @embed_options[:disable_rfc]
+  = render 'shared/modal',
+          title: t('exercises.implement.comment.request'),
+          modal_root_attributes: {id: 'comment-modal'},
+          template: 'exercises/_request_comment_dialogcontent'
+
+- unless @embed_options[:disable_interventions]
+  = render 'shared/modal',
+          title: t('exercises.implement.break_intervention.title'),
+          modal_root_attributes: {id: 'break-intervention-modal'},
+          template: 'interventions/_break_intervention_modal'
+
+- unless @embed_options[:disable_hints] || @tips.blank?
+  = render 'shared/modal',
+          title: t('exercises.implement.tips.heading'),
+          modal_root_attributes: {id: 'tips-intervention-modal'},
+          template: 'interventions/_tips_intervention_modal'

--- a/app/views/exercises/_editor_file_tree.html.slim
+++ b/app/views/exercises/_editor_file_tree.html.slim
@@ -30,4 +30,7 @@
       = render(partial: 'tips_content')
 
 - if @exercise.allow_file_creation?
-  = render('shared/modal', id: 'modal-file', template: 'code_ocean/files/_form', title: t('exercises.editor.create_file'))
+  = render 'shared/modal',
+          title: t('exercises.editor.create_file'),
+          modal_root_attributes: {id: 'modal-file'},
+          template: 'code_ocean/files/_form'

--- a/app/views/exercises/_export_actions.html.slim
+++ b/app/views/exercises/_export_actions.html.slim
@@ -9,4 +9,4 @@
 
 = button_tag type: 'submit', class: 'btn btn-secondary float-end export-button', data: {bs_dismiss: 'modal'} do
   i.fa-solid.fa-xmark.abort-icon
-  = exported ? t('exercises.export_codeharbor.buttons.close') : t('exercises.export_codeharbor.buttons.abort')
+  = exported ? t('shared.close') : t('exercises.export_codeharbor.buttons.abort')

--- a/app/views/exercises/_form.html.slim
+++ b/app/views/exercises/_form.html.slim
@@ -107,4 +107,7 @@
 
   .actions = render('shared/submit_button', f:, object: @exercise)
 
-= render('shared/modal', id: 'add-tips-modal', title: t('.add_tips'), template: 'exercises/_add_tip_modal')
+= render 'shared/modal',
+        title: t('.add_tips'),
+        modal_root_attributes: {id: 'add-tips-modal'},
+        template: 'exercises/_add_tip_modal'

--- a/app/views/exercises/implement.html.slim
+++ b/app/views/exercises/implement.html.slim
@@ -44,4 +44,8 @@
 
 
   = render('editor', exercise: @exercise, files: @files, submission: @submission)
-  = render('shared/modal', classes: 'modal-lg', id: 'modal-info-pair-programming', template: 'programming_groups/_info_pair_programming', title: t('programming_groups.new.pair_programming_info'))
+  = render 'shared/modal',
+          title: t('programming_groups.new.pair_programming_info'),
+          size: 'modal-lg',
+          modal_root_attributes: {id: 'modal-info-pair-programming'},
+          template: 'programming_groups/_info_pair_programming'

--- a/app/views/exercises/index.html.slim
+++ b/app/views/exercises/index.html.slim
@@ -58,4 +58,7 @@ h1 = Exercise.model_name.human(count: :other)
 = render('shared/pagination', collection: @exercises)
 p = render('shared/new_button', model: Exercise)
 
-= render('shared/modal', id: 'export-modal', title: t('exercises.export_codeharbor.dialogtitle'), template: 'exercises/_export_dialogcontent')
+= render 'shared/modal',
+        title: t('exercises.export_codeharbor.dialogtitle'),
+        modal_root_attributes: {id: 'export-modal'},
+        template: 'exercises/_export_dialogcontent'

--- a/app/views/exercises/show.html.slim
+++ b/app/views/exercises/show.html.slim
@@ -64,4 +64,7 @@ ul.list-unstyled#files
             .clearfix = link_to(t('shared.destroy'), file, class: 'btn btn-warning btn-sm float-end', data: {confirm: t('shared.confirm_destroy')}, method: :delete)
           = render('shared/file', file:)
 
-= render('shared/modal', id: 'export-modal', title: t('exercises.export_codeharbor.dialogtitle'), template: 'exercises/_export_dialogcontent')
+= render 'shared/modal',
+        title: t('exercises.export_codeharbor.dialogtitle'),
+        modal_root_attributes: {id: 'export-modal'},
+        template: 'exercises/_export_dialogcontent'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -46,4 +46,9 @@ html lang=I18n.locale data-default-locale=I18n.default_locale
         = yield
 
     - template_variables = {execution_environment: @exercise.execution_environment} if action_name == 'implement'
-    = render('shared/modal', classes: 'modal-lg', id: 'modal-help', template: 'application/help', template_variables:, title: t('shared.help.headline'))
+    = render 'shared/modal',
+            title: t('shared.help.headline'),
+            size: 'modal-lg',
+            modal_root_attributes: {id: 'modal-help'},
+            template: 'application/help',
+            template_variables:

--- a/app/views/programming_groups/_info_pair_programming.html.slim
+++ b/app/views/programming_groups/_info_pair_programming.html.slim
@@ -3,5 +3,5 @@
 - content_for :modal_footer, flush: true do
   button.btn.btn-secondary#dont_show_info_pp_modal_again data-bs-dismiss='modal'
     = t('programming_groups.new.dont_show_modal_again')
-  button.btn.btn-primary data-bs-dismiss='modal'
-    = t('programming_groups.new.close')
+  button.btn.btn-primary data-bs-dismiss='modal' type='button'
+    = t('shared.close')

--- a/app/views/programming_groups/new.html.slim
+++ b/app/views/programming_groups/new.html.slim
@@ -37,4 +37,8 @@ h1.d-inline-block = t('programming_groups.new.create_programming_pair')
         h5 = t('programming_groups.new.work_alone')
         == t('programming_groups.new.work_alone_description', path: implement_exercise_path(@exercise))
 
-= render('shared/modal', classes: 'modal-lg', id: 'modal-info-pair-programming', template: 'programming_groups/_info_pair_programming', title: t('programming_groups.new.pair_programming_info'))
+= render 'shared/modal',
+        title: t('programming_groups.new.pair_programming_info'),
+        size: 'modal-lg',
+        modal_root_attributes: {id: 'modal-info-pair-programming'},
+        template: 'programming_groups/_info_pair_programming'

--- a/app/views/request_for_comments/show.html.slim
+++ b/app/views/request_for_comments/show.html.slim
@@ -79,4 +79,7 @@
   #commentitor.editor data-file-id=file.id data-mode=file.file_type.editor_mode data-read-only='true'
     = file.content
 
-= render('shared/modal', id: 'comment-modal', title: t('exercises.implement.comment.dialogtitle'), template: 'exercises/_comment_dialogcontent')
+= render 'shared/modal',
+        title: t('exercises.implement.comment.dialogtitle'),
+        modal_root_attributes: {id: 'comment-modal'},
+        template: 'exercises/_comment_dialogcontent'

--- a/app/views/shared/_modal.html.slim
+++ b/app/views/shared/_modal.html.slim
@@ -1,14 +1,20 @@
-.fade.modal aria-hidden=true aria-labelledby='modal-title' id=id role='dialog' tabindex=-1
-  .modal-dialog.modal-dialog-scrollable class=local_assigns[:classes]
+- modal_root_attributes ||= {}
+- modal_body_attributes ||= {}
+- title ||= ''
+- size ||= '' # default is medium size, which is just ''
+
+
+.modal.fade *modal_root_attributes aria-hidden='true' aria-labelledby='modal-title' role='dialog' tabindex='-1'
+  .modal-dialog.modal-dialog-centered.modal-dialog-scrollable class=size
     .modal-content
       .modal-header
-        h4#modal-title.modal-title = title
-        button.btn-close data-bs-dismiss='modal' type='button'
-          span.visually-hidden Close
-      .modal-body
-        - if local_assigns.key?(:body)
-          = body
-        - else
-          = render(layout: false, locals: (local_assigns[:template_variables] || {}).merge(modal: true), template:)
-      .modal-footer
-        = yield(:modal_footer)
+        h4.modal-title#modal-title = title
+        button.btn-close data-bs-dismiss='modal' aria-label=t('shared.close') type='button'
+          span.visually-hidden = t('shared.close')
+
+      .modal-body *modal_body_attributes
+        = render(layout: false, locals: (local_assigns[:template_variables] || {}).merge(modal: true), template:)
+
+      - if content_for? :modal_footer
+        .modal-footer
+          = clear_content_for :modal_footer

--- a/config/locales/de/exercise.yml
+++ b/config/locales/de/exercise.yml
@@ -91,7 +91,6 @@ de:
     export_codeharbor:
       buttons:
         abort: Abbrechen
-        close: Schließen
         export: Export
         retry: Erneut probieren
       check:

--- a/config/locales/de/meta/shared.yml
+++ b/config/locales/de/meta/shared.yml
@@ -12,6 +12,7 @@ de:
     apply_filters: Filter anwenden
     back: Zurück
     batch_update: Batch-Update
+    close: Schließen
     color_mode:
       auto: Automatisch
       dark: Dunkel

--- a/config/locales/de/programming_group.yml
+++ b/config/locales/de/programming_group.yml
@@ -21,7 +21,6 @@ de:
     implement:
       info_disconnected: Ihre Verbindung zum Server wurde unterbrochen. Bitte überprüfen Sie Ihre Internetverbindung und laden Sie die Seite erneut.
     new:
-      close: Schließen
       create_programming_pair: Programmierpaar erstellen
       dont_show_modal_again: Auf diesem Gerät nicht mehr anzeigen
       enter_partner_id: Kennen Sie eine Person in dem Kurs, mit der Sie gemeinsam die Aufgabe lösen möchten? Dann geben Sie hier die zugehörige Personen-ID ein.

--- a/config/locales/en/exercise.yml
+++ b/config/locales/en/exercise.yml
@@ -91,7 +91,6 @@ en:
     export_codeharbor:
       buttons:
         abort: Abort
-        close: Close
         export: Export
         retry: Retry
       check:

--- a/config/locales/en/meta/shared.yml
+++ b/config/locales/en/meta/shared.yml
@@ -12,6 +12,7 @@ en:
     apply_filters: Apply filters
     back: Back
     batch_update: Batch Update
+    close: Close
     color_mode:
       auto: Auto
       dark: Dark

--- a/config/locales/en/programming_group.yml
+++ b/config/locales/en/programming_group.yml
@@ -21,7 +21,6 @@ en:
     implement:
       info_disconnected: You are disconnected from the server. Please check your internet connection and reload the page.
     new:
-      close: Close
       create_programming_pair: Create Programming Pair
       dont_show_modal_again: Don't display on this device anymore
       enter_partner_id: Do you know a person in the course with whom you would like to solve the task together? Then enter that person's user ID here.


### PR DESCRIPTION
* Introduce `clear_content_for` method to prevent double rendering of the footer (once again, amends 092e8426).
* Use common translation for Close button