### PR TITLE
chore: Remove env for easier deployment

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-INTERNAL_API_TOKEN=supersecrettoken

--- a/Gemfile
+++ b/Gemfile
@@ -85,10 +85,6 @@ group :development, :staging do
   gem 'slim_lint', require: false
 end
 
-group :development, :test do
-  gem 'dotenv-rails'
-end
-
 group :test do
   gem 'capybara'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,10 +150,6 @@ GEM
     docker-api (2.4.0)
       excon (>= 0.64.0)
       multi_json
-    dotenv (3.2.0)
-    dotenv-rails (3.2.0)
-      dotenv (= 3.2.0)
-      railties (>= 6.1)
     drb (2.2.3)
     erb (5.1.1)
     erubi (1.13.1)
@@ -692,7 +688,6 @@ DEPENDENCIES
   charlock_holmes
   csv
   docker-api
-  dotenv-rails
   eventmachine
   factory_bot_rails
   faraday
@@ -813,8 +808,6 @@ CHECKSUMS
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   docker-api (2.4.0) sha256=824be734f4cc8718189be9c8e795b6414acbbf7e8b082a06f959a27dd8dd63e6
-  dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
-  dotenv-rails (3.2.0) sha256=657e25554ba622ffc95d8c4f1670286510f47f2edda9f68293c3f661b303beab
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (5.1.1) sha256=b2c26e7924551d9efbae998e17ddbef220937b6422b1d2ec7ae71417b5a1f4ec
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
+ENV['INTERNAL_API_TOKEN'] = 'supersecrettoken'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?


### PR DESCRIPTION
The env file interferes with deployment. Using dotenv is not required at the moment. It is good enough to set the internal API token in test to make the development easy.

Related to 75aaf63