### PR TITLE
Prevent simultaneous code execution requests in JavaScript

### DIFF
--- a/app/assets/javascripts/community_solution.js
+++ b/app/assets/javascripts/community_solution.js
@@ -28,12 +28,15 @@ $(document).on('turbolinks:load', function() {
 function submitCode(event) {
     const button = $(event.target) || $('#submit');
     this.newSentryTransaction(button, async () => {
-        const submission = await this.createSubmission(button, null).catch(this.ajaxError.bind(this));
+        const submission = await this.createSubmission(button, null).catch((response) => {
+            this.ajaxError(response);
+            button.one('click', this.submitCode.bind(this));
+        });
         if (!submission) return;
         if (!submission.redirect) return;
 
         this.autosaveIfChanged();
-        this.stopCode(event);
+        await this.stopCode(event);
         this.editors = [];
         Turbolinks.clearCache();
         Turbolinks.visit(submission.redirect);

--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -473,9 +473,9 @@ var CodeOceanEditor = {
     initializeWorkspaceButtons: function () {
         $('#assess').one('click', this.scoreCode.bind(this));
         $('#render').on('click', this.renderCode.bind(this));
-        $('#run').on('click', this.runCode.bind(this));
+        $('#run').one('click', this.runCode.bind(this));
         $('#stop').on('click', this.stopCode.bind(this));
-        $('#test').on('click', this.testCode.bind(this));
+        $('#test').one('click', this.testCode.bind(this));
         $('#start-over').on('click', this.confirmReset.bind(this));
         $('#start-over-active-file').on('click', this.confirmResetActiveFile.bind(this));
     },

--- a/app/assets/javascripts/editor/execution.js
+++ b/app/assets/javascripts/editor/execution.js
@@ -76,6 +76,8 @@ CodeOceanEditorWebsocket = {
     return this.runSocket(Routes.test_submission_url, {id: submissionID, filename: filename}, (websocket) => {
       websocket.on('default', this.handleTestResponse.bind(this));
       websocket.on('exit', this.handleExitCommand.bind(this));
+    }).then(() => {
+      $('#test').one('click', this.testCode.bind(this));
     });
   },
 
@@ -102,6 +104,8 @@ CodeOceanEditorWebsocket = {
       websocket.on('status', this.showStatus.bind(this));
       websocket.on('hint', this.showHint.bind(this));
       websocket.on('files', this.prepareFileDownloads.bind(this));
+    }).then(() => {
+      $('#run').one('click', this.runCode.bind(this));
     });
   },
 

--- a/app/assets/javascripts/editor/participantsupport.js.erb
+++ b/app/assets/javascripts/editor/participantsupport.js.erb
@@ -122,9 +122,17 @@ CodeOceanEditorRequestForComments = {
       const file_id = $('.editor').data('id');
       const question = questionElement.val();
 
-      const submission = await this.createSubmission(cause, null).catch(this.ajaxError.bind(this));
+      const submission = await this.createSubmission(cause, null).catch((response) => {
+        this.ajaxError(response);
+        askForCommentsButton.one('click', this.requestComments.bind(this));
+        questionElement.prop("disabled", false);
+        closeAskForCommentsButton.removeClass('d-none');
+      });
       if (!submission) return;
 
+      this.showSpinner(askForCommentsButton);
+      await this.stopCode();
+      // Since `stopCode` might call `hideSpinner`, we need to show it again.
       this.showSpinner(askForCommentsButton);
 
       const response = await $.ajax({

--- a/app/assets/javascripts/editor/submissions.js
+++ b/app/assets/javascripts/editor/submissions.js
@@ -177,10 +177,14 @@ CodeOceanEditorSubmissions = {
     event.preventDefault();
     const cause = $('#run');
     this.newSentryTransaction(cause, async () => {
-      this.stopCode(event);
+      await this.stopCode(event);
       if (!cause.is(':visible')) return;
 
-      const submission = await this.createSubmission(cause, null).catch(this.ajaxError.bind(this));
+      const submission = await this.createSubmission(cause, null).catch((response) => {
+        this.ajaxError(response);
+        cause.one('click', this.runCode.bind(this));
+      });
+
       if (!submission) return;
 
       await this.runSubmission(submission);
@@ -202,7 +206,11 @@ CodeOceanEditorSubmissions = {
     this.newSentryTransaction(cause, async () => {
       if (!cause.is(':visible')) return;
 
-      const submission = await this.createSubmission(cause, null).catch(this.ajaxError.bind(this));
+      await this.stopCode(event);
+      const submission = await this.createSubmission(cause, null).catch((response) => {
+        this.ajaxError(response);
+        cause.one('click', this.testCode.bind(this));
+      });
       if (!submission) return;
 
       this.showSpinner($('#test'));


### PR DESCRIPTION
With these changes, we prevent that a second code execution can be triggered while a first one is still running. These change applies to any form of code execution, including runs, score runs, test runs, submit requests, RfC requests.

With the changed `stopCode` function, switching from one execution mode to another (i.e., run to score or vice versa) will wait until the previous execution stopped. When the window is reloaded, either the execution stops immediately (run) or the backend lock mechanism for runners will still prevent duplicate executions (test, score, submit).

The changes in this commit further ensures that the same button cannot be pressed twice. For example, a double-click on Run would previously schedule two executions, which might interfere with each other (or simply produce the "runner in use" message which is still annoying).