### PR TITLE
Simplify `Submission#command_for`

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -250,8 +250,7 @@ class Submission < ApplicationRecord
     [new_runner, new_waiting_duration]
   end
 
-  def command_for(template, file)
-    filepath = collect_files.find {|f| f.filepath == file }.filepath
+  def command_for(template, filepath)
     template % command_substitutions(filepath)
   end
 


### PR DESCRIPTION
The previous mechanism always cycled through all files once again, just to identify the very same file and using an attribute passed to the method. This can be simplified with the given refactoring.