### PR TITLE
fix: Avoid reports of legitimate content

### DIFF
--- a/config/locales/de/request_for_comment.yml
+++ b/config/locales/de/request_for_comment.yml
@@ -43,7 +43,7 @@ de:
     no_question: Der/die Autor:in hat keine Frage zu dieser Anfrage gestellt.
     passed: Erfolgreich
     report:
-      confirm: Sind Sie sicher, dass Sie diesen Inhalt **als unangemessen** melden möchten?
+      confirm: Sind Sie sicher, dass Sie diesen Inhalt als unangemessen melden möchten?
       report: Inhalt melden
       reported: Vielen Dank, dass Sie uns auf dieses Problem aufmerksam gemacht haben. Wir werden uns in Kürze darum kümmern.
     runtime_output: Programmausgabe

--- a/config/locales/en/request_for_comment.yml
+++ b/config/locales/en/request_for_comment.yml
@@ -43,7 +43,7 @@ en:
     no_question: The author did not enter a question for this request.
     passed: Passed
     report:
-      confirm: Are you sure you want to report this content **as inappropriate**?
+      confirm: Are you sure you want to report this content as inappropriate?
       report: Report
       reported: Thank you for letting us know about this issue. We will look into the matter shortly.
     runtime_output: Runtime Output


### PR DESCRIPTION
Social media platforms use `Melden` to report inappropriate content. In the teaching context, it is common in German to report yourself if you have a question (sich melden). It appears that students report content to get attention from the teacher because no reported content includes inappropriate content.

It is the hope that `Inhalt melden` makes it clearer that this is a content moderation function.

The popup message also asks the student if he wants to report the content. This should make it clearer that it is not "sich melden". Due to the Turbo.js migration, this message is not always displayed, or the students ignore the message. #3021 might also cause/contribute to the issue.

<img width="1331" height="186" alt="1754475348" src="https://github.com/user-attachments/assets/0446faad-5855-484f-8c71-679d0d7a5228" />
