### PR TITLE
Fix two issues preventing RfC searches

### DIFF
--- a/app/controllers/request_for_comments_controller.rb
+++ b/app/controllers/request_for_comments_controller.rb
@@ -48,7 +48,7 @@ class RequestForCommentsController < ApplicationController
       .where(user: current_user)
       .or(policy_scope(RequestForComment)
             .joins(:submission)
-            .where(submission: {contributor: current_user.programming_groups}))
+            .where(submissions: {contributor: current_user.programming_groups}))
       .order(created_at: :desc) # Order for the LIMIT part of the query
       .ransack(params[:q])
 

--- a/app/views/shared/_form_filters.html.slim
+++ b/app/views/shared/_form_filters.html.slim
@@ -1,5 +1,5 @@
 .card.card-body.bg-body-secondary.flex-row.container.justify-content-center
-  = search_form_for(@search, class: 'clearfix filter-form align-items-center row g-2 w-100') do |f|
+  = search_form_for(@search, class: 'clearfix filter-form align-items-center row g-2 w-100', url: request.path) do |f|
     = yield(f)
     .col-sm.ge-4.gy-2
       .btn-group.float-end.ms-auto.text-nowrap


### PR DESCRIPTION
This PR fixes two issues related to RfC searches:

- Use current path for form_filter search partial
- Fix `where` filter for `my_request_for_comments` search
