### PR TITLE
fix: Faster theme loading to avoid flickering

### DIFF
--- a/app/javascript/sprocket-asset-import/color-mode-picker.js
+++ b/app/javascript/sprocket-asset-import/color-mode-picker.js
@@ -77,7 +77,7 @@ function showActiveTheme(theme, focus = false) {
     }
 }
 
-$(document).on('turbo-migration:load', function() {
+$(document).on('turbo:load', function() {
     setTheme(getPreferredTheme())
 
     showActiveTheme(getPreferredTheme())


### PR DESCRIPTION
The `tubo:load` event is faster than the migration event. The color changing requires no sprocket code and can be controlled without the migration event. This removes the flickering in dark mode when navigating the page.

This change is possible because the theme-changing logic was moved to Webpacker and loads before Sprockets. Please see #3025

Related to #3040