### PR TITLE
RfC Search: Apply last_per_user filter after other search terms

### DIFF
--- a/app/models/concerns/ransack_object.rb
+++ b/app/models/concerns/ransack_object.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RansackObject
+  # Case insensitive search with Postgres and Ransack.
+  # Adapted from https://activerecord-hackery.github.io/ransack/getting-started/simple-mode/#case-insensitive-sorting-in-postgresql
+  def self.included(base)
+    base.columns.each do |column|
+      next unless column.type == :string
+
+      base.ransacker column.name.to_sym, type: :string do
+        Arel::Nodes::NamedFunction.new('LOWER', [base.arel_table[column.name]])
+      end
+    end
+  end
+end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -7,6 +7,7 @@ class Exercise < ApplicationRecord
   include Creation
   include DefaultValues
   include TimeHelper
+  include RansackObject
 
   after_initialize :generate_token
   after_initialize :set_default_values

--- a/app/models/request_for_comment.rb
+++ b/app/models/request_for_comment.rb
@@ -75,24 +75,6 @@ class RequestForComment < ApplicationRecord
       end
     end
 
-    def with_last_activity
-      joins('join "submissions" s on s.id = request_for_comments.submission_id ' \
-            'left outer join "files" f on f.context_id = s.id ' \
-            'left outer join "comments" c on c.file_id = f.id')
-        .group('request_for_comments.id')
-        .select('request_for_comments.*, max(c.updated_at) as last_comment')
-    end
-
-    def last_per_user(count = 5)
-      from(row_number_user_sql, :request_for_comments)
-        .where(row_number: ..count)
-        .group('request_for_comments.id, request_for_comments.user_id, request_for_comments.user_type, ' \
-               'request_for_comments.exercise_id, request_for_comments.file_id, request_for_comments.question, ' \
-               'request_for_comments.created_at, request_for_comments.updated_at, request_for_comments.solved, ' \
-               'request_for_comments.full_score_reached, request_for_comments.submission_id, request_for_comments.row_number')
-      # ugly, but necessary
-    end
-
     def ransackable_associations(_auth_object = nil)
       %w[exercise submission]
     end
@@ -101,23 +83,115 @@ class RequestForComment < ApplicationRecord
       %w[state]
     end
 
-    private
+    def ransortable_attributes(_auth_object = nil)
+      %w[created_at]
+    end
 
