### PR TITLE
Proforma: reuse existing files on import, if possible

### DIFF
--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -56,7 +56,7 @@ class ExercisesController < ApplicationController
   end
 
   def clone
-    exercise = @exercise.duplicate(public: false, token: nil, user: current_user)
+    exercise = @exercise.duplicate(public: false, token: nil, user: current_user, uuid: nil)
     exercise.send(:generate_token)
     if exercise.save
       redirect_to(exercise_path(exercise), notice: t('shared.object_cloned', model: Exercise.model_name.human))

--- a/app/models/code_ocean/file.rb
+++ b/app/models/code_ocean/file.rb
@@ -60,6 +60,11 @@ module CodeOcean
     validates :weight, absence: true, unless: :teacher_defined_assessment?
     validates :file, presence: true if :context.is_a?(Submission)
     validates :context_type, inclusion: {in: ALLOWED_CONTEXT_TYPES}
+    # xml_id_path must be unique within the scope of an exercise.
+    # Initially, it may match the record’s id (set while exporting),
+    # but it can later diverge as long as uniqueness is preserved.
+    validates :xml_id_path, uniqueness: {scope: %I[context_id context_type]}, allow_blank: true
+    validates :xml_id_path, absence: true, unless: -> { context.is_a?(Exercise) }
 
     validates_with FileNameValidator, fields: %i[name path file_type_id]
 

--- a/app/services/proforma_service/convert_exercise_to_task.rb
+++ b/app/services/proforma_service/convert_exercise_to_task.rb
@@ -77,62 +77,84 @@ module ProformaService
     end
 
     def model_solutions
-      @exercise.files.filter {|file| file.role == 'reference_implementation' }.map do |file|
+      model_solutions_files = @exercise.files.filter {|file| file.role == 'reference_implementation' }.group_by {|file| xml_id_from_file(file).first }
+      model_solutions_files.map do |xml_id, files|
         ProformaXML::ModelSolution.new(
-          id: "ms-#{file.id}",
-          files: model_solution_file(file)
+          id: xml_id,
+          files: files.map {|file| model_solution_file(file) }
         )
       end
     end
 
     def model_solution_file(file)
-      [
-        task_file(file).tap do |ms_file|
-          ms_file.used_by_grader = false
-          ms_file.usage_by_lms = 'display'
-        end,
-      ]
+      task_file(file).tap do |ms_file|
+        ms_file.used_by_grader = false
+        ms_file.usage_by_lms = 'display'
+      end
     end
 
     def tests
-      @exercise.files.filter(&:teacher_defined_assessment?).map do |file|
+      @exercise.files.filter(&:teacher_defined_assessment?).group_by {|file| xml_id_from_file(file).first }.map do |xml_id, files|
         ProformaXML::Test.new(
-          id: file.id,
-          title: file.name,
-          files: test_file(file),
-          meta_data: test_meta_data(file)
+          id: xml_id,
+          title: files.first.name,
+          files: files.map {|file| test_file(file) },
+          meta_data: test_meta_data(files)
         )
       end
     end
 
-    def test_meta_data(file)
+    def xml_id_from_file(file)
+      type = if file.teacher_defined_assessment?
+               'test'
+             elsif file.reference_implementation?
+               'ms'
+             else
+               'file'
+             end
+      xml_id_path_parts = file.xml_id_path&.split('/')
+      xml_id_path  = []
+
+      xml_id_path << (xml_id_path_parts&.first || "co-#{type}-#{file.id}") unless type == 'file'
+      xml_id_path << (xml_id_path_parts&.last || file.id)
+
+      xml_id_path
+    end
+
+    def test_meta_data(files)
       {
         '@@order' => %w[test-meta-data],
         'test-meta-data' => {
-          '@@order' => %w[CodeOcean:feedback-message CodeOcean:weight CodeOcean:hidden-feedback],
+          '@@order' => %w[CodeOcean:test-file],
           '@xmlns' => {'CodeOcean' => 'codeocean.openhpi.de'},
-          'CodeOcean:feedback-message' => {
-            '@@order' => %w[$1],
-            '$1' => file.feedback_message,
-          },
-          'CodeOcean:weight' => {
-            '@@order' => %w[$1],
-            '$1' => file.weight,
-          },
-          'CodeOcean:hidden-feedback' => {
-            '@@order' => %w[$1],
-            '$1' => file.hidden_feedback,
-          },
+          'CodeOcean:test-file' => files.map do |file|
+            {
+              '@@order' => %w[CodeOcean:feedback-message CodeOcean:weight CodeOcean:hidden-feedback],
+              '@xmlns' => {'CodeOcean' => 'codeocean.openhpi.de'},
+              '@id' =>  xml_id_from_file(file).last,
+              '@name' => file.name,
+              'CodeOcean:feedback-message' => {
+                '@@order' => %w[$1],
+                '$1' => file.feedback_message,
+              },
+              'CodeOcean:weight' => {
+                '@@order' => %w[$1],
+                '$1' => file.weight,
+              },
+              'CodeOcean:hidden-feedback' => {
+                '@@order' => %w[$1],
+                '$1' => file.hidden_feedback,
+              },
+            }
+          end,
         },
       }
     end
 
     def test_file(file)
