### PR TITLE
Unify comparison of the WebSocket ready state

### DIFF
--- a/app/assets/javascripts/editor/websocket.js
+++ b/app/assets/javascripts/editor/websocket.js
@@ -94,7 +94,7 @@ CommandSocket.prototype.executeCommand = function(cmd) {
 CommandSocket.prototype.send = function(data) {
   // Only send message if WebSocket is open and ready.
   // Ignore all other messages (they might hit a wrong container anyway)
-  if (this.getReadyState() === this.websocket.OPEN) {
+  if (this.getReadyState() === WebSocket.OPEN) {
     this.websocket.send(data);
   }
 };

--- a/spec/support/wait_for_websocket.rb
+++ b/spec/support/wait_for_websocket.rb
@@ -8,7 +8,7 @@ module WaitForWebsocket
   end
 
   def websocket_finished?
-    page.evaluate_script('CodeOceanEditorWebsocket?.websocket?.websocket?.readyState == WebSocket.CLOSED').present?
+    page.evaluate_script('CodeOceanEditorWebsocket?.websocket?.getReadyState() === WebSocket.CLOSED').present?
   end
 end
 


### PR DESCRIPTION
Previously, we used some mixed methods to identify the ready state of WebSocket connections with different methods and target states. By using the same method and enum values, we can ensure easier navigation for developers and better maintenance.