### PR TITLE
Migrate .js.erb files to .js

### DIFF
--- a/app/assets/javascripts/editor/editor.js
+++ b/app/assets/javascripts/editor/editor.js
@@ -1,9 +1,3 @@
-// Note: Directives are only processed if they come before any application code.
-// Once you have a line that does not include a comment or whitespace then Sprockets will stop looking for directives.
-// If you use a directive outside of the "header" of the document it will not do anything, and won't raise any errors.
-// <% config_file = CodeOcean::Config.new(:code_ocean, erb: false) %>
-//= depend_on <%= config_file.path.basename %>
-
 var CodeOceanEditor = {
     THEME: window.getCurrentTheme() === 'dark' ? 'ace/theme/tomorrow_night' : 'ace/theme/tomorrow',
 
@@ -33,7 +27,7 @@ var CodeOceanEditor = {
 
     lastCopyText: null,
 
-    sendEvents: <%= config_file.read['codeocean_events'] ? config_file.read['codeocean_events']['enabled'] : false %>,
+    sendEvents: null,
     eventURL: Routes.events_path(),
     fileTypeURL: Routes.file_types_path(),
 
@@ -1093,6 +1087,7 @@ var CodeOceanEditor = {
     },
 
     initializeEverything: function () {
+        CodeOceanEditor.sendEvents = $('#editor').data('events-enabled');
         CodeOceanEditor.editors = [];
         this.initializeRegexes();
         this.initializeEditors();

--- a/app/assets/javascripts/editor/participantsupport.js
+++ b/app/assets/javascripts/editor/participantsupport.js
@@ -1,5 +1,4 @@
 CodeOceanEditorFlowr = {
-  isFlowrEnabled: <%= CodeOcean::Config.new(:code_ocean).read[:flowr][:enabled] %>,
   flowrResultHtml:
     '<div class="card mb-2">' +
       '<div id="{{headingId}}" role="tab" class="card-header">' +
@@ -18,6 +17,13 @@ CodeOceanEditorFlowr = {
       '</div>' +
     '</div>',
 
+  getFlowrSettings: function () {
+    if (this._flowrSettings === undefined) {
+      this._flowrSettings = $('#editor').data('flowr');
+    }
+    return this._flowrSettings;
+  },
+
   getInsights: function () {
     var stackOverflowUrl = 'https://api.stackexchange.com/2.2/search/advanced';
 
@@ -29,7 +35,7 @@ CodeOceanEditorFlowr = {
       var stackoverflowRequests = _.map(insights, function (insight) {
         var queryParams = {
           accepted: true,
-          pagesize: <%= CodeOcean::Config.new(:code_ocean).read[:flowr][:answers_per_query] or 3 %>,
+          pagesize: this.getFlowrSettings().answers_per_query,
           order: 'desc',
           sort: 'relevance',
           site: 'stackoverflow',
@@ -43,9 +49,9 @@ CodeOceanEditorFlowr = {
           url: stackOverflowUrl,
           data: queryParams
         }).promise();
-      });
+      }.bind(this));
       return jQuery.when.apply(jQuery, stackoverflowRequests);
-    });
+    }.bind(this));
   },
   collectResults: function(response) {
     var results = [];
@@ -71,7 +77,7 @@ CodeOceanEditorFlowr = {
     return results;
   },
   handleStderrOutputForFlowr: function () {
-    if (! this.isFlowrEnabled) return;
+    if (! this.getFlowrSettings().enabled) return;
 
     var flowrHintBody = $('#flowrHint .card-body');
     flowrHintBody.empty();

--- a/app/helpers/exercise_helper.rb
+++ b/app/helpers/exercise_helper.rb
@@ -3,7 +3,22 @@
 module ExerciseHelper
   include LtiHelper
 
+  SETTINGS = CodeOcean::Config.new(:code_ocean)
+  EVENT_SETTINGS = SETTINGS.read[:codeocean_events] || {}
+  FLOWR_SETTINGS = SETTINGS.read[:flowr] || {}
+
   def embedding_parameters(exercise)
     "locale=#{I18n.locale}&token=#{exercise.token}"
+  end
+
+  def flowr_settings
+    {
+      enabled: FLOWR_SETTINGS.fetch(:enabled, false),
+      answers_per_query: FLOWR_SETTINGS.fetch(:answers_per_query, 3),
+    }
+  end
+
+  def editor_events_enabled
+    EVENT_SETTINGS.fetch(:enabled, false)
   end
 end

--- a/app/views/exercises/_editor.html.slim
+++ b/app/views/exercises/_editor.html.slim
@@ -4,7 +4,7 @@
 - show_tips_interventions = @show_tips_interventions || 'false'
 - hide_rfc_button = @hide_rfc_button || false
 
-#editor.row data-exercise-id=@exercise.id data-message-depleted=t('exercises.editor.depleted') data-message-timeout=t('exercises.editor.timeout', permitted_execution_time: @exercise.execution_environment.permitted_execution_time) data-message-out-of-memory=t('exercises.editor.out_of_memory', memory_limit: @exercise.execution_environment.memory_limit) data-submissions-url=submissions_path data-user-external-id=external_user_external_id data-working-times-url=working_times_exercise_path(@exercise) data-intervention-save-url=intervention_exercise_path(@exercise) data-rfc-interventions=show_rfc_interventions data-break-interventions=show_break_interventions data-tips-interventions=show_tips_interventions
+#editor.row data-exercise-id=@exercise.id data-message-depleted=t('exercises.editor.depleted') data-message-timeout=t('exercises.editor.timeout', permitted_execution_time: @exercise.execution_environment.permitted_execution_time) data-message-out-of-memory=t('exercises.editor.out_of_memory', memory_limit: @exercise.execution_environment.memory_limit) data-submissions-url=submissions_path data-user-external-id=external_user_external_id data-working-times-url=working_times_exercise_path(@exercise) data-intervention-save-url=intervention_exercise_path(@exercise) data-rfc-interventions=show_rfc_interventions data-break-interventions=show_break_interventions data-tips-interventions=show_tips_interventions data-flowr=flowr_settings.to_json data-events-enabled=editor_events_enabled.to_s
   - unless @embed_options[:hide_sidebar]
     - additional_classes = 'sidebar-col'
     - if @tips.blank?

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,5 +6,4 @@
 Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path.
-# We require the config directory to enable asset dependencies on CodeOcean::Config values (stored as YML files in `config`).
-Rails.application.config.assets.paths << Rails.root.join('config')
+# Rails.application.config.assets.paths << Emoji.images_path


### PR DESCRIPTION
This commit reverts the changes performed in 65416934, and uses local data attributes to pass settings to the frontend.

The current solution is not ideal yet, but sufficient to continue with other important tasks.

Relates to #2964.