### PR TITLE
Selenium: Refactor WaitFor* scripts to prevent crashes

### DIFF
--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -2,12 +2,19 @@
 
 module WaitForAjax
   def wait_for_ajax
-    Timeout.timeout(Capybara.default_max_wait_time) do
-      loop until ajax_requests_finished?
+    start_time = Time.current
+    timeout = Capybara.default_max_wait_time
+
+    loop do
+      break if ajax_requests_finished? || (Time.current - start_time) > timeout
+
+      sleep 0.1 # Short sleep time to prevent busy waiting
     end
   end
 
   def ajax_requests_finished?
+    # This method MUST NOT be interrupted. Hence, Timeout.timeout is not used here.
+    # Otherwise, Selenium and the browser driver might crash, preventing further tests from running.
     page.evaluate_script('jQuery.active').zero?
   end
 end

--- a/spec/support/wait_for_websocket.rb
+++ b/spec/support/wait_for_websocket.rb
@@ -2,12 +2,19 @@
 
 module WaitForWebsocket
   def wait_for_websocket
-    Timeout.timeout(Capybara.default_max_wait_time) do
-      loop until websocket_finished?
+    start_time = Time.current
+    timeout = Capybara.default_max_wait_time
+
+    loop do
+      break if websocket_finished? || (Time.current - start_time) > timeout
+
+      sleep 0.1 # Short sleep time to prevent busy waiting
     end
   end
 
   def websocket_finished?
+    # This method MUST NOT be interrupted. Hence, Timeout.timeout is not used here.
+    # Otherwise, Selenium and the browser driver might crash, preventing further tests from running.
     page.evaluate_script('CodeOceanEditorWebsocket?.websocket?.getReadyState() === WebSocket.CLOSED').present?
   end
 end


### PR DESCRIPTION
The previously used approach with `Timeout.timeout` works. However, it might interrupt the `page.evaluate_script`, which will cause an unhandled exception with the Selenium webdriver which in turn crashes. Once crashed, all further Selenium-based tests will fail, too.