### PR TITLE
Fix source map generation with Webpack

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -95,6 +95,12 @@ if (webpackConfig.mode === 'development') {
     envConfig.devtool = 'source-map';
 }
 
+// Enable source map for SASS / SCSS files, including the original sources in the source map.
+webpackConfig.module.rules
+  .flatMap(rule => Array.isArray(rule.use) ? rule.use : [])
+  .filter(loaderConfig => loaderConfig.options?.sassOptions)
+  .forEach(loaderConfig => loaderConfig.options.sassOptions.sourceMapIncludeSources = true);
+
 // Use the following lines below to remove original plugins and replace them with our custom config.
 // This is especially needed for the `WebpackAssetsManifest` plugin, which would otherwise run twice.
 const customPlugins = envConfig.plugins.map((plugin) => plugin.constructor.name);

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -90,6 +90,10 @@ const envConfig = module.exports = {
     stats: 'minimal',
 }
 
+// Enable working source maps in development mode, overwriting the default 'cheap-module-source-map'.
+if (webpackConfig.mode === 'development') {
+    envConfig.devtool = 'source-map';
+}
 
 // Use the following lines below to remove original plugins and replace them with our custom config.
 // This is especially needed for the `WebpackAssetsManifest` plugin, which would otherwise run twice.


### PR DESCRIPTION
There were two distinct issues with source maps generated by WebPakc that prevented them to be useful. Sprocket-generated source maps were not affected.

| Bug | Before | After |
|--------|--------|--------|
| JavaScript source maps were only available in production | <img width="1840" alt="Bildschirmfoto 2024-08-30 um 22 07 36" src="https://github.com/user-attachments/assets/97bc5b29-d021-44c5-a2af-76f1fabde944"> | <img width="1840" alt="Bildschirmfoto 2024-08-30 um 22 09 48" src="https://github.com/user-attachments/assets/10d87458-4e92-41d1-887e-dd334457758b"> |
| SASS / SCSS did not have proper source files at all | <img width="1840" alt="Bildschirmfoto 2024-08-30 um 22 07 43" src="https://github.com/user-attachments/assets/abfe5d07-7c2b-46e2-b004-f7bf22aafb48"> | <img width="1840" alt="Bildschirmfoto 2024-08-30 um 22 09 53" src="https://github.com/user-attachments/assets/46f52f44-c30a-4338-81a2-1b47456ba77c"> |