### PR TITLE
Extract health check for depleted environments

### DIFF
--- a/app/errors/runner/error.rb
+++ b/app/errors/runner/error.rb
@@ -20,6 +20,8 @@ class Runner
 
     class RunnerNotFound < Error; end
 
+    class PrewarmingPoolDepleted < Error; end
+
     class FaradayError < Error; end
 
     class UnexpectedResponse < Error; end

--- a/lib/runner/strategy/poseidon.rb
+++ b/lib/runner/strategy/poseidon.rb
@@ -222,6 +222,8 @@ class Runner::Strategy::Poseidon < Runner::Strategy
     case response.status
       when 204
         true
+      when 503
+        raise Runner::Error::PrewarmingPoolDepleted.new parse(response)[:message]
       else
         raise Runner::Error::UnexpectedResponse.new("Poseidon sent unexpected response status code #{response.status}")
     end


### PR DESCRIPTION
With the extracted method it is easier to recognize the environments which caused an issue in Sentry.