### PR TITLE
Replace `db:migrate` with `db:prepare`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,10 @@ jobs:
           cp config/mnemosyne.yml.ci config/mnemosyne.yml
           cp config/content_security_policy.yml.ci config/content_security_policy.yml
 
-      - name: Create database
+      - name: Prepare database
         env:
           RAILS_ENV: test
-        run: bundler exec rake db:schema:load
+        run: bundler exec rake db:prepare
       - name: Precompile assets
         env:
           RAILS_ENV: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,9 +39,7 @@ rspec:
     - bundle install
     - yarn install
     - export RAILS_ENV=test
-    - rake db:create
-    - rake db:schema:load
-    - rake db:migrate
+    - rake db:prepare
     - docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
     - docker pull openhpi/co_execenv_java:8-antlr
   script:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ In order to execute code submissions using the [DockerContainerPool](https://git
 ### Optional Steps
 - Use Docker Machine or Vagrant if there is no native support for Docker on your OS
 - If you want to use the app without Docker or a Runner management (and hence without code execution), comment the validation `validate :working_docker_image?` in `models/execution_environments.rb`. Otherwise the seed will fail.
-- Create seed data by executing `rails db:seed`
 - If you already created a configuration for your local installation and want to use vagrant, too, be sure to log into the vagrant instance via ssh and add your database user manually to the database. Afterwards, create, migrate and seed.
 
 ## Production Setup

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,9 @@
 #   * all: Objects are needed in every environment (production, development)
 #   * production: Objects are only needed for deployment
 #   * development: Only needed for local development
-#
+
+# Disable seeding if there are already internal users in the database
+return if InternalUser.any?
 
 def find_factories_by_class(klass)
   FactoryBot.factories.select do |factory|
@@ -25,13 +27,6 @@ module ActiveRecord
     end
   end
 end
-
-# delete all present records
-Rails.application.eager_load!
-(ApplicationRecord.descendants - [ActiveRecord::SchemaMigration, Contributor, User]).each(&:delete_all)
-
-# delete file uploads
-FileUtils.rm_rf(Rails.public_path.join('uploads'))
 
 ['all', Rails.env].each do |seed|
   seed_file = Rails.root.join("db/seeds/#{seed}.rb")

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -1,6 +1,6 @@
 # Local Setup CodeOcean with Poseidon
 
-CodeOcean is built as a micro service architecture and requires multiple components to work. Besides the main CodeOcean web application with a PostgreSQL database, a custom-developed Go service called [Poseidon](https://github.com/openHPI/poseidon) is required to allow code execution. Poseidon manages so-called Runners, which are responsible for running learners code. It is executed in (Docker) containers managed through Nomad. The following document will guide you through the setup of CodeOcean with all aforementioned components.
+CodeOcean is built as a micro service architecture and requires multiple components to work. Besides the main CodeOcean web application with PostgreSQL databases, a custom-developed Go service called [Poseidon](https://github.com/openHPI/poseidon) is required to allow code execution. Poseidon manages so-called Runners, which are responsible for running learners code. It is executed in (Docker) containers managed through Nomad. The following document will guide you through the setup of CodeOcean with all aforementioned components.
 
 We recommend using the **native setup** as described below. We also prepared a setup with Vagrant using a virtual machine as [described in this guide](./LOCAL_SETUP_VAGRANT.md). However, the Vagrant setup might be outdated and is not actively maintained (PRs are welcome though!)
 
@@ -172,12 +172,12 @@ bundle install
 yarn install
 ```
 
-### Initialize the database
+### Initialize the databases
 
-The following command will create a database for the development and test environments, setup tables, and load seed data.
+The following command will create the necessary databases for the development and test environments, setup tables, and load seed data.
 
 ```shell
-rake db:setup
+rake db:prepare
 ```
 
 ### Start CodeOcean

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,6 +1,6 @@
 # Backups
 
-CodeOcean persists most data in the PostgreSQL database including submissions and the respective user files. Only binary files that cannot be serialized are stored in the `public/uploads` folder in dedicated sub-folders with the ID as folder name. Necessary files are temporarily extracted to the container's file system during execution but don't need to backed up separately.
+CodeOcean persists most data in the PostgreSQL databases including submissions and the respective user files. Only binary files that cannot be serialized are stored in the `public/uploads` folder in dedicated sub-folders with the ID as folder name. Necessary files are temporarily extracted to the container's file system during execution but don't need to backed up separately.
 
 ## Summary
 
@@ -8,5 +8,5 @@ In order to back up CodeOcean, you should consider these locations:
 
 - `config/*.yml` and `config/*.yml.erb`
 - The values of [environment variables](environment_variables.md) set for the web server
-- PostgreSQL database as specified in `config/database.yml`
+- PostgreSQL databases as specified in `config/database.yml`
 - `public/uploads` and all sub-folders

--- a/spec/db/seeds_spec.rb
+++ b/spec/db/seeds_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe 'seeds' do
   before do
     Rails.application.load_tasks if Rake::Task.tasks.empty?
 
-    # We need to migrate the test database before seeding
+    # We need to prepare the test database before seeding
     # Otherwise, Rails 7.1+ will throw an `NoMethodError`: `pending_migrations.any?`
     # See ActiveRecord gem, file `lib/active_record/railties/databases.rake`
-    Rake::Task['db:migrate'].invoke
+    Rake::Task['db:prepare'].invoke
 
     # We want to execute the seeds for the dev environment against the test database
     # rubocop:disable Rails/Inquiry


### PR DESCRIPTION
`db:prepare` was introduced with Rails 6 and performs the necessary steps in a multi-database Rails app to bring the database to the required state. If non-existent, a new database is created and the schema is loaded; otherwise, migrations are performed.