### PR TITLE
chore: Remove erb templete requirments from editor

### DIFF
--- a/app/assets/javascripts/editor/editor.js
+++ b/app/assets/javascripts/editor/editor.js
@@ -1,9 +1,3 @@
-// Note: Directives are only processed if they come before any application code.
-// Once you have a line that does not include a comment or whitespace then Sprockets will stop looking for directives.
-// If you use a directive outside of the "header" of the document it will not do anything, and won't raise any errors.
-// <% config_file = CodeOcean::Config.new(:code_ocean, erb: false) %>
-//= depend_on <%= config_file.path.basename %>
-
 var CodeOceanEditor = {
     THEME: window.getCurrentTheme() === 'dark' ? 'ace/theme/tomorrow_night' : 'ace/theme/tomorrow',
 

--- a/app/assets/javascripts/editor/editor.js.erb
+++ b/app/assets/javascripts/editor/editor.js.erb
@@ -33,7 +33,7 @@ var CodeOceanEditor = {
 
     lastCopyText: null,
 
-    sendEvents: <%= config_file.read['codeocean_events'] ? config_file.read['codeocean_events']['enabled'] : false %>,
+    sendEvents: document.documentElement.dataset.eventsEnabled === 'true',
     eventURL: Routes.events_path(),
     fileTypeURL: Routes.file_types_path(),
 

--- a/app/assets/javascripts/editor/participantsupport.js
+++ b/app/assets/javascripts/editor/participantsupport.js
@@ -1,5 +1,5 @@
 CodeOceanEditorFlowr = {
-  isFlowrEnabled: <%= CodeOcean::Config.new(:code_ocean).read[:flowr][:enabled] %>,
+  isFlowrEnabled: document.documentElement.dataset.flowrEnabled === 'true',
   flowrResultHtml:
     '<div class="card mb-2">' +
       '<div id="{{headingId}}" role="tab" class="card-header">' +
@@ -29,7 +29,7 @@ CodeOceanEditorFlowr = {
       var stackoverflowRequests = _.map(insights, function (insight) {
         var queryParams = {
           accepted: true,
-          pagesize: <%= CodeOcean::Config.new(:code_ocean).read[:flowr][:answers_per_query] or 3 %>,
+          pagesize: Number(document.documentElement.dataset.flowrAnswersPerQuery),
           order: 'desc',
           sort: 'relevance',
           site: 'stackoverflow',

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -91,4 +91,13 @@ module ApplicationHelper
   def yes
     tag.i(nil, class: 'fa-solid fa-check')
   end
+
+  def html_data_attributes
+    {
+      'data-default-locale' => I18n.default_locale,
+      'data-events-enabled' => CodeOcean::Config.new(:code_ocean).read.dig('codeocean_events', 'enabled'),
+      'data-flowr-enabled' => CodeOcean::Config.new(:code_ocean).read.dig(:flowr, :enabled),
+      'data-flowr-answers-per-query' => CodeOcean::Config.new(:code_ocean).read[:flowranswers_per_query] || 3,
+    }
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -97,9 +97,9 @@ module ApplicationHelper
 
     {
       'data-default-locale' => I18n.default_locale,
-      'data-events-enabled' => config.dig('codeocean_events', 'enabled'),
+      'data-events-enabled' => config.dig(:codeocean_events, :enabled),
       'data-flowr-enabled' => config.dig(:flowr, :enabled),
-      'data-flowr-answers-per-query' => config.fetch(:flowranswers_per_query, 3),
+      'data-flowr-answers-per-query' => config.dig(:flowr, :answers_per_query) || 3,
     }
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -93,11 +93,13 @@ module ApplicationHelper
   end
 
   def html_data_attributes
+    config = CodeOcean::Config.new(:code_ocean).read
+
     {
       'data-default-locale' => I18n.default_locale,
-      'data-events-enabled' => CodeOcean::Config.new(:code_ocean).read.dig('codeocean_events', 'enabled'),
-      'data-flowr-enabled' => CodeOcean::Config.new(:code_ocean).read.dig(:flowr, :enabled),
-      'data-flowr-answers-per-query' => CodeOcean::Config.new(:code_ocean).read[:flowranswers_per_query] || 3,
+      'data-events-enabled' => config.dig('codeocean_events', 'enabled'),
+      'data-flowr-enabled' => config.dig(:flowr, :enabled),
+      'data-flowr-answers-per-query' => config.fetch(:flowranswers_per_query, 3),
     }
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html lang=I18n.locale data-default-locale=I18n.default_locale
+html lang=I18n.locale *html_data_attributes
   head
     meta charset='utf-8'
     meta name='viewport' content='width=device-width, initial-scale=1'


### PR DESCRIPTION
Configurations can be suppied to JavaScript with data attributes. This simplifies the JavaScript migration to Webpack.