### PR TITLE
Use `deliver_later` to send emails

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -88,7 +88,7 @@ class CommentsController < ApplicationController
 
   def send_mail_to_author(comment, request_for_comment)
     if current_user != request_for_comment.user
-      UserMailer.got_new_comment(comment, request_for_comment, current_user).deliver_now
+      UserMailer.got_new_comment(comment, request_for_comment, current_user).deliver_later
     end
   end
 
@@ -101,7 +101,7 @@ class CommentsController < ApplicationController
       )
       subscriptions.each do |subscription|
         if (((subscription.subscription_type == 'author') && (current_user == request_for_comment.user)) || (subscription.subscription_type == 'all')) && !((subscription.user == current_user) || already_sent_mail)
-          UserMailer.got_new_comment_for_subscription(comment, subscription, current_user).deliver_now
+          UserMailer.got_new_comment_for_subscription(comment, subscription, current_user).deliver_later
           already_sent_mail = true
         end
       end

--- a/app/controllers/request_for_comments_controller.rb
+++ b/app/controllers/request_for_comments_controller.rb
@@ -134,7 +134,7 @@ class RequestForCommentsController < ApplicationController
     @request_for_comment.thank_you_note = params[:note]
 
     commenters = @request_for_comment.commenters
-    commenters.each {|commenter| UserMailer.send_thank_you_note(@request_for_comment, commenter).deliver_now }
+    commenters.each {|commenter| UserMailer.send_thank_you_note(@request_for_comment, commenter).deliver_later }
 
     respond_to do |format|
       if @request_for_comment.save

--- a/lib/tasks/detect_exercise_anomalies.rake
+++ b/lib/tasks/detect_exercise_anomalies.rake
@@ -115,7 +115,7 @@ namespace :detect_exercise_anomalies do
 
   def notify_collection_author(collection, anomalies)
     log("Sending E-Mail to author (#{collection.user.displayname} <#{collection.user.email}>)...", 2)
-    UserMailer.exercise_anomaly_detected(collection, anomalies).deliver_now
+    UserMailer.exercise_anomaly_detected(collection, anomalies).deliver_later
   end
 
   def notify_contributors(collection, anomalies)


### PR DESCRIPTION
Now, we are only using `deliver_now` for login-based emails, such as password reset or confirmation emails.