### PR TITLE
Configure Sentry release Workflow for GitHub actions

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -1,0 +1,18 @@
+name: Create a Sentry release
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        with:
+          projects: ${{ secrets.SENTRY_PROJECT }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}


### PR DESCRIPTION
Marking a new commit on master as release is required for the newly-added Ansible workflow with integrated Sentry deployment tracking. This  workflow is based on Poseidon's workflow: https://github.com/openHPI/poseidon/blob/main/.github/workflows/sentry-release.yml