-      [
-        task_file(file).tap do |t_file|
-          t_file.used_by_grader = true
-        end,
-      ]
+      task_file(file).tap do |t_file|
+        t_file.used_by_grader = true
+      end
     end
 
     def exercise_files
@@ -168,8 +190,11 @@ module ProformaService
     end
 
     def task_file(file)
+      file.update(xml_id_path: xml_id_from_file(file).join('/')) if file.xml_id_path.blank?
+
+      xml_id = xml_id_from_file(file).last
       task_file = ProformaXML::TaskFile.new(
-        id: file.id,
+        id: xml_id,
         filename: filename(file),
         usage_by_lms: file.read_only ? 'display' : 'edit',
         visible: file.hidden ? 'no' : 'yes'

--- a/app/services/proforma_service/convert_exercise_to_task.rb
+++ b/app/services/proforma_service/convert_exercise_to_task.rb
@@ -77,8 +77,7 @@ module ProformaService
     end
 
     def model_solutions
-      model_solutions_files = @exercise.files.filter {|file| file.role == 'reference_implementation' }.group_by {|file| xml_id_from_file(file).first }
-      model_solutions_files.map do |xml_id, files|
+      @exercise.files.filter(&:reference_implementation?).group_by {|file| xml_id_from_file(file).first }.map do |xml_id, files|
         ProformaXML::ModelSolution.new(
           id: xml_id,
           files: files.map {|file| model_solution_file(file) }

--- a/app/services/proforma_service/convert_task_to_exercise.rb
+++ b/app/services/proforma_service/convert_task_to_exercise.rb
@@ -10,13 +10,16 @@ module ProformaService
     end
 
     def execute
-      import_task
+      ActiveRecord::Base.transaction do
+        import_task
+      end
       @exercise
     end
 
     private
 
     def import_task
+      destroy_old_files
       @exercise.assign_attributes(
         user: @user,
         title: @task.title,
@@ -32,9 +35,14 @@ module ProformaService
       )
     end
 
+    def destroy_old_files
+      file_ids = (@task.files + @task.tests.flat_map(&:files) + @task.model_solutions.flat_map(&:files)).map(&:id)
+      @exercise.files.reject {|file| file_ids.include? file.xml_id_path.last }.each(&:destroy)
+    end
+
     def extract_meta_data(meta_data, *path)
       current_level = meta_data
-      path.each {|attribute| current_level = current_level&.dig("CodeOcean:#{attribute}") }
+      path.each {|attribute| current_level = current_level.is_a?(Hash) ? current_level&.dig("CodeOcean:#{attribute}") : current_level&.find {|entry| entry['@id'] == attribute } } # || current_level
       current_level&.dig('$1')
     end
 
@@ -81,6 +89,7 @@ module ProformaService
         model_solution.files.map do |task_file|
           codeocean_file_from_task_file(task_file, model_solution).tap do |file|
             file.role ||= 'reference_implementation'
+            file.feedback_message = nil
           end
         end
       end
@@ -90,14 +99,15 @@ module ProformaService
       @task.files.reject {|file| file.id == 'ms-placeholder-file' }.map do |task_file|
         codeocean_file_from_task_file(task_file).tap do |file|
           file.role ||= 'regular_file'
+          file.feedback_message = nil
         end
       end
     end
 
     def codeocean_file_from_task_file(file, parent_object = nil)
       extension = File.extname(file.filename)
-
-      codeocean_file = CodeOcean::File.where(context: @exercise).where('xml_id_path = ? OR xml_id_path LIKE ?', file.id, "%/#{file.id}").first_or_initialize(context: @exercise)
+      # checking the last element of xml_id_path array for file.id
+      codeocean_file = @exercise.files.where('array_length(xml_id_path, 1) IS NOT NULL AND xml_id_path[array_length(xml_id_path, 1)] = ?', file.id).first_or_initialize
       codeocean_file.assign_attributes(
         context: @exercise,
         file_type: file_type(extension),
@@ -106,7 +116,7 @@ module ProformaService
         read_only: file.usage_by_lms != 'edit',
         role: extract_meta_data(@task.meta_data&.dig('meta-data'), 'files', "CO-#{file.id}", 'role'),
         path: File.dirname(file.filename).in?(['.', '']) ? nil : File.dirname(file.filename),
-        xml_id_path: (parent_object.nil? ? '' : "#{parent_object.id}/") + file.id.to_s
+        xml_id_path: (parent_object.nil? ? [file.id] : [parent_object.id, file.id]).map(&:to_s)
       )
       if file.binary
         codeocean_file.native_file = FileIO.new(file.content.dup.force_encoding('UTF-8'), File.basename(file.filename))

--- a/app/services/proforma_service/convert_task_to_exercise.rb
+++ b/app/services/proforma_service/convert_task_to_exercise.rb
@@ -107,7 +107,7 @@ module ProformaService
     def codeocean_file_from_task_file(file, parent_object = nil)
       extension = File.extname(file.filename)
       # checking the last element of xml_id_path array for file.id
-      codeocean_file = @exercise.files.where('array_length(xml_id_path, 1) IS NOT NULL AND xml_id_path[array_length(xml_id_path, 1)] = ?', file.id).first_or_initialize
+      codeocean_file = @exercise.files.detect {|f| f.xml_id_path.last == file.id } || @exercise.files.new
       codeocean_file.assign_attributes(
         context: @exercise,
         file_type: file_type(extension),

--- a/app/services/proforma_service/import.rb
+++ b/app/services/proforma_service/import.rb
@@ -14,13 +14,7 @@ module ProformaService
         import_result = importer.perform
         @task = import_result
 
-        exercise = base_exercise
-        exercise_files = exercise&.files&.to_a
-
-        exercise = ConvertTaskToExercise.call(task: @task, user: @user, exercise:)
-        exercise_files&.each(&:destroy) # feels suboptimal
-
-        exercise
+        ConvertTaskToExercise.call(task: @task, user: @user, exercise: base_exercise)
       else
         import_multi
       end

--- a/db/migrate/20240903204319_add_xml_path_to_files.rb
+++ b/db/migrate/20240903204319_add_xml_path_to_files.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddXmlPathToFiles < ActiveRecord::Migration[7.1]
+  def change
+    add_column :files, :xml_id_path, :string, null: true, default: nil
+  end
+end

--- a/db/migrate/20241007204319_add_xml_path_to_files.rb
+++ b/db/migrate/20241007204319_add_xml_path_to_files.rb
@@ -2,6 +2,6 @@
 
 class AddXmlPathToFiles < ActiveRecord::Migration[7.1]
   def change
-    add_column :files, :xml_id_path, :string, null: true, default: nil
+    add_column :files, :xml_id_path, :string, array: true, default: [], null: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_16_105338) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_26_204319) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -316,7 +316,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_16_105338) do
     t.string "path"
     t.integer "file_template_id"
     t.boolean "hidden_feedback", default: false, null: false
