### PR TITLE
Remove additional occurrences of TestrunExecutionEnvironment

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -439,7 +439,6 @@ class SubmissionsController < ApplicationController
       waiting_for_container_time: @testrun[:waiting_for_container_time]
     )
     TestrunMessage.create_for(testrun, @testrun[:messages])
-    TestrunExecutionEnvironment.create(testrun:, execution_environment: @submission.used_execution_environment)
   end
 
   def send_hints(tubesock, errors)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -48,8 +48,6 @@ class Submission < ApplicationRecord
 
   validates :cause, inclusion: {in: CAUSES}
 
-  attr_reader :used_execution_environment
-
   # after_save :trigger_working_times_action_cable
 
   def collect_files
@@ -287,7 +285,6 @@ class Submission < ApplicationRecord
       waiting_for_container_time: output[:waiting_for_container_time]
     )
     TestrunMessage.create_for(testrun, output[:messages])
-    TestrunExecutionEnvironment.create(testrun:, execution_environment: @used_execution_environment)
 
     filename = file.filepath
 


### PR DESCRIPTION
With these changes, everything except the model and the database column is removed. The latter two can be removed once the respective research is done, too.

Amends 7aaeac03