### PR TITLE
fix: Theme selection event listeners

### DIFF
--- a/lib/assets/javascripts/color_mode_picker.js
+++ b/lib/assets/javascripts/color_mode_picker.js
@@ -77,7 +77,7 @@ function showActiveTheme(theme, focus = false) {
     }
 }
 
-$(document).on('turbo:load', function() {
+$(document).on('turbo-migration:load', function() {
     setTheme(getPreferredTheme())
 
     showActiveTheme(getPreferredTheme())


### PR DESCRIPTION
The migration event needs to be used to set the event listeners for the theme select.