### PR TITLE
GitHub Actions: Use RSpec command without manual requires

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: true
-        run: bundle exec rspec --color --format RSpec::Github::Formatter --format progress --require spec_helper --require rails_helper
+        run: bundle exec rspec --color --format RSpec::Github::Formatter --format progress
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
Since aligning our RSpec setup to the recommended defaults, we don't need the manual require statements any longer.