-    t.string "xml_id_path"
+    t.string "xml_id_path", default: [], array: true
     t.index ["context_id", "context_type"], name: "index_files_on_context_id_and_context_type"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -316,6 +316,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_16_105338) do
     t.string "path"
     t.integer "file_template_id"
     t.boolean "hidden_feedback", default: false, null: false
+    t.string "xml_id_path"
     t.index ["context_id", "context_type"], name: "index_files_on_context_id_and_context_type"
   end
 

--- a/spec/controllers/exercises_controller_spec.rb
+++ b/spec/controllers/exercises_controller_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe ExercisesController do
       expect_redirect(Exercise.last)
     end
 
+    context 'when exercise has uuid' do
+      let(:exercise) { create(:dummy, uuid: SecureRandom.hex) }
+
+      it 'clones the exercise' do
+        expect_any_instance_of(Exercise).to receive(:duplicate).with(hash_including(public: false, user:)).and_call_original
+        expect { perform_request.call }.to change(Exercise, :count).by(1)
+      end
+    end
+
     context 'when saving fails' do
       before do
         allow_any_instance_of(Exercise).to receive(:save).and_return(false)

--- a/spec/models/code_ocean/file_spec.rb
+++ b/spec/models/code_ocean/file_spec.rb
@@ -57,6 +57,46 @@ RSpec.describe CodeOcean::File do
     end
   end
 
