### PR TITLE
Remove non-working default for ApplicationMailer

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  include ApplicationHelper
-
-  default from: "#{application_name} <codeocean@openhpi.de>"
   layout 'mailer'
 end


### PR DESCRIPTION
The `default` setting within the ApplicationMailer is overwriting the previously-set values from `config/action_mailer.yml`. Of course, that is not intended and needs to be fixed.