### PR TITLE
LTI: Catch `Errno::ECONNREFUSED` as error

### DIFF
--- a/app/controllers/concerns/lti.rb
+++ b/app/controllers/concerns/lti.rb
@@ -180,7 +180,7 @@ module Lti
     begin
       response = provider.post_replace_result!(score)
       {code: response.response_code, message: response.post_response.body, status: response.code_major, user:}
-    rescue IMS::LTI::XMLParseError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET, SocketError, EOFError
+    rescue IMS::LTI::XMLParseError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNREFUSED, Errno::ECONNRESET, SocketError, EOFError
       # A parsing error might happen if the LTI provider is down and doesn't return a valid XML response
       {status: 'error', user:}
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -86,7 +86,7 @@ class SessionsController < ApplicationController
         lti_parameters = params.slice(*Lti::SESSION_PARAMETERS).permit!.to_h
         provider = build_tool_provider(consumer: current_user.consumer, parameters: lti_parameters)
         provider.post_replace_result!(1.0)
-      rescue IMS::LTI::InvalidLTIConfigError, IMS::LTI::XMLParseError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET, SocketError, EOFError
+      rescue IMS::LTI::InvalidLTIConfigError, IMS::LTI::XMLParseError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNREFUSED, Errno::ECONNRESET, SocketError, EOFError
         # We don't do anything here because it is only a bonus point and we want the users to do the survey
       end
     end


### PR DESCRIPTION
This error could occur when a valid hostname is given, but no server is listening on the given address.

Fixes [CODEOCEAN-14K](https://codeocean.sentry.io/issues/5858077050/)