+  context 'with xml_id_path' do
+    let(:exercise) { create(:dummy) }
+    let(:file) { build(:file, context: file_context, xml_id_path: xml_id_path) }
+    let(:file_context) { exercise }
+    let(:xml_id_path) { ['abcde'] }
+
+    before do
+      create(:file, context: exercise, xml_id_path: ['abcde'])
+      file.validate
+    end
+
+    it 'has an error for xml_id_path' do
+      expect(file.errors[:xml_id_path]).to be_present
+    end
+
+    context 'when second file has a different exercise' do
+      let(:file_context) { create(:dummy) }
+
+      it 'has no error for xml_id_path' do
+        expect(file.errors[:xml_id_path]).not_to be_present
+      end
+    end
+
+    context 'when second file has a different xml_id_path' do
+      let(:xml_id_path) { ['foobar'] }
+
+      it 'has no error for xml_id_path' do
+        expect(file.errors[:xml_id_path]).not_to be_present
+      end
+    end
+
+    context 'when file_context is not Exercise' do
+      let(:file_context) { create(:submission) }
+
+      it 'has an error for xml_id_path' do
+        expect(file.errors[:xml_id_path]).to be_present
+      end
+    end
+  end
+
   context 'with a native file' do
     let(:file) { create(:file, :image) }
 

--- a/spec/services/proforma_service/convert_exercise_to_task_spec.rb
+++ b/spec/services/proforma_service/convert_exercise_to_task_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe ProformaService::ConvertExerciseToTask do
       end
 
       context 'when xml_id_path is set for file' do
-        let(:file) { create(:file, xml_id_path: ['foobar']) }
+        let(:file) { create(:file, xml_id_path: ['foobar'], context: create(:dummy)) }
 
         it 'does not change xml_id_path' do
           expect { convert_to_task.execute }.not_to change(file.reload, :xml_id_path)

--- a/spec/services/proforma_service/convert_task_to_exercise_spec.rb
+++ b/spec/services/proforma_service/convert_task_to_exercise_spec.rb
@@ -564,9 +564,9 @@ RSpec.describe ProformaService::ConvertTaskToExercise do
               description: 'exercise-description')
           end
           let(:co_files) do
-            [create(:file, xml_id_path: ['id'], role: 'regular_file'),
-             create(:file, xml_id_path: %w[ms-id ms-file-id], role: 'reference_implementation'),
-             create(:test_file, xml_id_path: %w[test-id test-file-id])]
+            [build(:file, xml_id_path: ['id'], role: 'regular_file'),
+             build(:file, xml_id_path: %w[ms-id ms-file-id], role: 'reference_implementation'),
+             build(:test_file, xml_id_path: %w[test-id test-file-id])]
           end
 
           it 'reuses existing file' do

--- a/spec/services/proforma_service/import_spec.rb
+++ b/spec/services/proforma_service/import_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ProformaService::Import do
     let(:execution_environment) { build(:java) }
     let(:files) { [] }
     let(:tests) { [] }
-    let(:exporter) { ProformaService::ExportTask.call(exercise: exercise.reload).string }
+    let(:exporter) { ProformaService::ExportTask.call(exercise:).string }
 
     before do
       zip_file.write(exporter)
@@ -51,7 +51,7 @@ RSpec.describe ProformaService::Import do
     it { is_expected.to be_an_equal_exercise_as exercise }
 
     it 'sets the correct user as owner of the exercise' do
-      expect(import_service.user).to be user
+      expect(import_service.user).to eq user
     end
 
     it 'sets the uuid' do

--- a/spec/services/proforma_service/import_spec.rb
+++ b/spec/services/proforma_service/import_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe ProformaService::Import do
     end
 
     context 'when exercise has multiple tests' do
-      let(:tests) { build_list(:test_file, 2) }
+      let(:tests) { [build(:test_file, xml_id_path: %w[test file1]), build(:test_file, xml_id_path: %w[test file2])] }
 
       it { is_expected.to be_an_equal_exercise_as exercise }
     end


### PR DESCRIPTION
Use `xml_id_path` to recreate proforma structure with tests and model_solutions containing multiple files

also sets `xml_id_path` for exported files, if it is not set. (similiar to uuid)