### PR TITLE
Immediately close a WebSocket connection to a runner

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -140,6 +140,7 @@ class SubmissionsController < ApplicationController
         case event[:cmd]
           when :client_kill
             @testrun[:status] = :terminated_by_client
+            runner_socket&.close(:terminated_by_client)
             close_client_connection(client_socket)
             Rails.logger.debug('Client exited container.')
           when :result, :canvasevent, :exception

--- a/lib/runner/connection.rb
+++ b/lib/runner/connection.rb
@@ -84,7 +84,12 @@ class Runner::Connection
     return unless active?
 
     @status = status
-    @socket.close
+    # Close the WebSocket connection _immediately_
+    # by scheduling it for the next execution of the EventMachine reactor run.
+    # Otherwise, the message might be queued causing delays for users.
+    EventMachine.next_tick do
+      @socket.close
+    end
   end
 
   # Check if the WebSocket connection is currently established


### PR DESCRIPTION
The previous code mostly worked but there could be cases where stopping was delayed. This is especially problematic with the reservation of runners, since they could still be reserved (internally) without a visual indicator for the learners.

 The change in the SubmissionsController is optional, since a browser should also close the connection once `close_client_connection` is executed. However, this change might stop the runner earlier, which is especially useful in case of infinite loops.