### PR TITLE
Improve file filtering for submission execution

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -220,10 +220,16 @@ class Submission < ApplicationRecord
       files = collect_files
 
       case cause
-        when 'run'
-          files.reject!(&:reference_implementation?)
-          files.reject!(&:teacher_defined_assessment?)
-        when 'assess'
+        when 'run', 'test'
+          files.reject! do |file|
+            next true if file.reference_implementation?
+            # Only remove teacher-defined assessments if they are hidden.
+            # Otherwise, 'test' might fail if a teacher-defined assessment is executed.
+            next true if file.teacher_defined_assessment? && file.hidden?
+
+            next false
+          end
+        when 'assess', 'submit', 'remoteAssess', 'remoteSubmit'
           regular_filepaths = files.reject(&:reference_implementation?).map(&:filepath)
           files.reject! {|file| file.reference_implementation? && regular_filepaths.include?(file.filepath) }
       end


### PR DESCRIPTION
Previously, many different executions got all files despite not necessary needed. We now extend the file filtering to apply for submit actions, remote evaluations and test executions, too.