### PR TITLE
Only allow stopping the current code execution when started

### DIFF
--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -764,6 +764,9 @@ var CodeOceanEditor = {
 
     showStatus: function (output) {
         switch (output.status) {
+            case 'container_running':
+                this.toggleButtonStates();
+                break;
             case 'timeout':
             case 'buffer_overflow':
                 this.showTimeoutMessage();

--- a/app/assets/javascripts/editor/submissions.js
+++ b/app/assets/javascripts/editor/submissions.js
@@ -196,7 +196,6 @@ CodeOceanEditorSubmissions = {
     this.running = true;
     this.showSpinner($('#run'));
     $('#score_div').addClass('d-none');
-    this.toggleButtonStates();
     await this.socketRunCode(submission.id, CodeOceanEditor.active_file.filename);
   },
 


### PR DESCRIPTION
When a code execution is started, we shortly show a spinner on the Run button before it changes to Stop, allowing learners to abort the current code execution. However, previously, the Stop button was shown too early namely when the WebSocket connection was getting initialized. When it was immediately pressed after becoming available, it didn't had any effect.

With the changes of this commit, we delay showing the Stop button, so that it will be shown only once the runner is actually beginning with the code execution (as indicated by the `container_running` status).