### PR TITLE
refactor: Files feedback_message without NULL state

### DIFF
--- a/app/models/code_ocean/file.rb
+++ b/app/models/code_ocean/file.rb
@@ -16,6 +16,7 @@ module CodeOcean
 
     after_initialize :set_default_values
     before_validation :clear_weight, unless: :teacher_defined_assessment?
+    before_validation :clear_feedback_message, unless: :teacher_defined_assessment?
     before_validation :hash_content, if: :content_present?
     before_validation :set_ancestor_values, if: :incomplete_descendent?
 
@@ -49,7 +50,6 @@ module CodeOcean
     default_scope { order(path: :asc, name: :asc) }
 
     validates :feedback_message, if: :teacher_defined_assessment?, presence: true
-    validates :feedback_message, absence: true, unless: :teacher_defined_assessment?
     validates :hashed_content, if: :content_present?, presence: true
     validates :hidden, inclusion: [true, false]
     validates :hidden_feedback, inclusion: [true, false]
@@ -152,6 +152,11 @@ module CodeOcean
       set_default_values_if_present(weight: DEFAULT_WEIGHT) if teacher_defined_assessment?
     end
     private :set_default_values
+
+    def clear_feedback_message
+      self.feedback_message = ''
+    end
+    private :clear_feedback_message
 
     def visible?
       !hidden

--- a/app/services/proforma_service/convert_task_to_exercise.rb
+++ b/app/services/proforma_service/convert_task_to_exercise.rb
@@ -89,7 +89,6 @@ module ProformaService
         model_solution.files.map do |task_file|
           codeocean_file_from_task_file(task_file, model_solution).tap do |file|
             file.role ||= 'reference_implementation'
-            file.feedback_message = nil
           end
         end
       end
@@ -99,7 +98,6 @@ module ProformaService
       @task.files.reject {|file| file.id == 'ms-placeholder-file' }.map do |task_file|
         codeocean_file_from_task_file(task_file).tap do |file|
           file.role ||= 'regular_file'
-          file.feedback_message = nil
         end
       end
     end

--- a/db/migrate/20250729085843_remove_null_from_files_feedback_message.rb
+++ b/db/migrate/20250729085843_remove_null_from_files_feedback_message.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RemoveNullFromFilesFeedbackMessage < ActiveRecord::Migration[8.0]
+  def up
+    CodeOcean::File.where(feedback_message: nil).in_batches.update_all(feedback_message: '') # rubocop:disable Rails/SkipsModelValidations
+
+    change_column_default :files, :feedback_message, ''
+    change_column_null :files, :feedback_message, false
+  end
+
+  def down
+    change_column_null :files, :feedback_message, true
+    change_column_default :files, :feedback_message, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_13_114125) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_29_085843) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -312,7 +312,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_13_114125) do
     t.string "native_file"
     t.string "role"
     t.string "hashed_content"
-    t.string "feedback_message"
+    t.string "feedback_message", default: "", null: false
     t.float "weight"
     t.string "path"
     t.integer "file_template_id"


### PR DESCRIPTION
Column type string should not have a null state to avoid logical
distinction between `NULL` and `''` case.

User defined tests are created without feedback_message. Removing
the NULL case allows the new record to render the empty feedback_message.

An edge case is resolved when a test for assessment with a feedback_message
is transformed to a user defined test. The feedback_message is
overwritten, and no validation error for invisible fields is displayed.

Resolves #3014