### PR TITLE
Fix: Persist factory assignments of file for RfCs

### DIFF
--- a/spec/factories/request_for_comment.rb
+++ b/spec/factories/request_for_comment.rb
@@ -5,16 +5,14 @@ FactoryBot.define do
     user factory: :external_user
     exercise factory: :math
     submission { association :submission, exercise:, user:, study_group: user&.study_groups&.first }
-    file
+    file { submission.files.first }
     sequence :question do |n|
       "test question #{n}"
     end
 
     factory :rfc_with_comment, class: 'RequestForComment' do
       after(:create) do |rfc|
-        rfc.file = rfc.submission.files.first
         Comment.create(file: rfc.file, user: rfc.user, row: 1, text: "comment for rfc #{rfc.question}")
-        rfc.submission.study_group_id = rfc.user.current_study_group_id
       end
     end
   end


### PR DESCRIPTION
Associations created by a factory need to be persisted to avoid testing against an in memory object by mistake.