### PR TITLE
Use openHPI-managed Tubesock fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'sorcery'
 gem 'sprockets-rails'
 gem 'telegraf'
 gem 'terser', require: false
-gem 'tubesock'
+gem 'tubesock', github: 'openhpi/tubesock'
 gem 'turbolinks'
 gem 'whenever', require: false
 gem 'zxcvbn-ruby', require: 'zxcvbn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/openhpi/tubesock.git
+  revision: 6952050f00e795c3d96eb0a5ee163784de41cd8b
+  specs:
+    tubesock (0.2.9)
+      rack (>= 1.5.0)
+      websocket (>= 1.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -551,9 +559,6 @@ GEM
     thor (1.3.2)
     tilt (2.4.0)
     timeout (0.4.1)
-    tubesock (0.2.9)
-      rack (>= 1.5.0)
-      websocket (>= 1.1.0)
     turbo-rails (2.0.10)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -671,7 +676,7 @@ DEPENDENCIES
   stackprof
   telegraf
   terser
-  tubesock
+  tubesock!
   turbolinks
   web-console
   webmock

--- a/config/initializers/monkey_patches.rb
+++ b/config/initializers/monkey_patches.rb
@@ -28,25 +28,3 @@ module Sorcery
     end
   end
 end
-
-# Tubesock uses a deprecated method to clear active connections with ActiveRecord.
-# Hence, we update the method call to the new method name (including `connection_handler`).
-module Tubesock::Hijack
-  extend ActiveSupport::Concern
-
-  # First, we need to remove the old `included` definition.
-  # Otherwise, we would get an `ActiveSupport::Concern::MultipleIncludedBlocks` exception.
-  remove_instance_variable :@_included_block
-
-  included do
-    def hijack
-      sock = Tubesock.hijack(request.env)
-      yield sock
-      sock.onclose do
-        ActiveRecord::Base.connection_handler.clear_active_connections! if defined? ActiveRecord
-      end
-      sock.listen
-      render plain: nil, status: -1
-    end
-  end
-end


### PR DESCRIPTION
Tubesock is outdated and should be replaced with ActionCable. For now, however, we simply patch the issues we've discovered.

I've created a custom fork, included some pending contributions and made additional suggestions.