-    def row_number_user_sql
-      select('
-        request_for_comments.id,
-        request_for_comments.user_id,
-        request_for_comments.user_type,
-        request_for_comments.exercise_id,
-        request_for_comments.file_id,
-        request_for_comments.question,
-        request_for_comments.created_at,
-        request_for_comments.updated_at,
-        request_for_comments.solved,
-        request_for_comments.full_score_reached,
-        request_for_comments.submission_id,
-        row_number() OVER (PARTITION BY request_for_comments.user_id, request_for_comments.user_type ORDER BY request_for_comments.created_at DESC) as row_number
-      ')
+    # @param [Arel::Nodes::TableAlias] from_arel_table The Arel table to select from.
+    # @param [Integer] count The number of RfCs to select per user. `nil` selects all.
+    # @return [Arel::Nodes::TableAlias] The resulting Arel query limited to `count` RfCs per user.
+    def with_last_per_user_arel(from_arel_table, count = 5)
+      # If no limit should be applied, we don't need to perform any calculations.
+      return from_arel_table if count.nil?
+
+      row_number_column_name = :row_number
+      # We fist need to assign a row number to each RfC per user.
+      search_result_with_row_number_arel = RequestForComment.with_row_number_arel(from_arel_table, row_number_column_name)
+      # Then we can select the first `count` RfCs per user.
+      RequestForComment.with_first_n_row_numbers_arel(search_result_with_row_number_arel, row_number_column_name, count)
+    end
+
+    # @param [RanSack::Search] search The Ransack search object with the search parameters.
+    # @return [Arel::Nodes::TableAlias] The resulting Arel query limited to the search parameters.
+    def with_ransack_search_arel(search)
+      rfc_table = RequestForComment.arel_table
+      # We need to use `reorder(nil)` to remove any existing order from the search.
+      # This is required to ensure the correct filtering and pagination is performed.
+      search.result.reorder(nil).arel.as(rfc_table.name)
+    end
+
+    # @param [RanSack::Search] sort The Ransack search object with the sort parameters. Any search parameters are ignored.
+    # @param [Array<Arel::Nodes::Ordering>] secondary_sort_options Additional sort options to apply after the Ransack sort.
+    # @param [Arel::Nodes::TableAlias] from_arel_table The Arel table to select from.
+    # @return [Arel::Nodes::TableAlias] The resulting Arel query sorted by the sort parameters.
+    def with_ransack_sort_arel(sort, secondary_sort_options, from_arel_table)
+      rfc_table = RequestForComment.arel_table
+      sorted_arel = sort.result.arel
+
+      if secondary_sort_options.present?
+        sorted_arel = sorted_arel.order(*secondary_sort_options)
+      end
+
+      sorted_arel.from(from_arel_table).as(rfc_table.name)
+    end
+
+    # @param [Arel::Nodes::TableAlias] from_arel_table The Arel table to select from.
+    # @param [String] row_number_column_name The name of the column to store the row number in.
+    # @return [Arel::Nodes::TableAlias] The resulting Arel query annotated with the row number.
+    def with_row_number_arel(from_arel_table, row_number_column_name)
+      rfc_table = RequestForComment.arel_table
+
+      row_number = Arel::Nodes::Window.new
+        .partition(rfc_table[:user_id], rfc_table[:user_type])
+        # Since we want to show the n newest RfCs per user, we need to order by `created_at` in descending order.
+        # This is not related to the order of the RfCs in the result set (e.g., the Ransack ordering).
+        .order(rfc_table[:created_at].desc)
+
+      row_number_function = Arel::Nodes::NamedFunction.new('row_number', [])
+        .over(row_number)
+        .as(row_number_column_name.to_s)
+
+      rfc_table.project(rfc_table[Arel.star], row_number_function)
+        .from(from_arel_table).as(rfc_table.name)
+    end
+
+    # @param [Arel::Nodes::TableAlias] from_arel_table The Arel table to select from.
+    # @param [String] row_number_column_name The name of the column to store the row number in.
+    # @param [Integer] max_row_number The maximum row number to select.
+    # @return [Arel::Nodes::TableAlias] The resulting Arel query limited to the first `max_row_number` RfCs.
+    def with_first_n_row_numbers_arel(from_arel_table, row_number_column_name, max_row_number)
+      rfc_table = RequestForComment.arel_table
+      column_names = RequestForComment.column_names.map {|name| rfc_table[name.to_sym] }
+
+      rfc_table.project(*column_names)
+        .where(rfc_table[row_number_column_name].lteq(max_row_number))
+        .group(rfc_table[row_number_column_name], *column_names)
+        .from(from_arel_table).as(rfc_table.name)
+    end
+
+    # @param [Arel::Nodes::TableAlias] from_arel_table The Arel table to select from.
+    # @return [Arel::Nodes::TableAlias] The resulting Arel query annotated with the last activity timestamp of the RfC.
+    def with_last_activity_arel(from_arel_table)
+      rfc_table = RequestForComment.arel_table
+      submissions_table = Submission.arel_table
+      files_table = CodeOcean::File.arel_table
+      comments_table = Comment.arel_table
+      column_names = RequestForComment.column_names.map {|name| rfc_table[name.to_sym] }
+
+      # If no comment is available yet, we want to show the last activity of the RfC.
+      # This behavior is inline with `views/request_for_comments/index.html.slim`.
+      last_activity = Arel::Nodes::NamedFunction.new('COALESCE', [comments_table[:updated_at].maximum, rfc_table[:updated_at]])
+
+      # We need to join the submissions, files, and comments tables to get the last activity timestamp of a comment.
+      # This query is rather expensive and should be performed as late as possible.
+      rfc_table
+        .project(*column_names, last_activity.as('last_activity'))
+        .join(submissions_table)
+        .on(submissions_table[:id].eq(rfc_table[:submission_id]))
+        .join(files_table, Arel::Nodes::OuterJoin)
+        .on(files_table[:context_id].eq(submissions_table[:id]))
+        .join(comments_table, Arel::Nodes::OuterJoin)
+        .on(comments_table[:file_id].eq(files_table[:id]))
+        .group(*column_names)
+        .from(from_arel_table).as(rfc_table.name)
+    end
+
+    # @param [Array<Integer>, Array<ActiveRecord::Relation<RequestForComment>>] rfc_ids The IDs of the RfCs to select.
+    # @return [Arel::Nodes::TableAlias] The resulting Arel query limited to the specified RfCs.
+    def with_id_arel(rfc_ids)
+      rfc_table = RequestForComment.arel_table
+
+      RequestForComment.where(id: rfc_ids).arel.as(rfc_table.name)
     end
   end
 end

--- a/app/views/request_for_comments/index.html.slim
+++ b/app/views/request_for_comments/index.html.slim
@@ -8,7 +8,7 @@ h1 = RequestForComment.model_name.human(count: :other)
           = f.label(:exercise_title_cont, RequestForComment.human_attribute_name('exercise'), class: 'visually-hidden form-label')
           = f.search_field(:exercise_title_cont, class: 'form-control', placeholder: RequestForComment.human_attribute_name('exercise'))
       .col-auto.mt-3.mt-md-0
-        = f.label(:title_cont, t('request_for_comments.solved'), class: 'visually-hidden form-label')
+        = f.label(:state, t('request_for_comments.solved'), class: 'visually-hidden form-label')
         = f.select(:state, [[t('request_for_comments.show_all'), RequestForComment::ALL], [t('request_for_comments.show_unsolved'), RequestForComment::ONGOING], [t('request_for_comments.show_soft_solved'), RequestForComment::SOFT_SOLVED], [t('request_for_comments.show_solved'), RequestForComment::SOLVED]])
     - unless current_user.consumer.rfc_visibility_study_group?
       .row
@@ -23,12 +23,12 @@ h1 = RequestForComment.model_name.human(count: :other)
       tr
         th
           i.fa-regular.fa-lightbulb aria-hidden='true' title = t('request_for_comments.solved') align='right'
-        th.sorttable_nosort = sort_link(@search, :title, RequestForComment.human_attribute_name('exercise'))
+        th.sorttable_nosort = sort_link(@search, :exercise_title, RequestForComment.human_attribute_name('exercise'))
         th = RequestForComment.human_attribute_name('question')
         th
           i.fa-solid.fa-comment aria-hidden='true' title = t('request_for_comments.comments') align='center'
         th = RequestForComment.human_attribute_name('username')
-        th = RequestForComment.human_attribute_name('requested_at')
+        th.sorttable_nosort = sort_link(@search, :created_at, RequestForComment.human_attribute_name('requested_at'))
         th = RequestForComment.human_attribute_name('last_update')
     tbody
       - @request_for_comments.each do |request_for_comment|
@@ -49,6 +49,6 @@ h1 = RequestForComment.model_name.human(count: :other)
           td = request_for_comment.comments.size
           td = link_to_if(request_for_comment.user && policy(request_for_comment.user).show?, request_for_comment.user.displayname, request_for_comment.user)
           td = t('shared.time.before', time: distance_of_time_in_words_to_now(request_for_comment.created_at))
-          td = t('shared.time.before', time: distance_of_time_in_words_to_now(request_for_comment.last_comment.nil? ? request_for_comment.updated_at : request_for_comment.last_comment))
+          td = t('shared.time.before', time: distance_of_time_in_words_to_now(request_for_comment.last_activity.nil? ? request_for_comment.updated_at : request_for_comment.last_activity))
 
 = render('shared/pagination', collection: @request_for_comments)


### PR DESCRIPTION
Without this change, we would first filter for the last 2 RfCs per record and then perform the search. Imagine, a user has three RfCs for exercises 1, 2, 3 (created in the order of the exercises). Now, when searching for open RfCs of the first exercise, the learner's RfC wasn't shown: The last_per_user would only return RfC for exercise 2 and 3, where the search term for exercise 1 would remove those two from the result set further.

With the new version, we first apply the custom filter and then limit the result set by two RfCs per learner.

We further took the opportunity to fix the broken sorting (by exercise name). The resulting code seems pretty complex, but I wasn't able to find a better, more suitable (and performant!) version.

Here are examples of the resulting SQL queries and their performance for a non-administrator:

<details><summary><code>/request_for_comments</code></summary>
<p>

```sql
SELECT "request_for_comments".*
FROM (SELECT "request_for_comments"."id",
             "request_for_comments"."user_id",
             "request_for_comments"."exercise_id",
             "request_for_comments"."file_id",
             "request_for_comments"."created_at",
             "request_for_comments"."updated_at",
             "request_for_comments"."user_type",
             "request_for_comments"."question",
             "request_for_comments"."solved",
             "request_for_comments"."submission_id",
             "request_for_comments"."thank_you_note",
             "request_for_comments"."full_score_reached",
             "request_for_comments"."times_featured",
             COALESCE(MAX("comments"."updated_at"), "request_for_comments"."updated_at") AS last_activity
      FROM (SELECT "request_for_comments".*
            FROM "request_for_comments"
            WHERE "request_for_comments"."id" IN (SELECT "request_for_comments"."id"
                                                  FROM (SELECT "request_for_comments".*
                                                        FROM (SELECT "request_for_comments"."id",
                                                                     "request_for_comments"."user_id",
                                                                     "request_for_comments"."exercise_id",
                                                                     "request_for_comments"."file_id",
                                                                     "request_for_comments"."created_at",
                                                                     "request_for_comments"."updated_at",
                                                                     "request_for_comments"."user_type",
                                                                     "request_for_comments"."question",
                                                                     "request_for_comments"."solved",
                                                                     "request_for_comments"."submission_id",
                                                                     "request_for_comments"."thank_you_note",
                                                                     "request_for_comments"."full_score_reached",
                                                                     "request_for_comments"."times_featured"
                                                              FROM (SELECT "request_for_comments".*,
                                                                           row_number()
                                                                           OVER (PARTITION BY "request_for_comments"."user_id", "request_for_comments"."user_type" ORDER BY "request_for_comments"."created_at" DESC) AS row_number
                                                                    FROM (SELECT "request_for_comments".*
                                                                          FROM "request_for_comments"
                                                                                   LEFT OUTER JOIN external_users
                                                                                                   ON request_for_comments.user_type =
                                                                                                      'ExternalUser' AND
                                                                                                      request_for_comments.user_id =
                                                                                                      external_users.id
                                                                                   LEFT OUTER JOIN internal_users
                                                                                                   ON request_for_comments.user_type =
                                                                                                      'InternalUser' AND
                                                                                                      request_for_comments.user_id =
                                                                                                      internal_users.id
                                                                                   INNER JOIN "exercises" ON "exercises"."id" = "request_for_comments"."exercise_id"
                                                                          WHERE ("external_users"."consumer_id" IN
                                                                                 (SELECT "consumers"."id"
                                                                                  FROM "consumers"
                                                                                  WHERE "consumers"."rfc_visibility" = 0) OR
                                                                                 "internal_users"."consumer_id" IN
                                                                                 (SELECT "consumers"."id"
                                                                                  FROM "consumers"
                                                                                  WHERE "consumers"."rfc_visibility" = 0))
                                                                            AND "exercises"."unpublished" = FALSE) request_for_comments) request_for_comments
                                                              WHERE "request_for_comments"."row_number" <= 2
                                                              GROUP BY "request_for_comments"."row_number",
                                                                       "request_for_comments"."id",
                                                                       "request_for_comments"."user_id",
                                                                       "request_for_comments"."exercise_id",
                                                                       "request_for_comments"."file_id",
                                                                       "request_for_comments"."created_at",
                                                                       "request_for_comments"."updated_at",
                                                                       "request_for_comments"."user_type",
                                                                       "request_for_comments"."question",
                                                                       "request_for_comments"."solved",
                                                                       "request_for_comments"."submission_id",
                                                                       "request_for_comments"."thank_you_note",
                                                                       "request_for_comments"."full_score_reached",
                                                                       "request_for_comments"."times_featured") request_for_comments
                                                        ORDER BY "request_for_comments"."created_at" DESC) request_for_comments
                                                  LIMIT 20 OFFSET 0)) request_for_comments
               INNER JOIN "submissions" ON "submissions"."id" = "request_for_comments"."submission_id"
               LEFT OUTER JOIN "files" ON "files"."context_id" = "submissions"."id"
               LEFT OUTER JOIN "comments" ON "comments"."file_id" = "files"."id"
      GROUP BY "request_for_comments"."id", "request_for_comments"."user_id", "request_for_comments"."exercise_id",
               "request_for_comments"."file_id", "request_for_comments"."created_at",
               "request_for_comments"."updated_at", "request_for_comments"."user_type",
               "request_for_comments"."question", "request_for_comments"."solved",
               "request_for_comments"."submission_id", "request_for_comments"."thank_you_note",
               "request_for_comments"."full_score_reached",
               "request_for_comments"."times_featured") request_for_comments
ORDER BY "request_for_comments"."created_at" DESC
LIMIT 20;
```

`RequestForComment Load (101.6ms)`

</p>
</details> 

<details><summary><code>/my_rfc_activity</code></summary>
<p>

```sql
SELECT "request_for_comments".*
FROM (SELECT "request_for_comments".*
      FROM (SELECT "request_for_comments".*
            FROM (SELECT "request_for_comments"."id",
                         "request_for_comments"."user_id",
                         "request_for_comments"."exercise_id",
                         "request_for_comments"."file_id",
                         "request_for_comments"."created_at",
                         "request_for_comments"."updated_at",
                         "request_for_comments"."user_type",
                         "request_for_comments"."question",
                         "request_for_comments"."solved",
                         "request_for_comments"."submission_id",
                         "request_for_comments"."thank_you_note",
                         "request_for_comments"."full_score_reached",
                         "request_for_comments"."times_featured",
                         COALESCE(MAX("comments"."updated_at"), "request_for_comments"."updated_at") AS last_activity
                  FROM (SELECT "request_for_comments".*
                        FROM "request_for_comments"
                                 LEFT OUTER JOIN external_users ON request_for_comments.user_type = 'ExternalUser' AND
                                                                   request_for_comments.user_id = external_users.id
                                 LEFT OUTER JOIN internal_users ON request_for_comments.user_type = 'InternalUser' AND
                                                                   request_for_comments.user_id = internal_users.id
                                 INNER JOIN "exercises" ON "exercises"."id" = "request_for_comments"."exercise_id"
                                 INNER JOIN "submissions" ON "submissions"."id" = "request_for_comments"."submission_id"
                                 INNER JOIN "files" ON "files"."context_type" = 'Submission' AND
                                                       "files"."context_id" = "submissions"."id"
                                 INNER JOIN "comments" ON "comments"."file_id" = "files"."id"
                        WHERE ("external_users"."consumer_id" IN
                               (SELECT "consumers"."id" FROM "consumers" WHERE "consumers"."rfc_visibility" = 0) OR
                               "internal_users"."consumer_id" IN
                               (SELECT "consumers"."id" FROM "consumers" WHERE "consumers"."rfc_visibility" = 0))
                          AND "comments"."user_type" = 'InternalUser'
                          AND "comments"."user_id" = 90) request_for_comments
                           INNER JOIN "submissions" ON "submissions"."id" = "request_for_comments"."submission_id"
                           LEFT OUTER JOIN "files" ON "files"."context_id" = "submissions"."id"
                           LEFT OUTER JOIN "comments" ON "comments"."file_id" = "files"."id"
                  GROUP BY "request_for_comments"."id", "request_for_comments"."user_id",
                           "request_for_comments"."exercise_id", "request_for_comments"."file_id",
                           "request_for_comments"."created_at", "request_for_comments"."updated_at",
                           "request_for_comments"."user_type", "request_for_comments"."question",
                           "request_for_comments"."solved", "request_for_comments"."submission_id",
                           "request_for_comments"."thank_you_note", "request_for_comments"."full_score_reached",
                           "request_for_comments"."times_featured") request_for_comments
            ORDER BY "last_activity" DESC) request_for_comments
      LIMIT 20 OFFSET 0) request_for_comments
ORDER BY "last_activity" DESC
LIMIT 20;
```

`RequestForComment Load (27.4ms)`

</p>
</details> 

<details><summary><code>/my_request_for_comments</code></summary>
<p>

```sql
SELECT "request_for_comments".*
FROM (SELECT "request_for_comments"."id",
             "request_for_comments"."user_id",
             "request_for_comments"."exercise_id",
             "request_for_comments"."file_id",
             "request_for_comments"."created_at",
             "request_for_comments"."updated_at",
             "request_for_comments"."user_type",
             "request_for_comments"."question",
             "request_for_comments"."solved",
             "request_for_comments"."submission_id",
             "request_for_comments"."thank_you_note",
             "request_for_comments"."full_score_reached",
             "request_for_comments"."times_featured",
             COALESCE(MAX("comments"."updated_at"), "request_for_comments"."updated_at") AS last_activity
      FROM (SELECT "request_for_comments".*
            FROM "request_for_comments"
            WHERE "request_for_comments"."id" IN (SELECT "request_for_comments"."id"
                                                  FROM (SELECT "request_for_comments".*
                                                        FROM (SELECT "request_for_comments".*
                                                              FROM "request_for_comments"
                                                                       LEFT OUTER JOIN external_users
                                                                                       ON request_for_comments.user_type =
                                                                                          'ExternalUser' AND
                                                                                          request_for_comments.user_id =
                                                                                          external_users.id
                                                                       LEFT OUTER JOIN internal_users
                                                                                       ON request_for_comments.user_type =
                                                                                          'InternalUser' AND
                                                                                          request_for_comments.user_id =
                                                                                          internal_users.id
                                                                       INNER JOIN "exercises" ON "exercises"."id" = "request_for_comments"."exercise_id"
                                                                       INNER JOIN "submissions"
                                                                                  ON "submissions"."id" = "request_for_comments"."submission_id"
                                                              WHERE ("external_users"."consumer_id" IN
                                                                     (SELECT "consumers"."id"
                                                                      FROM "consumers"
                                                                      WHERE "consumers"."rfc_visibility" = 0) OR
                                                                     "internal_users"."consumer_id" IN
                                                                     (SELECT "consumers"."id"
                                                                      FROM "consumers"
                                                                      WHERE "consumers"."rfc_visibility" = 0))
                                                                AND ("request_for_comments"."user_type" =
                                                                     'InternalUser' AND
                                                                     "request_for_comments"."user_id" = 90 OR
                                                                     "submissions"."contributor_id" =
                                                                     6)) request_for_comments
                                                        ORDER BY "request_for_comments"."created_at" DESC) request_for_comments
                                                  LIMIT 20 OFFSET 0)) request_for_comments
               INNER JOIN "submissions" ON "submissions"."id" = "request_for_comments"."submission_id"
               LEFT OUTER JOIN "files" ON "files"."context_id" = "submissions"."id"
               LEFT OUTER JOIN "comments" ON "comments"."file_id" = "files"."id"
      GROUP BY "request_for_comments"."id", "request_for_comments"."user_id", "request_for_comments"."exercise_id",
               "request_for_comments"."file_id", "request_for_comments"."created_at",
               "request_for_comments"."updated_at", "request_for_comments"."user_type",
               "request_for_comments"."question", "request_for_comments"."solved",
               "request_for_comments"."submission_id", "request_for_comments"."thank_you_note",
               "request_for_comments"."full_score_reached",
               "request_for_comments"."times_featured") request_for_comments
ORDER BY "request_for_comments"."created_at" DESC
LIMIT 20;
```

`RequestForComment Load (260.8ms)`

</p>
</details> 

<details><summary><code>/exercises/{id}/request_for_comments</code></summary>
<p>

```sql

SELECT "request_for_comments".*
FROM (SELECT "request_for_comments".*
      FROM (SELECT "request_for_comments".*
            FROM (SELECT "request_for_comments"."id",
                         "request_for_comments"."user_id",
                         "request_for_comments"."exercise_id",
                         "request_for_comments"."file_id",
                         "request_for_comments"."created_at",
                         "request_for_comments"."updated_at",
                         "request_for_comments"."user_type",
                         "request_for_comments"."question",
                         "request_for_comments"."solved",
                         "request_for_comments"."submission_id",
                         "request_for_comments"."thank_you_note",
                         "request_for_comments"."full_score_reached",
                         "request_for_comments"."times_featured",
                         COALESCE(MAX("comments"."updated_at"), "request_for_comments"."updated_at") AS last_activity
                  FROM (SELECT "request_for_comments".*
                        FROM "request_for_comments"
                                 LEFT OUTER JOIN external_users ON request_for_comments.user_type = 'ExternalUser' AND
                                                                   request_for_comments.user_id = external_users.id
                                 LEFT OUTER JOIN internal_users ON request_for_comments.user_type = 'InternalUser' AND
                                                                   request_for_comments.user_id = internal_users.id
                                 INNER JOIN "exercises" ON "exercises"."id" = "request_for_comments"."exercise_id"
                        WHERE ("external_users"."consumer_id" IN
                               (SELECT "consumers"."id" FROM "consumers" WHERE "consumers"."rfc_visibility" = 0) OR
                               "internal_users"."consumer_id" IN
                               (SELECT "consumers"."id" FROM "consumers" WHERE "consumers"."rfc_visibility" = 0))
                          AND "request_for_comments"."exercise_id" = 218) request_for_comments
                           INNER JOIN "submissions" ON "submissions"."id" = "request_for_comments"."submission_id"
                           LEFT OUTER JOIN "files" ON "files"."context_id" = "submissions"."id"
                           LEFT OUTER JOIN "comments" ON "comments"."file_id" = "files"."id"
                  GROUP BY "request_for_comments"."id", "request_for_comments"."user_id",
                           "request_for_comments"."exercise_id", "request_for_comments"."file_id",
                           "request_for_comments"."created_at", "request_for_comments"."updated_at",
                           "request_for_comments"."user_type", "request_for_comments"."question",
                           "request_for_comments"."solved", "request_for_comments"."submission_id",
                           "request_for_comments"."thank_you_note", "request_for_comments"."full_score_reached",
                           "request_for_comments"."times_featured") request_for_comments
            ORDER BY "last_activity" DESC) request_for_comments
      LIMIT 20 OFFSET 0) request_for_comments
ORDER BY "last_activity" DESC
LIMIT 20;
```

`RequestForComment Load (103.3ms)`

</p>
</details> 