### PR TITLE
Prevent duplicate close of client connection

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -338,6 +338,8 @@ class SubmissionsController < ApplicationController
   end
 
   def close_client_connection(client_socket)
+    return if client_socket&.closed?
+
     # search for errors and save them as StructuredError (for scoring runs see submission.rb)
     errors = extract_errors
     send_hints(client_socket, errors)
@@ -409,7 +411,7 @@ class SubmissionsController < ApplicationController
                           end
     @testrun[:messages].push message
     @testrun[:status] = message[:status] if message[:status]
-    client_socket.send_data(message.to_json)
+    client_socket&.send_data(message.to_json)
   end
 
   def max_output_buffer_size


### PR DESCRIPTION
When a running execution is stopped by the client (through the WebSocket connection), we immediately call `close_client_connection` to terminate Tubesock connection to the browser and stop the runner. However, since the regular workflow also included a call to `close_client_connection`, it might have been called twice.