### PR TITLE
Add Solid Cable adapter for ActionCable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'actioncable-enhanced-postgresql-adapter'
 gem 'bcrypt'
 gem 'bootsnap', require: false
 gem 'bootstrap-will_paginate'
@@ -47,6 +46,7 @@ gem 'rubyzip'
 gem 'sassc-rails'
 gem 'shakapacker', '8.0.2'
 gem 'slim-rails'
+gem 'solid_cable'
 gem 'solid_queue'
 gem 'sorcery'
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,6 @@ GEM
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
       zeitwerk (~> 2.6)
-    actioncable-enhanced-postgresql-adapter (1.0.1)
-      actioncable (>= 6.0)
-      connection_pool (>= 2.2.5)
-      pg (~> 1.5)
     actionmailbox (7.2.1)
       actionpack (= 7.2.1)
       activejob (= 7.2.1)
@@ -515,6 +511,8 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
+    solid_cable (1.0.3)
+      rails (< 9)
     solid_queue (0.9.0)
       activejob (>= 7.1)
       activerecord (>= 7.1)
@@ -589,7 +587,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actioncable-enhanced-postgresql-adapter
   bcrypt
   better_errors
   binding_of_caller
@@ -662,6 +659,7 @@ DEPENDENCIES
   simplecov
   slim-rails
   slim_lint
+  solid_cable
   solid_queue
   sorcery
   sprockets-rails

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,20 +1,27 @@
+default: &default
+  adapter: solid_cable # OR postgresql OR redis
+
+  ### Config options for `solid_cable`
+  connects_to:
+    database:
+      writing: cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day
+  autotrim: true
+  silence_polling: true
+
+  ### Config options for `redis`
+  # url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  # channel_prefix: codeocean_production
+
 development:
-  adapter: enhanced_postgresql
+  <<: *default
 
 test:
   adapter: test
 
 staging:
-  adapter: enhanced_postgresql
+  <<: *default
 
 production:
-  adapter: enhanced_postgresql # OR postgresql OR redis
-
-  ### Config options for `enhanced_postgresql`
-  # payload_encryptor_secret: # Required. Will be the defined value or `Rails.application.secret_key_base` or `ENV["SECRET_KEY_BASE"]`
-  # url: <%= ENV.fetch("DATABASE_URL") { "postgresql://localhost:5432/code_ocean_production" } %>
-  # connection_pool_size: <%= ENV.fetch("RAILS_MAX_THREADS", 5).to_i %> # Only used in conjunction with `url`
-
-  ### Config options for `redis`
-  # url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  # channel_prefix: code_ocean_production
+  <<: *default

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -32,6 +32,10 @@ development:
   primary: &primary_development
     <<: *default
     database: codeocean_development
+  cable:
+    <<: *primary_development
+    database: codeocean_development_cable
+    migrations_paths: db/cable_migrate
   queue:
     <<: *primary_development
     database: codeocean_development_queue
@@ -64,6 +68,10 @@ production:
   primary: &primary_production
     <<: *default
     database: codeocean_production
+  cable:
+    <<: *primary_production
+    database: codeocean_production_cable
+    migrations_paths: db/cable_migrate
   queue:
     <<: *primary_production
     database: codeocean_production_queue

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 1) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "solid_cable_messages", force: :cascade do |t|
+    t.text "channel"
+    t.text "payload"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+  end
+end

--- a/db/migrate/20240912101506_drop_action_cable_large_payloads.rb
+++ b/db/migrate/20240912101506_drop_action_cable_large_payloads.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class DropActionCableLargePayloads < ActiveRecord::Migration[7.2]
+  def change
+    # Drop the previously-used table for large payloads in ActionCable.
+    # This table was implicitly created by the EnhancedPostgresql adapter.
+    # Solid Cable used from now on manages the required schema separately.
+    drop_table :action_cable_large_payloads, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2023_12_08_194632) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_12_101506) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"


### PR DESCRIPTION
Switching the adapter is not expected to make any noticeable difference. The previous gem used was an interim solution and is now replaced by the new Solid Cable adapter shipping with Rails 8 by default.

This PR depends on the following two PRs to be merged first:
- #2478
- #2524 

Only when those two PRs are merged, the tests in this branch will pass. Nevertheless, reviewing is already possible, @Dome-GER 😉