### PR TITLE
RfCs: Correctly increment `times_featured` counter

### DIFF
--- a/app/controllers/concerns/redirect_behavior.rb
+++ b/app/controllers/concerns/redirect_behavior.rb
@@ -4,7 +4,7 @@ module RedirectBehavior
   include Lti
 
   def redirect_after_submit
-    Rails.logger.debug { "Redirecting user with score:s #{@submission.normalized_score}" }
+    Rails.logger.debug { "Redirecting user with score: #{@submission.normalized_score}" }
 
     # Redirect to the corresponding community solution if enabled and the user is eligible.
     return redirect_to_community_solution if redirect_to_community_solution?
@@ -78,7 +78,7 @@ module RedirectBehavior
     flash.keep(:notice)
 
     # Increase counter 'times_featured' in rfc
-    @rfc.increment(:times_featured) unless own
+    @rfc.increment!(:times_featured) unless own # rubocop:disable Rails/SkipsModelValidations
 
     respond_to do |format|
       format.html { redirect_to(@rfc) }


### PR DESCRIPTION
Previously, the counter was only changed in memory but not persisted. Rather than adding a .save call, I decided to use the bang method (despite skipping model validations). This, however, will improve the SQL query and prevent any concurrent updates that otherwise wouldn't be atomic.

The resulting SQL query is really nice:

```
UPDATE "request_for_comments" SET "times_featured" = COALESCE("times_featured", 0) + 1 WHERE "request_for_comments"."id" = $1
```