### PR TITLE
Improve file name extraction for Java files

### DIFF
--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -467,7 +467,7 @@ var CodeOceanEditor = {
     initializeRegexes: function () {
         // These RegEx are run on the HTML escaped output!
         this.regex_for_language.set("ace/mode/python", /File &quot;(.+?)&quot;, line (\d+)/g);
-        this.regex_for_language.set("ace/mode/java", /(?:\.\/)?(.*\.java):(\d+):/g);
+        this.regex_for_language.set("ace/mode/java", /^(?:\.\/)?(.*\.java):(\d+):/g);
     },
 
     initializeWorkspaceButtons: function () {


### PR DESCRIPTION
The previous RegEx used was pretty inefficient and could result in an "too much recursion" error. I still assume that the updated RegEx catches all relevant file names, without limiting recognition.

Fixes [CODEOCEAN-FRONTEND-9Q](https://codeocean.sentry.io/issues/5535604651/)