### PR TITLE
Show all attributes when inspecting an object in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -114,4 +114,8 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  # Show all attributes when inspecting an object.
+  # Otherwise, only the `id` is shown by default (in contrast to `#full_inspect`).
+  config.active_record.attributes_for_inspect = :all
 end


### PR DESCRIPTION
Otherwise, only the `id` is shown by default (in contrast to `full_inspect`). This behavior has changed with Rails 7.2, and previously showed all information by default.

Since we often use `inspect` within the application to get details about unexpected errors, we want to keep the previous behavior.