### PR TITLE
chore: Drop Array.includes polyfull

### DIFF
--- a/app/assets/javascripts/base.js
+++ b/app/assets/javascripts/base.js
@@ -1,7 +1,3 @@
-Array.prototype.includes = function(element) {
-  return this.indexOf(element) !== -1;
-};
-
 window.CodeOcean = {
   refresh: function() {
     Turbo.visit(window.location.pathname);


### PR DESCRIPTION
Browser support for Array.includes is wildly available and does not need be patched.