### PR TITLE
Gracefully handle more errors during file copy

### DIFF
--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -46,7 +46,8 @@ class Runner < ApplicationRecord
   def copy_files(files)
     reserve!
     @strategy.copy_files(files)
-  rescue Runner::Error::RunnerNotFound
+  rescue Runner::Error => e
+    Sentry.capture_exception(e) unless e.is_a? Runner::Error::RunnerNotFound
     request_new_id
     save
     @strategy.copy_files(files)


### PR DESCRIPTION
If something goes wrong while copying files, we just want to retry with a new runner. If the error is not expected (which would be only an `Runner::Error::RunnerNotFound`), we log the error to Sentry.

This PR is related to https://github.com/openHPI/poseidon/issues/649.